### PR TITLE
Fixes Fetch bug on response not being cloned

### DIFF
--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -58,12 +58,13 @@ export const interceptFetch: Interceptor = (observer, resolver) => {
     debug('no mocked response found, bypassing...')
 
     return pureFetch(input, init).then(async (response) => {
-      debug('original fetch performed', response)
+      const clonedResponse = response.clone()
+      debug('original fetch performed', clonedResponse)
 
       observer.emit(
         'response',
         isoRequest,
-        await normalizeFetchResponse(response)
+        await normalizeFetchResponse(clonedResponse)
       )
       return response
     })


### PR DESCRIPTION
Hey, I was getting an error on fetch interceptor, especially when webpack makes the hot reload. This is the error:

`[HMR] Update failed: TypeError: Failed to execute 'json' on 'Response': body stream already read`

I noticed that the fetch response is being read inside `normalizeFetchResponse` function, so... It's required to clone the response before passing it to the function, That wont touch the real response.

Here is a Stackoverflow thread: https://stackoverflow.com/questions/40497859/reread-a-response-body-from-javascripts-fetch

## GitHub

- May fix #113 and #138 