### PR TITLE
Supports request interception in a ChildProcess

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ npm install @mswjs/interceptors
 
 ### `createInterceptor(options: CreateInterceptorOptions)`
 
+Enables request interception in the current process.
+
 ```js
 import { createInterceptor } from '@mswjs/interceptors'
 import nodeInterceptors from '@mswjs/interceptors/lib/presets/node'
@@ -64,6 +66,40 @@ const interceptor = createInterceptor({
 ```
 
 > Using the `/presets/node` interceptors preset is the recommended way to ensure all requests get intercepted, regardless of their origin.
+
+### `createRemoteInterceptor(options: CreateRemoteInterceptorOptions)`
+
+Enables request interception in the current process while delegating the response resolution logic to the _parent process_. **Requires the current process to be a child process**. Requires the parent process to establish a resolver by calling the `createRemoteResolver` function.
+
+```js
+import { createRemoteInterceptor } from '@mswjs/interceptors'
+
+const interceptor = createRemoteInterceptor({
+  modules: nodeInterceptors,
+})
+
+interceptor.apply()
+
+process.on('disconnect', () => {
+  interceptor.restore()
+})
+```
+
+### `createRemoteResolver(options: CreateRemoteResolverOptions)`
+
+Resolves an intercepted request in the given child `process`. Requires for that child process to enable request interception by calling the `createRemoteInterceptor` function.
+
+```js
+import { createRemoteResolver } from '@mswjs/interceptors'
+
+createRemoteResolver({
+  process: fff,
+  resolver(request) {
+    // Optionally, return a mocked response
+    // for a request that occurred in the child "process".
+  },
+})
+```
 
 ### Interceptors
 

--- a/src/createInterceptor.ts
+++ b/src/createInterceptor.ts
@@ -15,6 +15,7 @@ export type Observer = StrictEventEmitter<InterceptorEventsMap>
 export type InterceptorCleanupFn = () => void
 
 export interface IsomorphicRequest {
+  id: string
   url: URL
   method: string
   headers: Headers

--- a/src/createInterceptor.ts
+++ b/src/createInterceptor.ts
@@ -34,7 +34,7 @@ export interface MockedResponse
   headers?: HeadersObject
 }
 
-interface InterceptorEventsMap {
+export interface InterceptorEventsMap {
   request(request: IsomorphicRequest): void
   response(request: IsomorphicRequest, response: IsomorphicResponse): void
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './createInterceptor'
+export * from './remote'
 
 /* Utils */
 export { getCleanUrl } from './utils/getCleanUrl'

--- a/src/interceptors/ClientRequest/createClientRequestOverride.ts
+++ b/src/interceptors/ClientRequest/createClientRequestOverride.ts
@@ -15,6 +15,7 @@ import { normalizeHttpRequestEndParams } from './utils/normalizeHttpRequestEndPa
 import { getIncomingMessageBody } from './utils/getIncomingMessageBody'
 import { IsomorphicRequest, Observer, Resolver } from '../../createInterceptor'
 import { toIsoResponse } from '../../utils/toIsoResponse'
+import { uuidv4 } from '../../utils/uuid'
 
 const createDebug = require('debug')
 
@@ -173,6 +174,7 @@ export function createClientRequestOverride(
 
       // Construct the intercepted request instance exposed to the request middleware.
       const isoRequest: IsomorphicRequest = {
+        id: uuidv4(),
         url,
         method: options.method || 'GET',
         headers: requestHeaders,

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -13,6 +13,7 @@ import { DOMParser } from 'xmldom'
 import { IsomorphicRequest, Observer, Resolver } from '../../createInterceptor'
 import { parseJson } from '../../utils/parseJson'
 import { toIsoResponse } from '../../utils/toIsoResponse'
+import { uuidv4 } from '../../utils/uuid'
 import { bufferFrom } from './utils/bufferFrom'
 import { createEvent } from './utils/createEvent'
 
@@ -240,6 +241,7 @@ export const createXMLHttpRequestOverride = (
 
       // Create an intercepted request instance exposed to the request intercepting middleware.
       const isoRequest: IsomorphicRequest = {
+        id: uuidv4(),
         url,
         method: this.method,
         body: this.data,

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -10,6 +10,7 @@ import {
   IsomorphicResponse,
 } from '../../createInterceptor'
 import { toIsoResponse } from '../../utils/toIsoResponse'
+import { uuidv4 } from '../../utils/uuid'
 
 const debug = require('debug')('fetch')
 
@@ -26,6 +27,7 @@ export const interceptFetch: Interceptor = (observer, resolver) => {
     debug('[%s] %s', method, url)
 
     const isoRequest: IsomorphicRequest = {
+      id: uuidv4(),
       url: new URL(url, location.origin),
       method: method,
       headers: new Headers(init?.headers || {}),

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -1,0 +1,145 @@
+import { ChildProcess } from 'child_process'
+import { Headers } from 'headers-utils'
+import { Serializable } from 'node:child_process'
+import {
+  createInterceptor,
+  InterceptorApi,
+  InterceptorOptions,
+  IsomorphicRequest,
+  Resolver,
+} from './createInterceptor'
+
+type ProcessEventListener = (message: Serializable, ...args: any[]) => void
+
+export type CreateRemoteInterceptorOptions = Omit<
+  InterceptorOptions,
+  'resolver'
+>
+
+export interface CreateRemoteResolverOptions {
+  process: ChildProcess
+  resolver: Resolver
+}
+
+function requestReviver(key: string, value: any) {
+  switch (key) {
+    case 'url':
+      return new URL(value)
+
+    case 'headers':
+      return new Headers(value)
+
+    default:
+      return value
+  }
+}
+
+/**
+ * Creates a remote request interceptor that delegates
+ * the mocked response resolution to the parent process.
+ * The parent process must establish a remote resolver
+ * by calling `createRemoteResolver` function.
+ */
+export function createRemoteInterceptor(
+  options: CreateRemoteInterceptorOptions
+): InterceptorApi {
+  if (!process.connected) {
+    throw new Error(
+      `Failed to create a remote interceptor: the current process (${process.pid}) does not have a parent. Please make sure you're spawning this process as a child process in order to use remote request interception.`
+    )
+  }
+
+  if (typeof process.send === 'undefined') {
+    throw new Error(
+      `\
+Failed to create a remote interceptor: the current process (${process.pid}) does not have the IPC enabled. Please make sure you're spawning this process with the "ipc" stdio value set:
+
+spawn('node', ['module.js'], { stdio: ['ipc'] })\
+`
+    )
+  }
+
+  let handleParentMessage: ProcessEventListener
+
+  const interceptor = createInterceptor({
+    ...options,
+    resolver(request) {
+      const serializedRequest = JSON.stringify(request)
+      process.send?.(`request:${serializedRequest}`)
+
+      return new Promise((resolve) => {
+        handleParentMessage = (message: Serializable) => {
+          if (typeof message !== 'string') {
+            return
+          }
+
+          if (message.startsWith(`response:${request.id}`)) {
+            const [, responseString] =
+              message.match(/^response:.+?:(.+)$/) || []
+
+            if (!responseString) {
+              return resolve()
+            }
+
+            const mockedResponse = JSON.parse(responseString)
+
+            return resolve(mockedResponse)
+          }
+        }
+
+        process.addListener('message', handleParentMessage)
+      })
+    },
+  })
+
+  return {
+    ...interceptor,
+    restore() {
+      interceptor.restore()
+      process.removeListener('message', handleParentMessage)
+    },
+  }
+}
+
+/**
+ * Creates a response resolver function attached to the given `ChildProcess`.
+ * The child process must establish a remote interceptor by calling `createRemoteInterceptor` function.
+ */
+export function createRemoteResolver(
+  options: CreateRemoteResolverOptions
+): void {
+  const handleChildMessage: ProcessEventListener = async (message) => {
+    if (typeof message !== 'string') {
+      return
+    }
+
+    if (message.startsWith('request:')) {
+      const [, requestString] = message.match(/^request:(.+)$/) || []
+
+      if (!requestString) {
+        return
+      }
+
+      const isoRequest: IsomorphicRequest = JSON.parse(
+        requestString,
+        requestReviver
+      )
+
+      // Retrieve the mocked response.
+      const mockedResponse = await options.resolver(isoRequest, null as any)
+
+      // Send the mocked response to the child process.
+      const serializedResponse = JSON.stringify(mockedResponse)
+      options.process.send(`response:${isoRequest.id}:${serializedResponse}`)
+    }
+  }
+
+  const cleanup = () => {
+    options.process.removeListener('message', handleChildMessage)
+  }
+
+  options.process.addListener('message', handleChildMessage)
+  options.process.addListener('disconnect', cleanup)
+  options.process.addListener('error', cleanup)
+  options.process.addListener('exit', cleanup)
+}

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,7 @@
+export function uuidv4(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0
+    const v = c == 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}

--- a/test/features/remote/child-process.test.ts
+++ b/test/features/remote/child-process.test.ts
@@ -1,0 +1,47 @@
+import * as path from 'path'
+import { spawn } from 'child_process'
+import { createRemoteResolver } from '../../../src'
+
+const child = spawn('node', [path.resolve(__dirname, 'child.js')], {
+  stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+})
+
+createRemoteResolver({
+  process: child,
+  resolver() {
+    return {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        mockedFromParent: true,
+      }),
+    }
+  },
+})
+
+afterAll(() => {
+  child.kill()
+})
+
+it('intercepts an HTTP request made in a child process', async () => {
+  child.send('make:request')
+
+  const response = await new Promise((resolve, reject) => {
+    child.addListener('message', (message) => {
+      if (typeof message !== 'string') {
+        return
+      }
+
+      if (message.startsWith('done:')) {
+        const [, responseString] = message.match(/^done:(.+)$/) || []
+        resolve(JSON.parse(responseString))
+      }
+    })
+    child.addListener('error', reject)
+    child.addListener('exit', reject)
+  })
+
+  expect(response).toEqual({ mockedFromParent: true })
+})

--- a/test/features/remote/child.js
+++ b/test/features/remote/child.js
@@ -1,0 +1,34 @@
+const fetch = require('node-fetch')
+const { createRemoteInterceptor } = require('../../../lib')
+const {
+  interceptClientRequest,
+} = require('../../../lib/interceptors/ClientRequest')
+
+console.log('footer')
+console.log('footer')
+console.log('footer')
+console.log('footer')
+
+const interceptor = createRemoteInterceptor({
+  modules: [interceptClientRequest],
+})
+
+interceptor.apply()
+
+function callEndpoint() {
+  fetch('https://httpbin.org/get')
+    .then((res) => res.json())
+    .then((json) => {
+      process.send(`done:${JSON.stringify(json)}`)
+    })
+}
+
+process.on('message', (message) => {
+  if (message === 'make:request') {
+    callEndpoint()
+  }
+})
+
+process.on('disconnect', () => {
+  interceptor.restore()
+})

--- a/test/features/remote/child.js
+++ b/test/features/remote/child.js
@@ -4,11 +4,6 @@ const {
   interceptClientRequest,
 } = require('../../../lib/interceptors/ClientRequest')
 
-console.log('footer')
-console.log('footer')
-console.log('footer')
-console.log('footer')
-
 const interceptor = createRemoteInterceptor({
   modules: [interceptClientRequest],
 })

--- a/test/features/remote/remote.test.ts
+++ b/test/features/remote/remote.test.ts
@@ -1,8 +1,10 @@
 import * as path from 'path'
-import { spawn } from 'child_process'
+import { ChildProcess, spawn } from 'child_process'
 import { createRemoteResolver } from '../../../src'
 
-const child = spawn('node', [path.resolve(__dirname, 'child.js')], {
+const CHILD_PATH = path.resolve(__dirname, 'child.js')
+
+const child = spawn('node', [CHILD_PATH], {
   stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
 })
 
@@ -22,7 +24,9 @@ createRemoteResolver({
 })
 
 afterAll(() => {
-  child.kill()
+  if (!child.killed) {
+    child.kill()
+  }
 })
 
 it('intercepts an HTTP request made in a child process', async () => {


### PR DESCRIPTION
## Motivation

Since this library patches the request-issuing modules in the _current process_, there is no way to enable request interception in a _child_ process (i.e. when testing a running application). An alternative has been suggested previously to enable the interception on the application's side, for example:

```js
// src/index.js
createInterceptors({ ... }).apply()
```

However, this implies that:

- Response resolution logic needs to be described in the app (possibly on runtime via environmental variables).
- A single test cannot affect the response resolution logic, as the application and a test live in separate universes.

This change aims to support request interception in a child process by using the IPC between the parent (test) and the child (spawned application) processes and signaling requests/responses between them. 

## Changes

- Isomorphic requests now have a required `id` property—a UUID representing a request and assigned by the library.
- The library now exports two new functions: `createRemoteInterceptor` and `createRemoteResolver`, to be used in child and parent processes respectively. 

## Usage example

```js
// parent.js
import { spawn } from 'child_process'
import { createRemoteResolver } from '@mswjs/interceptors/remote'

const serverProcess = spawn('node', ['child.js'], {
  // It's required to spawn the child process with the "ipc" stdio
  // in order to have the IPC working in Node.js.
  stdio: ['inherit', 'inherit', 'inherit', 'ipc']
})

// Receives the request events from the given child "process"
// and uses the "resolver" function to produce a mocked response.
// Sends the mocked response to the child process to be used.
createRemoteResolver({
  process: serverProcess,
  resolver(request) {
    return { status: 301 }
  }
})
```

```js
// child.js
import { interceptClientRequest } from '@mswjs/interceptors/lib/interceptors/ClientRequest'
import { createRemoteInterceptor } from '@mswjs/interceptors/remote'

// Intercepts requests according to the given modules
// and signals the parent process to send back the mocked response.
const interceptor = createRemoteInterceptor({
  modules: [interceptClientRequest]
})
```

## Limitations & caveats

- The child process must be spawned with the "ipc" `stdio` value provided. This is required for the IPC (inter-process communication) to work in Node.js (for `process.send` to be defined).
- The request reference (the second `resolver` argument) cannot be reliably serialized and passed via IPC (serializing classes isn't a good idea), so it's `undefined` when using the remote interception. 

## Roadmap

- [ ] Try constructing a request reference coerced from the known information (second argument for the `resolver` function). 