### PR TITLE
Adds the "toIsoResponse" helper function

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -12,6 +12,7 @@ import {
 import { DOMParser } from 'xmldom'
 import { IsomorphicRequest, Observer, Resolver } from '../../createInterceptor'
 import { parseJson } from '../../utils/parseJson'
+import { toIsoResponse } from '../../utils/toIsoResponse'
 import { bufferFrom } from './utils/bufferFrom'
 import { createEvent } from './utils/createEvent'
 
@@ -49,7 +50,8 @@ export const createXMLHttpRequestOverride = (
     _responseHeaders: Headers
 
     // Collection of events modified by `addEventListener`/`removeEventListener` calls.
-    _events: XMLHttpRequestEvent<InternalXMLHttpRequestEventTargetEventMap>[] = []
+    _events: XMLHttpRequestEvent<InternalXMLHttpRequestEventTargetEventMap>[] =
+      []
 
     /* Request state */
     public static readonly UNSENT = 0
@@ -82,10 +84,8 @@ export const createXMLHttpRequestOverride = (
     public responseURL: string
     public upload: XMLHttpRequestUpload
     public readyState: number
-    public onreadystatechange: (
-      this: XMLHttpRequest,
-      ev: Event
-    ) => any = null as any
+    public onreadystatechange: (this: XMLHttpRequest, ev: Event) => any =
+      null as any
     public timeout: number
 
     /* Events */
@@ -93,10 +93,8 @@ export const createXMLHttpRequestOverride = (
       this: XMLHttpRequestEventTarget,
       event: ProgressEvent
     ) => any = null as any
-    public onerror: (
-      this: XMLHttpRequestEventTarget,
-      event: Event
-    ) => any = null as any
+    public onerror: (this: XMLHttpRequestEventTarget, event: Event) => any =
+      null as any
     public onload: (
       this: XMLHttpRequestEventTarget,
       event: ProgressEvent
@@ -322,12 +320,7 @@ export const createXMLHttpRequestOverride = (
             // Trigger a loadend event to indicate the fetch has completed.
             this.trigger('loadend')
 
-            observer.emit('response', isoRequest, {
-              status: this.status,
-              statusText: this.statusText,
-              headers: objectToHeaders(mockedResponse.headers || {}),
-              body: mockedResponse.body,
-            })
+            observer.emit('response', isoRequest, toIsoResponse(mockedResponse))
           } else {
             debug('no mocked response received!')
 

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -8,8 +8,8 @@ import {
   Interceptor,
   IsomorphicRequest,
   IsomorphicResponse,
-  MockedResponse,
 } from '../../createInterceptor'
+import { toIsoResponse } from '../../utils/toIsoResponse'
 
 const debug = require('debug')('fetch')
 
@@ -39,7 +39,7 @@ export const interceptFetch: Interceptor = (observer, resolver) => {
     debug('mocked response', response)
 
     if (response) {
-      const isomorphicResponse = normalizeMockedResponse(response)
+      const isomorphicResponse = toIsoResponse(response)
       debug('derived isomorphic response', isomorphicResponse)
 
       observer.emit('response', isoRequest, isomorphicResponse)
@@ -70,15 +70,6 @@ export const interceptFetch: Interceptor = (observer, resolver) => {
   return () => {
     debug('restoring modules...')
     window.fetch = pureFetch
-  }
-}
-
-function normalizeMockedResponse(response: MockedResponse): IsomorphicResponse {
-  return {
-    status: response.status || 200,
-    statusText: response.statusText || 'OK',
-    headers: objectToHeaders(response.headers || {}),
-    body: response.body,
   }
 }
 

--- a/src/utils/toIsoResponse.test.ts
+++ b/src/utils/toIsoResponse.test.ts
@@ -1,0 +1,39 @@
+import { Headers } from 'headers-utils'
+import { toIsoResponse } from './toIsoResponse'
+
+it('returns a well-formed empty response', () => {
+  expect(toIsoResponse({})).toEqual({
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers(),
+  })
+})
+
+it('uses fallback values for the missing response properties', () => {
+  expect(toIsoResponse({ status: 301, body: 'text-body' })).toEqual({
+    status: 301,
+    statusText: 'OK',
+    headers: new Headers(),
+    body: 'text-body',
+  })
+})
+
+it('returns a full response as-is, converting the headers', () => {
+  expect(
+    toIsoResponse({
+      status: 301,
+      statusText: 'Custom Status',
+      headers: {
+        'X-Allowed': 'yes',
+      },
+      body: 'text-body',
+    })
+  ).toEqual({
+    status: 301,
+    statusText: 'Custom Status',
+    headers: new Headers({
+      'X-Allowed': 'yes',
+    }),
+    body: 'text-body',
+  })
+})

--- a/src/utils/toIsoResponse.ts
+++ b/src/utils/toIsoResponse.ts
@@ -1,0 +1,14 @@
+import { objectToHeaders } from 'headers-utils'
+import { IsomorphicResponse, MockedResponse } from '../createInterceptor'
+
+/**
+ * Converts a given mocked response object into an isomorphic response.
+ */
+export function toIsoResponse(response: MockedResponse): IsomorphicResponse {
+  return {
+    status: response.status || 200,
+    statusText: response.statusText || 'OK',
+    headers: objectToHeaders(response.headers || {}),
+    body: response.body,
+  }
+}


### PR DESCRIPTION
## Motivation

Currently, all override classes normalize a `MockedResponse` object into an `IsomorphicResponse` object by listing the same fallback values logic repeatedly. This change aims to have a single utility to perform said normalization.

## Changes

- Adds the `toIsoResponse` utility that convers a (partial) mocked response into an `IsomorphicResponse` (adds fallback values).
- Adjusts the interceptor classes to use the said utility. 