### PR TITLE
Ugrade xmldom to use latest version at new location at @xmldom/xmldom

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,11 +52,11 @@
   },
   "dependencies": {
     "@open-draft/until": "^1.0.3",
+    "@xmldom/xmldom": "^0.7.2",
     "debug": "^4.3.0",
     "headers-utils": "^3.0.2",
     "outvariant": "^1.2.0",
-    "strict-event-emitter": "^0.2.0",
-    "xmldom": "^0.6.0"
+    "strict-event-emitter": "^0.2.0"
   },
   "keywords": [
     "request",

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -9,7 +9,7 @@ import {
   objectToHeaders,
   headersToString,
 } from 'headers-utils'
-import { DOMParser } from 'xmldom'
+import { DOMParser } from '@xmldom/xmldom'
 import { IsomorphicRequest, Observer, Resolver } from '../../createInterceptor'
 import { parseJson } from '../../utils/parseJson'
 import { toIsoResponse } from '../../utils/toIsoResponse'

--- a/test/regressions/xhr-response-xml-body.test.ts
+++ b/test/regressions/xhr-response-xml-body.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { DOMParser } from 'xmldom'
+import { DOMParser } from '@xmldom/xmldom'
 import { createInterceptor } from '../../src'
 import { interceptXMLHttpRequest } from '../../src/interceptors/XMLHttpRequest'
 import { createXMLHttpRequest } from '../helpers'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,6 +1107,11 @@
     "@webassemblyjs/ast" "1.11.0"
     "@xtuc/long" "4.2.2"
 
+"@xmldom/xmldom@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.2.tgz#d920079e66806b2626b5311955f6a7c4bed1cba8"
+  integrity sha512-t/Zqo0ewes3iq6zGqEqJNUWI27Acr3jkmSUNp6E3nl0Z2XbtqAG5XYqPNLdYonILmhcxANsIidh69tHzjXtuRg==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -4197,11 +4202,6 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-
-xmldom@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.6.0.tgz#43a96ecb8beece991cef382c08397d82d4d0c46f"
-  integrity sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
This is to fix the xmldom security vulnerability - closes #145 

Per [the xmldom issue](https://github.com/xmldom/xmldom/issues/271), xmldom is now published at @xmldom/xmldom.