### PR TITLE
Supports gzip content-encoding when retrieving the IncomingMessage body

### DIFF
--- a/src/interceptors/ClientRequest/utils/getIncomingMessageBody.test.ts
+++ b/src/interceptors/ClientRequest/utils/getIncomingMessageBody.test.ts
@@ -1,0 +1,44 @@
+import { IncomingMessage } from 'http'
+import { Socket } from 'net'
+import * as zlib from 'zlib'
+import { getIncomingMessageBody } from './getIncomingMessageBody'
+
+test('returns utf8 string given a utf8 response body', async () => {
+  const utfBuffer = Buffer.from('one')
+  const message: IncomingMessage = new IncomingMessage(new Socket())
+
+  const pendingResponseBody = getIncomingMessageBody(message)
+  message.emit('data', utfBuffer)
+  message.emit('end')
+
+  expect(pendingResponseBody).resolves.toEqual('one')
+})
+
+test('returns utf8 string given a gzipped response body', async () => {
+  const utfBuffer = zlib.gzipSync(Buffer.from('two'))
+  const message: IncomingMessage = new IncomingMessage(new Socket())
+  message.headers = {
+    'content-encoding': 'gzip',
+  }
+
+  const pendingResponseBody = getIncomingMessageBody(message)
+  message.emit('data', utfBuffer)
+  message.emit('end')
+
+  expect(pendingResponseBody).resolves.toEqual('two')
+})
+
+test('returns utf8 string given a gzipped response body with incorrect "content-lenght"', async () => {
+  const utfBuffer = zlib.gzipSync(Buffer.from('three'))
+  const message: IncomingMessage = new IncomingMessage(new Socket())
+  message.headers = {
+    'content-encoding': 'gzip',
+    'content-length': '500',
+  }
+
+  const pendingResponseBody = getIncomingMessageBody(message)
+  message.emit('data', utfBuffer)
+  message.emit('end')
+
+  expect(pendingResponseBody).resolves.toEqual('three')
+})

--- a/src/interceptors/ClientRequest/utils/getIncomingMessageBody.ts
+++ b/src/interceptors/ClientRequest/utils/getIncomingMessageBody.ts
@@ -1,12 +1,19 @@
 import { IncomingMessage } from 'http'
+import { Stream } from 'stream'
+import * as zlib from 'zlib'
 
 export function getIncomingMessageBody(res: IncomingMessage): Promise<string> {
   let responseBody = ''
+  let stream: Stream = res
+
+  if (res.headers['content-encoding'] === 'gzip') {
+    stream = res.pipe(zlib.createGunzip())
+  }
 
   return new Promise((resolve, reject) => {
-    res.once('error', reject)
-    res.on('data', (chunk) => (responseBody += chunk))
-    res.once('end', () => {
+    stream.once('error', reject)
+    stream.on('data', (chunk) => (responseBody += chunk))
+    stream.once('end', () => {
       resolve(responseBody)
     })
   })


### PR DESCRIPTION
## GitHub

- Fixes #109 

## Changes

- `getIncomingMessageBody` will now handle the gzip compression to prevent the corruption of compressed response bodies. 
- Adds previously missing unit tests for the `getIncomingMessageBody` function. 