### PR TITLE
fix: assume node returns buffers, not strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@open-draft/test-server": "^0.2.3",
     "@types/chai": "^4.2.15",
+    "@types/compression": "^1.7.0",
     "@types/cors": "^2.8.7",
     "@types/express": "^4.17.8",
     "@types/jest": "^26.0.21",
@@ -37,6 +38,7 @@
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
     "chai": "^4.3.4",
+    "compression": "^1.7.4",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "got": "^11.8.1",

--- a/src/createInterceptor.ts
+++ b/src/createInterceptor.ts
@@ -25,7 +25,7 @@ export interface IsomorphicResponse {
   status: number
   statusText: string
   headers: Headers
-  body?: string
+  body?: Buffer | string
 }
 
 export interface MockedResponse

--- a/src/interceptors/ClientRequest/utils/getIncomingMessageBody.ts
+++ b/src/interceptors/ClientRequest/utils/getIncomingMessageBody.ts
@@ -1,13 +1,13 @@
 import { IncomingMessage } from 'http'
 
-export function getIncomingMessageBody(res: IncomingMessage): Promise<string> {
-  let responseBody = ''
+export function getIncomingMessageBody(res: IncomingMessage): Promise<Buffer> {
+  const bufs: Buffer[] = [];
 
   return new Promise((resolve, reject) => {
     res.once('error', reject)
-    res.on('data', (chunk) => (responseBody += chunk))
+    res.on('data', (chunk) => bufs.push(chunk))
     res.once('end', () => {
-      resolve(responseBody)
+      resolve(Buffer.concat(bufs))
     })
   })
 }

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -288,8 +288,8 @@ export const createXMLHttpRequestOverride = (
             this.setReadyState(this.HEADERS_RECEIVED)
 
             debug('response type', this.responseType)
-            this.response = this.getResponseBody(mockedResponse.body)
-            this.responseText = mockedResponse.body || ''
+            this.response = this.getResponseBody(mockedResponse.body?.toString())
+            this.responseText = mockedResponse.body?.toString() || ''
 
             debug('set response body', this.response)
 
@@ -298,7 +298,7 @@ export const createXMLHttpRequestOverride = (
 
               // Presense of the mocked response implies a response body (not null).
               // Presense of the coerced `this.response` implies the mocked body is valid.
-              const bodyBuffer = bufferFrom(mockedResponse.body)
+              const bodyBuffer = bufferFrom(mockedResponse.body?.toString())
 
               // Trigger a progress event based on the mocked response body.
               this.trigger('progress', {

--- a/test/regressions/http-compression.test.ts
+++ b/test/regressions/http-compression.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment node
+ * @see https://github.com/mswjs/interceptors/issues/109
+ */
+import got from 'got';
+import compression from 'compression';
+import * as zlib from 'zlib';
+
+import { createServer, ServerApi } from '@open-draft/test-server'
+import { createInterceptor, IsomorphicResponse } from '../../src'
+import { interceptClientRequest } from '../../src/interceptors/ClientRequest'
+
+let server: ServerApi
+
+const interceptor = createInterceptor({
+  modules: [interceptClientRequest],
+  resolver(req) {
+  },
+})
+
+beforeAll(async () => {
+  server = await createServer((app) => {
+    app.use(compression( { threshold: 1, }));
+    app.get('/', (req, res) =>
+      res.send({hello: 'world'}));
+  })
+
+  interceptor.apply()
+})
+
+afterAll(async () => {
+  interceptor.restore()
+  await server.close()
+})
+
+const GZIP_MAGIC_HEX = '1f8b08';
+
+test('returns a valid body', async () => {
+  const intercepted = new Promise<IsomorphicResponse>(resolve =>
+    interceptor.on('response', (req, resp) =>
+      resolve(resp)));
+  expect(await got(server.http.makeUrl('/')).json()).toEqual({hello: 'world'});
+  const resp = await intercepted;
+  expect(resp.headers.get('content-encoding')).toBe('gzip')
+  const bodyBuffer = Buffer.from(resp.body!);
+  expect(bodyBuffer.slice(0, 3).toString('hex')).toBe(GZIP_MAGIC_HEX);
+  const unzipped = zlib.gunzipSync(bodyBuffer).toString('utf-8');
+  expect(JSON.parse(unzipped)).toEqual({hello: 'world'});
+})


### PR DESCRIPTION
Sub-optimal fix for #109; just assume everything is a buffer, and `toString` it in other places.