### PR TITLE
Unref SocketPolyfill#setTimeout()

### DIFF
--- a/src/interceptors/ClientRequest/polyfills/SocketPolyfill.ts
+++ b/src/interceptors/ClientRequest/polyfills/SocketPolyfill.ts
@@ -94,10 +94,18 @@ export class SocketPolyfill extends EventEmitter {
   }
 
   setTimeout(timeout: number, callback?: () => void): SocketPolyfill {
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       callback?.()
       this.emit('timeout')
     }, timeout)
+
+    /**
+     * Unref the timer in node.js so the process won't hang on exit if long
+     * timeouts were used
+     */
+    if (typeof timer.unref === 'function') {
+      timer.unref()
+    }
 
     return this
   }

--- a/src/interceptors/ClientRequest/polyfills/SocketPolyfill.ts
+++ b/src/interceptors/ClientRequest/polyfills/SocketPolyfill.ts
@@ -99,10 +99,8 @@ export class SocketPolyfill extends EventEmitter {
       this.emit('timeout')
     }, timeout)
 
-    /**
-     * Unref the timer in node.js so the process won't hang on exit if long
-     * timeouts were used
-     */
+    // Unref the timer in Node.js so the process won't hang on exit if long
+    // timeouts were used.
     if (typeof timer.unref === 'function') {
       timer.unref()
     }

--- a/test/regressions/http-timeout.test.ts
+++ b/test/regressions/http-timeout.test.ts
@@ -1,0 +1,35 @@
+import { ChildProcess, spawn } from 'child_process'
+
+jest.setTimeout(20000)
+
+let child: ChildProcess
+let stderr = Buffer.from('')
+
+beforeAll(() => {
+  child = spawn('yarn', [
+    'test:integration:node',
+    'test/regressions/http-timeout.ts',
+    '--testRegex=/test/regressions/http-timeout.ts$',
+  ])
+
+  // Jest writes its output into "stderr".
+  child.stderr?.on('data', (buffer: Buffer) => {
+    stderr = Buffer.concat([stderr, buffer])
+  })
+})
+
+afterAll(() => {
+  child.kill()
+})
+
+it('does not leave the test process hanging due to the custom socket timeout', async () => {
+  const exitCode = await new Promise<number>((resolve) => {
+    child.on('exit', (code: number) => resolve(code))
+  })
+  expect(exitCode).toEqual(0)
+
+  const testResult = stderr.toString('utf-8')
+  expect(testResult).not.toContain(
+    'Jest did not exit one second after the test run has completed'
+  )
+})

--- a/test/regressions/http-timeout.ts
+++ b/test/regressions/http-timeout.ts
@@ -1,0 +1,53 @@
+/**
+ * @note This test is intentionally omitted in the test run.
+ * It's meant to be spawned in a child process by the actual test
+ * that asserts that this one doesn't leave the Jest runner hanging
+ * due to the unterminated socket.
+ */
+import * as http from 'http'
+import { ServerApi, createServer } from '@open-draft/test-server'
+import { createInterceptor } from '../../src/createInterceptor'
+import { interceptClientRequest } from '../../src/interceptors/ClientRequest'
+
+jest.setTimeout(5000)
+
+const interceptor = createInterceptor({
+  modules: [interceptClientRequest],
+  resolver() {
+    return {
+      status: 301,
+      body: 'Hello world',
+    }
+  },
+})
+
+let server: ServerApi
+
+beforeAll(async () => {
+  server = await createServer((app) => {
+    app.get('/resource', (req, res) => {
+      res.status(500).send('must-not-reach-server')
+    })
+  })
+
+  interceptor.apply()
+})
+
+afterAll(async () => {
+  interceptor.restore()
+  await server.close()
+})
+
+it('supports custom socket timeout on the HTTP request', (done) => {
+  const req = http.request(server.http.makeUrl('/resource'), (res) => {
+    res.on('data', () => null)
+    res.on('end', () => {
+      expect(res.statusCode).toEqual(301)
+      done()
+    })
+  })
+
+  // Intentionally large request timeout.
+  req.setTimeout(10000)
+  req.end()
+})


### PR DESCRIPTION
Noticed that my tests hanged in Jest with

```
Jest did not exit one second after the test run has completed.

This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```

when I has using the Elasticsearch client with msw passthrough. It used 30 second timeout. 


After comparing to the real socket in node.js core I noticed it uses unreffed timers so I guess it should be used here too. At least this fixes my hanging test issue. Although I'm not sure why the SocketPolyfill is in play with the passthrough requests.

Node.js source links:
https://github.com/nodejs/node/blob/7766b3853a5a521fd4e8994fab5e9d4b6c83ccba/lib/net.js#L458
https://github.com/nodejs/node/blob/7766b3853a5a521fd4e8994fab5e9d4b6c83ccba/lib/internal/stream_base_commons.js#L264