### PR TITLE
fix(NodeClientRequest): clone "response" to allow reading its body twice

### DIFF
--- a/src/interceptors/ClientRequest/utils/cloneIncomingMessage.test.ts
+++ b/src/interceptors/ClientRequest/utils/cloneIncomingMessage.test.ts
@@ -1,6 +1,6 @@
 import { Socket } from 'net'
 import { IncomingMessage } from 'http'
-import { cloneIncomingMessage } from './cloneIncomingMessage'
+import { cloneIncomingMessage, IS_CLONE } from './cloneIncomingMessage'
 
 test('clones a given IncomingMessage', () => {
   const source = new IncomingMessage(new Socket())
@@ -12,6 +12,9 @@ test('clones a given IncomingMessage', () => {
   expect(clone.statusCode).toEqual(200)
   expect(clone.statusMessage).toEqual('OK')
   expect(clone.headers).toHaveProperty('x-powered-by', 'msw')
+
+  // Cloned IncomingMessage must be marked respectively.
+  expect(clone[IS_CLONE]).toEqual(true)
 
   expect(clone).toHaveProperty('_events')
 })

--- a/src/interceptors/ClientRequest/utils/cloneIncomingMessage.test.ts
+++ b/src/interceptors/ClientRequest/utils/cloneIncomingMessage.test.ts
@@ -1,0 +1,17 @@
+import { Socket } from 'net'
+import { IncomingMessage } from 'http'
+import { cloneIncomingMessage } from './cloneIncomingMessage'
+
+test('clones a given IncomingMessage', () => {
+  const source = new IncomingMessage(new Socket())
+  source.statusCode = 200
+  source.statusMessage = 'OK'
+  source.headers = { 'x-powered-by': 'msw' }
+  const clone = cloneIncomingMessage(source)
+
+  expect(clone.statusCode).toEqual(200)
+  expect(clone.statusMessage).toEqual('OK')
+  expect(clone.headers).toHaveProperty('x-powered-by', 'msw')
+
+  expect(clone).toHaveProperty('_events')
+})

--- a/src/interceptors/ClientRequest/utils/cloneIncomingMessage.ts
+++ b/src/interceptors/ClientRequest/utils/cloneIncomingMessage.ts
@@ -1,0 +1,37 @@
+import { IncomingMessage } from 'http'
+import { PassThrough } from 'stream'
+
+const IS_CLONE = Symbol('isClone')
+
+export function cloneIncomingMessage(
+  message: IncomingMessage
+): IncomingMessage {
+  const stream = message.pipe(new PassThrough())
+  const properties = [
+    ...Object.getOwnPropertyNames(message),
+    ...Object.getOwnPropertySymbols(message),
+  ] as Array<keyof IncomingMessage>
+
+  for (const propertyName of properties) {
+    if (stream.hasOwnProperty(propertyName)) {
+      continue
+    }
+
+    const propertyDescriptor = Object.getOwnPropertyDescriptor(
+      message,
+      propertyName
+    )
+
+    Object.defineProperty(stream, propertyName, {
+      ...propertyDescriptor,
+      value: message[propertyName],
+    })
+  }
+
+  Object.defineProperty(stream, IS_CLONE, {
+    enumerable: true,
+    value: true,
+  })
+
+  return stream as unknown as IncomingMessage
+}

--- a/src/interceptors/ClientRequest/utils/cloneIncomingMessage.ts
+++ b/src/interceptors/ClientRequest/utils/cloneIncomingMessage.ts
@@ -1,11 +1,15 @@
 import { IncomingMessage } from 'http'
 import { PassThrough } from 'stream'
 
-const IS_CLONE = Symbol('isClone')
+export const IS_CLONE = Symbol('isClone')
+
+export interface ClonedIncomingMessage extends IncomingMessage {
+  [IS_CLONE]: boolean
+}
 
 export function cloneIncomingMessage(
   message: IncomingMessage
-): IncomingMessage {
+): ClonedIncomingMessage {
   const stream = message.pipe(new PassThrough())
   const properties = [
     ...Object.getOwnPropertyNames(message),
@@ -33,5 +37,5 @@ export function cloneIncomingMessage(
     value: true,
   })
 
-  return stream as unknown as IncomingMessage
+  return stream as unknown as ClonedIncomingMessage
 }

--- a/src/interceptors/ClientRequest/utils/getIncomingMessageBody.test.ts
+++ b/src/interceptors/ClientRequest/utils/getIncomingMessageBody.test.ts
@@ -5,18 +5,18 @@ import { getIncomingMessageBody } from './getIncomingMessageBody'
 
 test('returns utf8 string given a utf8 response body', async () => {
   const utfBuffer = Buffer.from('one')
-  const message: IncomingMessage = new IncomingMessage(new Socket())
+  const message = new IncomingMessage(new Socket())
 
   const pendingResponseBody = getIncomingMessageBody(message)
   message.emit('data', utfBuffer)
   message.emit('end')
 
-  expect(pendingResponseBody).resolves.toEqual('one')
+  expect(await pendingResponseBody).toEqual('one')
 })
 
 test('returns utf8 string given a gzipped response body', async () => {
   const utfBuffer = zlib.gzipSync(Buffer.from('two'))
-  const message: IncomingMessage = new IncomingMessage(new Socket())
+  const message = new IncomingMessage(new Socket())
   message.headers = {
     'content-encoding': 'gzip',
   }
@@ -25,12 +25,12 @@ test('returns utf8 string given a gzipped response body', async () => {
   message.emit('data', utfBuffer)
   message.emit('end')
 
-  expect(pendingResponseBody).resolves.toEqual('two')
+  expect(await pendingResponseBody).toEqual('two')
 })
 
 test('returns utf8 string given a gzipped response body with incorrect "content-lenght"', async () => {
   const utfBuffer = zlib.gzipSync(Buffer.from('three'))
-  const message: IncomingMessage = new IncomingMessage(new Socket())
+  const message = new IncomingMessage(new Socket())
   message.headers = {
     'content-encoding': 'gzip',
     'content-length': '500',
@@ -40,5 +40,5 @@ test('returns utf8 string given a gzipped response body with incorrect "content-
   message.emit('data', utfBuffer)
   message.emit('end')
 
-  expect(pendingResponseBody).resolves.toEqual('three')
+  expect(await pendingResponseBody).toEqual('three')
 })

--- a/src/interceptors/ClientRequest/utils/getIncomingMessageBody.ts
+++ b/src/interceptors/ClientRequest/utils/getIncomingMessageBody.ts
@@ -1,28 +1,38 @@
+import { debug } from 'debug'
 import { IncomingMessage } from 'http'
-import { Stream } from 'stream'
+import { PassThrough } from 'stream'
 import * as zlib from 'zlib'
+
+const log = debug('http getIncomingMessageBody')
 
 export function getIncomingMessageBody(
   response: IncomingMessage
 ): Promise<string> {
-  let responseBody = ''
-  let stream: Stream = response
-
-  if (response.headers['content-encoding'] === 'gzip') {
-    stream = response.pipe(zlib.createGunzip())
-  }
-
   return new Promise((resolve, reject) => {
-    stream.once('error', (error) => {
-      stream.removeAllListeners()
-      reject(error)
+    log('cloning the original response...')
+
+    // Pipe the original response to support non-clone
+    // "response" input. No need to clone the response,
+    // as we always have access to the full "response" input,
+    // either a clone or an original one (in tests).
+    const responseClone = response.pipe(new PassThrough())
+    const stream =
+      response.headers['content-encoding'] === 'gzip'
+        ? responseClone.pipe(zlib.createGunzip())
+        : responseClone
+
+    const encoding = response.readableEncoding || 'utf8'
+    stream.setEncoding(encoding)
+    log('using encoding:', encoding)
+
+    stream.once('data', (responseBody) => {
+      log('response body read:', responseBody)
+      resolve(responseBody)
     })
 
-    stream.on('data', (chunk) => (responseBody += chunk))
-
-    stream.once('end', () => {
-      stream.removeAllListeners()
-      resolve(responseBody)
+    stream.once('error', (error) => {
+      log('error while reading response body:', error)
+      reject(error)
     })
   })
 }

--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
@@ -166,7 +166,7 @@ export function normalizeClientRequestArgs(
     log('normalized request options:', options)
 
     url = getUrlByRequestOptions(options)
-    log('created a URL from RequestOptions:', url)
+    log('created a URL from RequestOptions:', url.href)
 
     callback = resolveCallback(args)
   } else {
@@ -198,7 +198,7 @@ export function normalizeClientRequestArgs(
     log('resolved fallback agent:', agent)
   }
 
-  log('resolved url:', url)
+  log('successfully resolved url:', url.href)
   log('successfully resolved options:', options)
 
   return [url, options, callback]

--- a/test/events/response.node.test.ts
+++ b/test/events/response.node.test.ts
@@ -54,24 +54,59 @@ afterAll(async () => {
   await httpServer.close()
 })
 
-test('ClientRequest: emits the "response" event upon the mocked response', async () => {
-  await fetch(httpServer.https.makeUrl('/mocked'))
+test('fetch: emits the "response" event upon the mocked response', async () => {
+  const originalResponse = await fetch(httpServer.https.makeUrl('/mocked'))
 
   expect(responses).toHaveLength(1)
   const [request, response] = responses[0]
 
+  // Isomorphic request.
   expect(request).toHaveProperty('method', 'GET')
   expect(request.url).toBeInstanceOf(URL)
   expect(request.url.toString()).toBe(httpServer.https.makeUrl('/mocked'))
   expect(request).toHaveProperty('body', '')
 
+  // Isomorphic response.
   expect(response).toHaveProperty('status', 200)
   expect(response.headers.get('x-response-type')).toBe('mocked')
   expect(response).toHaveProperty('body', 'response-text')
+
+  // Original response.
+  expect(originalResponse.status).toEqual(200)
+  expect(originalResponse.statusText).toEqual('OK')
+  expect(originalResponse.headers.get('x-response-type')).toEqual('mocked')
+  expect(await originalResponse.text()).toEqual('response-text')
+})
+
+test('ClientRequest: emits the "response" event upon the mocked response', async () => {
+  const { res, resBody } = await httpsRequest(
+    httpServer.https.makeUrl('/mocked'),
+    { agent: httpsAgent }
+  )
+
+  expect(responses).toHaveLength(1)
+  const [request, response] = responses[0]
+
+  // Isomorphic request.
+  expect(request).toHaveProperty('method', 'GET')
+  expect(request.url).toBeInstanceOf(URL)
+  expect(request.url.toString()).toBe(httpServer.https.makeUrl('/mocked'))
+  expect(request).toHaveProperty('body', '')
+
+  // Isomorphic response.
+  expect(response).toHaveProperty('status', 200)
+  expect(response.headers.get('x-response-type')).toBe('mocked')
+  expect(response).toHaveProperty('body', 'response-text')
+
+  // Original response.
+  expect(res.statusCode).toEqual(200)
+  expect(res.statusMessage).toEqual(undefined)
+  expect(res.headers).toHaveProperty('x-response-type', 'mocked')
+  expect(resBody).toEqual('response-text')
 })
 
 test('ClientRequest: emits the "response" event upon the original response', async () => {
-  await httpsRequest(
+  const { res, resBody } = await httpsRequest(
     httpServer.https.makeUrl('/account'),
     {
       agent: httpsAgent,
@@ -87,15 +122,23 @@ test('ClientRequest: emits the "response" event upon the original response', asy
   expect(responses).toHaveLength(1)
   const [request, response] = responses[0]
 
-  expect(request).toHaveProperty('method', 'POST')
+  // Isomorphic request.
+  expect(request.method).toEqual('POST')
   expect(request.url).toBeInstanceOf(URL)
   expect(request.url.toString()).toBe(httpServer.https.makeUrl('/account'))
   expect(request.headers.get('content-type')).toBe('application/json')
   expect(request.headers.get('x-request-custom')).toBe('yes')
-  expect(request).toHaveProperty('body', `{"id":"abc-123"}`)
+  expect(request.body).toEqual(`{"id":"abc-123"}`)
 
-  expect(response).toHaveProperty('status', 200)
-  expect(response).toHaveProperty('statusText', 'OK')
+  // Isomorphic response.
+  expect(response.status).toEqual(200)
+  expect(response.statusText).toEqual('OK')
   expect(response.headers.get('x-response-type')).toBe('original')
-  expect(response).toHaveProperty('body', 'original-response-text')
+  expect(response.body).toEqual('original-response-text')
+
+  // Original response.
+  expect(res.statusCode).toEqual(200)
+  expect(res.statusMessage).toEqual('OK')
+  expect(res.headers).toHaveProperty('x-powered-by', 'Express')
+  expect(resBody).toEqual('original-response-text')
 })

--- a/test/jest.node.config.js
+++ b/test/jest.node.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  testTimeout: 30000,
+  testTimeout: 10000,
   testRegex: '(?<!browser.*)(\\.test)\\.ts$',
   transform: {
     '^.+\\.ts$': 'ts-jest',

--- a/test/regressions/http-incoming-message-clone.test.ts
+++ b/test/regressions/http-incoming-message-clone.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Ensure that reading the response body stream for the internal "response"
+ * event does not lock that stream for any further reading.
+ * @see https://github.com/mswjs/interceptors/issues/161
+ */
+import http, { IncomingMessage } from 'http'
+import { createServer, ServerApi } from '@open-draft/test-server'
+import {
+  createInterceptor,
+  IsomorphicRequest,
+  IsomorphicResponse,
+} from '../../src'
+import { interceptClientRequest } from '../../src/interceptors/ClientRequest'
+
+let requests: IsomorphicRequest[] = []
+let httpServer: ServerApi
+
+const interceptor = createInterceptor({
+  modules: [interceptClientRequest],
+  resolver(request) {
+    requests.push(request)
+  },
+})
+
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    app.get('/user', (req, res) => {
+      res.status(200).send('user-body')
+    })
+  })
+
+  interceptor.apply()
+})
+
+afterEach(() => {
+  requests = []
+})
+
+afterAll(async () => {
+  interceptor.restore()
+  await httpServer.close()
+})
+
+test('allows reading the response body after it has been read internally', async () => {
+  class RequestTransformer {
+    response: IncomingMessage
+
+    constructor(response: IncomingMessage) {
+      this.response = response
+    }
+
+    toText(): Promise<string> {
+      return new Promise<string>((resolve, reject) => {
+        let responseBody = ''
+        this.response.setEncoding('utf8')
+        this.response.on('data', (chunk) => (responseBody += chunk))
+        this.response.on('error', reject)
+        this.response.once('end', () => {
+          resolve(responseBody)
+        })
+      })
+    }
+  }
+
+  const makeRequest = (): Promise<RequestTransformer> => {
+    return new Promise((resolve, reject) => {
+      const request = http.get(httpServer.http.makeUrl('/user'))
+      request.on('response', (response) => {
+        resolve(new RequestTransformer(response))
+      })
+      request.on('error', reject)
+    })
+  }
+
+  const request = await makeRequest()
+  const capturedResponse = await new Promise<IsomorphicResponse>((resolve) => {
+    interceptor.on('response', (_, response) => resolve(response))
+  })
+
+  // Original response.
+  expect(request.response.statusCode).toEqual(200)
+  expect(request.response.statusMessage).toEqual('OK')
+  expect(request.response.headers).toHaveProperty('x-powered-by', 'Express')
+  const text = await request.toText()
+  expect(text).toEqual('user-body')
+
+  // Isomorphic response (callback).
+  expect(capturedResponse.status).toEqual(200)
+  expect(capturedResponse.statusText).toEqual('OK')
+  expect(capturedResponse.headers.get('x-powered-by')).toEqual('Express')
+  expect(capturedResponse.body).toEqual('user-body')
+})


### PR DESCRIPTION
- Fixes https://github.com/mswjs/msw/issues/941
- Fixes #161


## Changes

- Uses an internal `cloneIncomingMessage` function that pipes a given IncomingMessage to a `PassThrough` stream. It also copies all the message's properties and symbols to ensure an identical copy for whichever code may rely on it (piped stream does not have response properties like `statusCode` or `rawHeaders`).
- Fixes `getIncomingMessageBody` test so they won't silently swallow assertion failures.
- Adds a regression test to capture the Stripe use-case (see https://github.com/mswjs/msw/issues/941)