### PR TITLE
fix: set responseXML when resolver returns xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/node": "^14.14.35",
     "@types/node-fetch": "^2.5.7",
     "@types/supertest": "^2.0.10",
+    "@types/xmldom": "^0.1.30",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
     "chai": "^4.3.4",
@@ -53,7 +54,8 @@
     "@open-draft/until": "^1.0.3",
     "debug": "^4.3.0",
     "headers-utils": "^3.0.2",
-    "strict-event-emitter": "^0.2.0"
+    "strict-event-emitter": "^0.2.0",
+    "xmldom": "^0.6.0"
   },
   "keywords": [
     "request",

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -9,6 +9,7 @@ import {
   objectToHeaders,
   headersToString,
 } from 'headers-utils'
+import { DOMParser } from 'xmldom'
 import { IsomorphicRequest, Observer, Resolver } from '../../createInterceptor'
 import { parseJson } from '../../utils/parseJson'
 import { bufferFrom } from './utils/bufferFrom'

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -292,6 +292,7 @@ export const createXMLHttpRequestOverride = (
             debug('response type', this.responseType)
             this.response = this.getResponseBody(mockedResponse.body)
             this.responseText = mockedResponse.body || ''
+            this.responseXML = this.getResponseXML()
 
             debug('set response body', this.response)
 
@@ -513,6 +514,14 @@ export const createXMLHttpRequestOverride = (
         default:
           return textBody
       }
+    }
+
+    getResponseXML() {
+      const contentType = this.getResponseHeader('Content-Type')
+      if (contentType === 'application/xml' || contentType === 'text/xml') {
+        return new DOMParser().parseFromString(this.responseText, contentType)
+      }
+      return null
     }
 
     /**

--- a/test/regressions/xhr-response-xml-body.test.ts
+++ b/test/regressions/xhr-response-xml-body.test.ts
@@ -1,0 +1,67 @@
+import { createInterceptor } from '../../src';
+import { interceptXMLHttpRequest } from '../../src/interceptors/XMLHttpRequest';
+import { createXMLHttpRequest } from '../helpers';
+
+const XML_STRING = '<node key="value">Content</node>'
+
+describe('Content-Type: application/xml', () => {
+  const interceptor = createInterceptor({
+    modules: [interceptXMLHttpRequest],
+    resolver() {
+      return {
+        headers: { 'Content-Type': 'application/xml' },
+        status: 200,
+        body: XML_STRING,
+      }
+    },
+  })
+
+  beforeAll(() => {
+    interceptor.apply()
+  })
+
+  afterAll(() => {
+    interceptor.restore()
+  })
+
+  test('supports XHR mocked response with an XML response body', async () => {
+    const req = await createXMLHttpRequest((req) => {
+      req.open('GET', '/arbitrary-url')
+    })
+
+    expect(req.responseXML).toStrictEqual(
+      new DOMParser().parseFromString(XML_STRING, 'application/xml')
+    )
+  })
+})
+
+describe('Content-Type: text/xml', () => {
+  const interceptor = createInterceptor({
+    modules: [interceptXMLHttpRequest],
+    resolver() {
+      return {
+        headers: { 'Content-Type': 'text/xml' },
+        status: 200,
+        body: XML_STRING,
+      }
+    },
+  })
+
+  beforeAll(() => {
+    interceptor.apply()
+  })
+
+  afterAll(() => {
+    interceptor.restore()
+  })
+
+  test('supports XHR mocked response with an XML response body', async () => {
+    const req = await createXMLHttpRequest((req) => {
+      req.open('GET', '/arbitrary-url')
+    })
+
+    expect(req.responseXML).toStrictEqual(
+      new DOMParser().parseFromString(XML_STRING, 'text/xml')
+    )
+  })
+})

--- a/test/regressions/xhr-response-xml-body.test.ts
+++ b/test/regressions/xhr-response-xml-body.test.ts
@@ -1,6 +1,7 @@
-import { createInterceptor } from '../../src';
-import { interceptXMLHttpRequest } from '../../src/interceptors/XMLHttpRequest';
-import { createXMLHttpRequest } from '../helpers';
+import { DOMParser } from 'xmldom'
+import { createInterceptor } from '../../src'
+import { interceptXMLHttpRequest } from '../../src/interceptors/XMLHttpRequest'
+import { createXMLHttpRequest } from '../helpers'
 
 const XML_STRING = '<node key="value">Content</node>'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -781,6 +781,11 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
   integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
 
+"@types/xmldom@^0.1.30":
+  version "0.1.30"
+  resolved "https://registry.yarnpkg.com/@types/xmldom/-/xmldom-0.1.30.tgz#d36d9a7d64af4693d3b18d5dc02ce432a95be12e"
+  integrity sha512-edqgAFXMEtVvaBZ3YnhamvmrHjoYpuxETmnb0lbTZmf/dXpAsO9ZKotUO4K2rn2SIZBDFCMOuA7fOe0H6dRZcA==
+
 "@types/yargs-parser@*":
   version "20.2.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"
@@ -5047,6 +5052,11 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmldom@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.6.0.tgz#43a96ecb8beece991cef382c08397d82d4d0c46f"
+  integrity sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==
 
 y18n@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
Prior to this PR, `responseXML` was always set to `null`, even if the `Content-Type: */xml` header was present. This PR updates the XMLHttpRequest interceptor to return `responseXML` when XML is returned by the resolver.

I originally opened https://github.com/mswjs/msw/issues/715 for this issue before I understood that this repo was a better location for the fix.