### PR TITLE
fix: add support for Jest 27

### DIFF
--- a/src/interceptors/ClientRequest/createClientRequestOverride.ts
+++ b/src/interceptors/ClientRequest/createClientRequestOverride.ts
@@ -121,9 +121,9 @@ export function createClientRequestOverride(
         }
       }
 
-      setImmediate(() => {
+      setTimeout(() => {
         this.emit('drain')
-      })
+      }, 0)
 
       return false
     }


### PR DESCRIPTION
Jest 27 removes the `setImmediate`-global so replaced it with setTimeout with a 0 delay

fixes #123 