### PR TITLE
refactor(intercept): remove request abstractions for http/https

### DIFF
--- a/src/interceptors/ClientRequest/index.ts
+++ b/src/interceptors/ClientRequest/index.ts
@@ -70,7 +70,7 @@ export const interceptClientRequest: Interceptor = (observer, resolver) => {
 
     // @ts-ignore
     requestModule.request = function requestOverride(...args: any[]) {
-      debug('%s.request proxy call', protocol)
+      debug('intercepted %s.request call', protocol)
 
       return handleClientRequest(
         protocol,
@@ -83,18 +83,23 @@ export const interceptClientRequest: Interceptor = (observer, resolver) => {
 
     // @ts-ignore
     requestModule.get = function getOverride(...args: any[]) {
-      debug('%s.get call', protocol)
+      debug('intercepted %s.get call', protocol)
 
-      const req = handleClientRequest(
+      const request = handleClientRequest(
         protocol,
         originalGet.bind(requestModule),
         args,
         observer,
         resolver
       )
-      req.end()
 
-      return req
+      /**
+       * @note https://nodejs.org/api/http.html#httpgetoptions-callback
+       * "http.get" sets the method to "GET" and calls "req.end()" automatically.
+       */
+      request.end()
+
+      return request
     }
 
     pureModules.set(protocol, {

--- a/test/intercept/XMLHttpRequest/XMLHttpRequest.browser.test.ts
+++ b/test/intercept/XMLHttpRequest/XMLHttpRequest.browser.test.ts
@@ -7,7 +7,7 @@ import { createServer, ServerApi } from '@open-draft/test-server'
 import { RequestHandler } from 'express'
 import { createBrowserXMLHttpRequest } from '../../helpers'
 
-let server: ServerApi
+let httpServer: ServerApi
 
 function prepareRuntime() {
   return pageWith({
@@ -16,7 +16,7 @@ function prepareRuntime() {
 }
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     const requestHandler: RequestHandler = (req, res) => {
       res.status(200).send('user-body').end()
     }
@@ -27,13 +27,13 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
-  await server.close()
+  await httpServer.close()
 })
 
 test('intercepts an HTTP GET request', async () => {
   const context = await prepareRuntime()
   const request = createBrowserXMLHttpRequest(context)
-  const url = server.http.makeUrl('/user')
+  const url = httpServer.http.makeUrl('/user')
   const response = await request(
     'GET',
     url,
@@ -53,15 +53,15 @@ test('intercepts an HTTP GET request', async () => {
     }
   )
 
-  expect(response).toHaveProperty('status', 200)
-  expect(response).toHaveProperty('statusText', 'OK')
-  expect(response).toHaveProperty('body', 'user-body')
+  expect(response.status).toEqual(200)
+  expect(response.statusText).toEqual('OK')
+  expect(response.body).toEqual('user-body')
 })
 
 test('intercepts an HTTP POST request', async () => {
   const context = await prepareRuntime()
   const request = createBrowserXMLHttpRequest(context)
-  const url = server.http.makeUrl('/user')
+  const url = httpServer.http.makeUrl('/user')
   const response = await request(
     'POST',
     url,
@@ -81,7 +81,7 @@ test('intercepts an HTTP POST request', async () => {
     }
   )
 
-  expect(response).toHaveProperty('status', 200)
-  expect(response).toHaveProperty('statusText', 'OK')
-  expect(response).toHaveProperty('body', 'user-body')
+  expect(response.status).toEqual(200)
+  expect(response.statusText).toEqual('OK')
+  expect(response.body).toEqual('user-body')
 })

--- a/test/intercept/XMLHttpRequest/XMLHttpRequest.test.ts
+++ b/test/intercept/XMLHttpRequest/XMLHttpRequest.test.ts
@@ -12,18 +12,18 @@ import { IsomorphicRequest } from '../../../src/createInterceptor'
 function lookupRequest(
   req: XMLHttpRequest,
   method: string,
-  pool: IsomorphicRequest[]
+  requests: IsomorphicRequest[]
 ): IsomorphicRequest | undefined {
-  return findRequest(pool, method, req.responseURL)
+  return findRequest(requests, method, req.responseURL)
 }
 
-let pool: IsomorphicRequest[] = []
-let server: ServerApi
+let requests: IsomorphicRequest[] = []
+let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
   resolver(request) {
-    pool.push(request)
+    requests.push(request)
   },
 })
 
@@ -32,7 +32,7 @@ beforeAll(async () => {
   // Allow XHR requests to the local HTTPS server with a self-signed certificate.
   window._resourceLoader._strictSSL = false
 
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     const handleUserRequest: RequestHandler = (req, res) => {
       res.status(200).send('user-body').end()
     }
@@ -49,229 +49,195 @@ beforeAll(async () => {
 })
 
 afterEach(() => {
-  pool = []
+  requests = []
 })
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
+})
+
+test('intercepts an HTTP HEAD request', async () => {
+  const url = httpServer.http.makeUrl('/user?id=123')
+  const originalRequest = await createXMLHttpRequest((req) => {
+    req.open('HEAD', url)
+    req.setRequestHeader('x-custom-header', 'yes')
+  })
+  const capturedRequest = lookupRequest(originalRequest, 'HEAD', requests)!!
+
+  expect(capturedRequest.method).toEqual('HEAD')
+  expect(capturedRequest.url).toBeInstanceOf(URL)
+  expect(capturedRequest.url.href).toEqual(url)
+  expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
+  expect(capturedRequest.headers).toBeInstanceOf(Headers)
+  expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
 })
 
 test('intercepts an HTTP GET request', async () => {
+  const url = httpServer.http.makeUrl('/user?id=123')
   const originalRequest = await createXMLHttpRequest((req) => {
-    req.open('GET', server.http.makeUrl('/user?id=123'))
+    req.open('GET', url)
     req.setRequestHeader('x-custom-header', 'yes')
   })
-  const capturedRequest = lookupRequest(originalRequest, 'GET', pool)!
+  const capturedRequest = lookupRequest(originalRequest, 'GET', requests)!
 
-  expect(capturedRequest).toBeTruthy()
+  expect(capturedRequest.method).toEqual('GET')
   expect(capturedRequest.url).toBeInstanceOf(URL)
-  expect(capturedRequest.url.toString()).toEqual(
-    server.http.makeUrl('/user?id=123')
-  )
-  expect(capturedRequest).toHaveProperty('method', 'GET')
+  expect(capturedRequest.url.href).toEqual(url)
   expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
   expect(capturedRequest.headers).toBeInstanceOf(Headers)
   expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
 })
 
 test('intercepts an HTTP POST request', async () => {
+  const url = httpServer.http.makeUrl('/user?id=123')
   const originalRequest = await createXMLHttpRequest((req) => {
-    req.open('POST', server.http.makeUrl('/user?id=123'))
+    req.open('POST', url)
     req.setRequestHeader('x-custom-header', 'yes')
-    req.send('request-body')
+    req.send('post-payload')
   })
-  const capturedRequest = lookupRequest(originalRequest, 'POST', pool)!
+  const capturedRequest = lookupRequest(originalRequest, 'POST', requests)!
 
-  expect(capturedRequest).toBeTruthy()
+  expect(capturedRequest.method).toEqual('POST')
   expect(capturedRequest.url).toBeInstanceOf(URL)
-  expect(capturedRequest.url.toString()).toEqual(
-    server.http.makeUrl('/user?id=123')
-  )
-  expect(capturedRequest).toHaveProperty('method', 'POST')
+  expect(capturedRequest.url.href).toEqual(url)
   expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
-  expect(capturedRequest).toHaveProperty('body', 'request-body')
   expect(capturedRequest.headers).toBeInstanceOf(Headers)
   expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
+  expect(capturedRequest.body).toEqual('post-payload')
 })
 
 test('intercepts an HTTP PUT request', async () => {
+  const url = httpServer.http.makeUrl('/user?id=123')
   const originalRequest = await createXMLHttpRequest((req) => {
-    req.open('PUT', server.http.makeUrl('/user?id=123'))
+    req.open('PUT', url)
     req.setRequestHeader('x-custom-header', 'yes')
+    req.send('put-payload')
   })
-  const capturedRequest = lookupRequest(originalRequest, 'PUT', pool)!
+  const capturedRequest = lookupRequest(originalRequest, 'PUT', requests)!
 
-  expect(capturedRequest).toBeTruthy()
+  expect(capturedRequest.method).toEqual('PUT')
   expect(capturedRequest.url).toBeInstanceOf(URL)
-  expect(capturedRequest.url.toString()).toEqual(
-    server.http.makeUrl('/user?id=123')
-  )
-  expect(capturedRequest).toHaveProperty('method', 'PUT')
+  expect(capturedRequest.url.href).toEqual(url)
   expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
   expect(capturedRequest.headers).toBeInstanceOf(Headers)
   expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
+  expect(capturedRequest.body).toEqual('put-payload')
 })
 
 test('intercepts an HTTP DELETE request', async () => {
+  const url = httpServer.http.makeUrl('/user?id=123')
   const originalRequest = await createXMLHttpRequest((req) => {
-    req.open('DELETE', server.http.makeUrl('/user?id=123'))
+    req.open('DELETE', url)
     req.setRequestHeader('x-custom-header', 'yes')
   })
-  const capturedRequest = lookupRequest(originalRequest, 'DELETE', pool)!
+  const capturedRequest = lookupRequest(originalRequest, 'DELETE', requests)!
 
-  expect(capturedRequest).toBeTruthy()
+  expect(capturedRequest.method).toEqual('DELETE')
   expect(capturedRequest.url).toBeInstanceOf(URL)
-  expect(capturedRequest.url.toString()).toEqual(
-    server.http.makeUrl('/user?id=123')
-  )
-  expect(capturedRequest).toHaveProperty('method', 'DELETE')
-  expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
-  expect(capturedRequest.headers).toBeInstanceOf(Headers)
-  expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
-})
-
-test('intercepts an HTTP PATCH request', async () => {
-  const originalRequest = await createXMLHttpRequest((req) => {
-    req.open('PATCH', server.http.makeUrl('/user?id=123'))
-    req.setRequestHeader('x-custom-header', 'yes')
-  })
-  const capturedRequest = lookupRequest(originalRequest, 'PATCH', pool)!
-
-  expect(capturedRequest).toBeTruthy()
-  expect(capturedRequest.url).toBeInstanceOf(URL)
-  expect(capturedRequest.url.toString()).toEqual(
-    server.http.makeUrl('/user?id=123')
-  )
-  expect(capturedRequest).toHaveProperty('method', 'PATCH')
-  expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
-  expect(capturedRequest.headers).toBeInstanceOf(Headers)
-  expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
-})
-
-test('intercepts an HTTP HEAD request', async () => {
-  const originalRequest = await createXMLHttpRequest((req) => {
-    req.open('HEAD', server.http.makeUrl('/user?id=123'))
-    req.setRequestHeader('x-custom-header', 'yes')
-  })
-  const capturedRequest = lookupRequest(originalRequest, 'HEAD', pool)!!
-
-  expect(capturedRequest).toBeTruthy()
-  expect(capturedRequest.url).toBeInstanceOf(URL)
-  expect(capturedRequest.url.toString()).toEqual(
-    server.http.makeUrl('/user?id=123')
-  )
-  expect(capturedRequest).toHaveProperty('method', 'HEAD')
-  expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
-  expect(capturedRequest.headers).toBeInstanceOf(Headers)
-  expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
-})
-
-test('intercepts an HTTPS GET request', async () => {
-  const originalRequest = await createXMLHttpRequest((req) => {
-    req.open('GET', server.https.makeUrl('/user?id=123'))
-    req.setRequestHeader('x-custom-header', 'yes')
-  })
-  const capturedRequest = lookupRequest(originalRequest, 'GET', pool)!
-
-  expect(capturedRequest).toBeTruthy()
-  expect(capturedRequest.url).toBeInstanceOf(URL)
-  expect(capturedRequest.url.toString()).toEqual(
-    server.https.makeUrl('/user?id=123')
-  )
-  expect(capturedRequest).toHaveProperty('method', 'GET')
-  expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
-  expect(capturedRequest.headers).toBeInstanceOf(Headers)
-  expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
-})
-
-test('intercepts an HTTPS POST request', async () => {
-  const originalRequest = await createXMLHttpRequest((req) => {
-    req.open('POST', server.https.makeUrl('/user?id=123'))
-    req.setRequestHeader('x-custom-header', 'yes')
-    req.send('request-body')
-  })
-  const capturedRequest = lookupRequest(originalRequest, 'POST', pool)!
-
-  expect(capturedRequest).toBeTruthy()
-  expect(capturedRequest.url).toBeInstanceOf(URL)
-  expect(capturedRequest.url.toString()).toEqual(
-    server.https.makeUrl('/user?id=123')
-  )
-  expect(capturedRequest).toHaveProperty('method', 'POST')
-  expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
-  expect(capturedRequest).toHaveProperty('body', 'request-body')
-  expect(capturedRequest.headers).toBeInstanceOf(Headers)
-  expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
-})
-
-test('intercepts an HTTPS PUT request', async () => {
-  const originalRequest = await createXMLHttpRequest((req) => {
-    req.open('PUT', server.https.makeUrl('/user?id=123'))
-    req.setRequestHeader('x-custom-header', 'yes')
-  })
-  const capturedRequest = lookupRequest(originalRequest, 'PUT', pool)!
-
-  expect(capturedRequest).toBeTruthy()
-  expect(capturedRequest.url).toBeInstanceOf(URL)
-  expect(capturedRequest.url.toString()).toEqual(
-    server.https.makeUrl('/user?id=123')
-  )
-  expect(capturedRequest).toHaveProperty('method', 'PUT')
-  expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
-  expect(capturedRequest.headers).toBeInstanceOf(Headers)
-  expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
-})
-
-test('intercepts an HTTPS DELETE request', async () => {
-  const originalRequest = await createXMLHttpRequest((req) => {
-    req.open('DELETE', server.https.makeUrl('/user?id=123'))
-    req.setRequestHeader('x-custom-header', 'yes')
-  })
-  const capturedRequest = lookupRequest(originalRequest, 'DELETE', pool)!
-
-  expect(capturedRequest).toBeTruthy()
-  expect(capturedRequest.url).toBeInstanceOf(URL)
-  expect(capturedRequest.url.toString()).toEqual(
-    server.https.makeUrl('/user?id=123')
-  )
-  expect(capturedRequest).toHaveProperty('method', 'DELETE')
-  expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
-  expect(capturedRequest.headers).toBeInstanceOf(Headers)
-  expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
-})
-
-test('intercepts an HTTPS PATCH request', async () => {
-  const originalRequest = await createXMLHttpRequest((req) => {
-    req.open('PATCH', server.https.makeUrl('/user?id=123'))
-    req.setRequestHeader('x-custom-header', 'yes')
-  })
-  const capturedRequest = lookupRequest(originalRequest, 'PATCH', pool)!
-
-  expect(capturedRequest).toBeTruthy()
-  expect(capturedRequest.url).toBeInstanceOf(URL)
-  expect(capturedRequest.url.toString()).toEqual(
-    server.https.makeUrl('/user?id=123')
-  )
-  expect(capturedRequest).toHaveProperty('method', 'PATCH')
+  expect(capturedRequest.url.href).toEqual(url)
   expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
   expect(capturedRequest.headers).toBeInstanceOf(Headers)
   expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
 })
 
 test('intercepts an HTTPS HEAD request', async () => {
+  const url = httpServer.https.makeUrl('/user?id=123')
   const originalRequest = await createXMLHttpRequest((req) => {
-    req.open('HEAD', server.https.makeUrl('/user?id=123'))
+    req.open('HEAD', url)
     req.setRequestHeader('x-custom-header', 'yes')
   })
-  const capturedRequest = lookupRequest(originalRequest, 'HEAD', pool)!
+  const capturedRequest = lookupRequest(originalRequest, 'HEAD', requests)!
 
-  expect(capturedRequest).toBeTruthy()
+  expect(capturedRequest.method).toEqual('HEAD')
   expect(capturedRequest.url).toBeInstanceOf(URL)
-  expect(capturedRequest.url.toString()).toEqual(
-    server.https.makeUrl('/user?id=123')
-  )
-  expect(capturedRequest).toHaveProperty('method', 'HEAD')
+  expect(capturedRequest.url.href).toEqual(url)
+  expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
+  expect(capturedRequest.headers).toBeInstanceOf(Headers)
+  expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
+})
+
+test('intercepts an HTTPS GET request', async () => {
+  const url = httpServer.https.makeUrl('/user?id=123')
+  const originalRequest = await createXMLHttpRequest((req) => {
+    req.open('GET', httpServer.https.makeUrl('/user?id=123'))
+    req.setRequestHeader('x-custom-header', 'yes')
+  })
+  const capturedRequest = lookupRequest(originalRequest, 'GET', requests)!
+
+  expect(capturedRequest.method).toEqual('GET')
+  expect(capturedRequest.url).toBeInstanceOf(URL)
+  expect(capturedRequest.url.href).toEqual(url)
+  expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
+  expect(capturedRequest.headers).toBeInstanceOf(Headers)
+  expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
+})
+
+test('intercepts an HTTPS POST request', async () => {
+  const url = httpServer.https.makeUrl('/user?id=123')
+  const originalRequest = await createXMLHttpRequest((req) => {
+    req.open('POST', url)
+    req.setRequestHeader('x-custom-header', 'yes')
+    req.send('post-payload')
+  })
+  const capturedRequest = lookupRequest(originalRequest, 'POST', requests)!
+
+  expect(capturedRequest.method).toEqual('POST')
+  expect(capturedRequest.url).toBeInstanceOf(URL)
+  expect(capturedRequest.url.href).toEqual(url)
+  expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
+  expect(capturedRequest.headers).toBeInstanceOf(Headers)
+  expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
+  expect(capturedRequest.body).toEqual('post-payload')
+})
+
+test('intercepts an HTTPS PUT request', async () => {
+  const url = httpServer.https.makeUrl('/user?id=123')
+  const originalRequest = await createXMLHttpRequest((req) => {
+    req.open('PUT', url)
+    req.setRequestHeader('x-custom-header', 'yes')
+    req.send('put-payload')
+  })
+  const capturedRequest = lookupRequest(originalRequest, 'PUT', requests)!
+
+  expect(capturedRequest.method).toEqual('PUT')
+  expect(capturedRequest.url).toBeInstanceOf(URL)
+  expect(capturedRequest.url.href).toEqual(url)
+  expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
+  expect(capturedRequest.headers).toBeInstanceOf(Headers)
+  expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
+  expect(capturedRequest.body).toEqual('put-payload')
+})
+
+test('intercepts an HTTPS PATCH request', async () => {
+  const url = httpServer.https.makeUrl('/user?id=123')
+  const originalRequest = await createXMLHttpRequest((req) => {
+    req.open('PATCH', url)
+    req.setRequestHeader('x-custom-header', 'yes')
+    req.send('patch-payload')
+  })
+  const capturedRequest = lookupRequest(originalRequest, 'PATCH', requests)!
+
+  expect(capturedRequest.method).toEqual('PATCH')
+  expect(capturedRequest.url).toBeInstanceOf(URL)
+  expect(capturedRequest.url.href).toEqual(url)
+  expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
+  expect(capturedRequest.headers).toBeInstanceOf(Headers)
+  expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')
+  expect(capturedRequest.body).toEqual('patch-payload')
+})
+
+test('intercepts an HTTPS DELETE request', async () => {
+  const url = httpServer.https.makeUrl('/user?id=123')
+  const originalRequest = await createXMLHttpRequest((req) => {
+    req.open('DELETE', url)
+    req.setRequestHeader('x-custom-header', 'yes')
+  })
+  const capturedRequest = lookupRequest(originalRequest, 'DELETE', requests)!
+
+  expect(capturedRequest.method).toEqual('DELETE')
+  expect(capturedRequest.url).toBeInstanceOf(URL)
+  expect(capturedRequest.url.href).toEqual(url)
   expect(capturedRequest.url.searchParams.get('id')).toEqual('123')
   expect(capturedRequest.headers).toBeInstanceOf(Headers)
   expect(capturedRequest.headers.get('x-custom-header')).toEqual('yes')

--- a/test/jest.node.config.js
+++ b/test/jest.node.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  testTimeout: 60000,
+  testTimeout: 30000,
   testRegex: '(?<!browser.*)(\\.test)\\.ts$',
   transform: {
     '^.+\\.ts$': 'ts-jest',


### PR DESCRIPTION
- Related to https://github.com/mswjs/msw/issues/950

## Changes

There are no changes, actually, only test refactoring. The library correctly calls `.end()` on `ClientRequest` when using `http.get`/`https.get`. 