### PR TITLE
fix(ClientRequest): preserve custom listeners on IncomingMessage

### DIFF
--- a/src/interceptors/ClientRequest/utils/cloneIncomingMessage.ts
+++ b/src/interceptors/ClientRequest/utils/cloneIncomingMessage.ts
@@ -1,0 +1,31 @@
+import { IncomingMessage } from 'http'
+import { PassThrough } from 'stream'
+
+const clonableProperties = ['headers', 'rawHeaders', 'trailers', 'rawTrailers']
+
+export function cloneIncomingMessage(
+  message: IncomingMessage
+): IncomingMessage {
+  const streamClone = message.pipe(new PassThrough())
+
+  /**
+   * Inherit the original message properties (i.e. "headers").
+   * @note Cloning a readable stream is not sufficient,
+   * libraries may depend on "res.headers" and such.
+   */
+  Object.defineProperties(
+    streamClone,
+    clonableProperties.reduce<PropertyDescriptorMap>(
+      (properties, propertyName) => {
+        properties[propertyName] = {
+          // @ts-ignore
+          value: message[propertyName],
+        }
+        return properties
+      },
+      {}
+    )
+  )
+
+  return streamClone as unknown as IncomingMessage
+}


### PR DESCRIPTION
## GitHub

- Fixes https://github.com/mswjs/msw/issues/941
- Fixes #161

## Changes

- Does not call `stream.removeAllListeners()` on the response `IncomingMessage` in the `getIncomingMessageBody` helper (when reading the response body for the internal "response" event). 

## Roadmap

- [x] Write the test so it fails without the fix.
- [ ] Annotate the cloned `IncomingMessage` better (drop `as unknown as IncomingMessage`). 