### PR TITLE
chore: use "httpServer" namespace consistently

### DIFF
--- a/test/compliance/XMLHttpRequest/events-order.test.ts
+++ b/test/compliance/XMLHttpRequest/events-order.test.ts
@@ -8,7 +8,7 @@ import { createXMLHttpRequest } from '../../helpers'
 
 type EventPool = [string, number][]
 
-let server: ServerApi
+let httpServer: ServerApi
 const interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
   resolver(request) {
@@ -44,7 +44,7 @@ function spyOnEvents(request: XMLHttpRequest, pool: EventPool) {
 }
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.get('/', (req, res) => {
       res.status(200).end()
     })
@@ -59,14 +59,14 @@ afterEach(() => {
 })
 
 afterAll(async () => {
-  await server.close()
+  await httpServer.close()
 })
 
 test('emits correct events sequence for an unhandled request with no response body', async () => {
   interceptor.apply()
   const mockEvents: EventPool = []
   const request = await createXMLHttpRequest((request) => {
-    request.open('GET', server.http.makeUrl())
+    request.open('GET', httpServer.http.makeUrl())
     spyOnEvents(request, mockEvents)
   })
 
@@ -90,7 +90,7 @@ test('emits correct events sequence for a handled request with no response body'
   interceptor.apply()
   const mockEvents: EventPool = []
   const request = await createXMLHttpRequest((request) => {
-    request.open('GET', server.http.makeUrl('/user'))
+    request.open('GET', httpServer.http.makeUrl('/user'))
     spyOnEvents(request, mockEvents)
   })
 
@@ -108,7 +108,7 @@ test('emits correct events sequence for an unhandled request with a response bod
   interceptor.apply()
   const mockEvents: EventPool = []
   const request = await createXMLHttpRequest((request) => {
-    request.open('GET', server.http.makeUrl('/numbers'))
+    request.open('GET', httpServer.http.makeUrl('/numbers'))
     spyOnEvents(request, mockEvents)
   })
 
@@ -132,7 +132,7 @@ test('emits correct events sequence for a handled request with a response body',
   interceptor.apply()
   const mockEvents: EventPool = []
   const request = await createXMLHttpRequest((request) => {
-    request.open('GET', server.http.makeUrl('/numbers-mock'))
+    request.open('GET', httpServer.http.makeUrl('/numbers-mock'))
     spyOnEvents(request, mockEvents)
   })
 

--- a/test/compliance/XMLHttpRequest/request-headers.test.ts
+++ b/test/compliance/XMLHttpRequest/request-headers.test.ts
@@ -6,7 +6,7 @@ import { createInterceptor } from '../../../src'
 import { interceptXMLHttpRequest } from '../../../src/interceptors/XMLHttpRequest'
 import { createXMLHttpRequest } from '../../helpers'
 
-let server: ServerApi
+let httpServer: ServerApi
 let rawRequestHeaders: string[]
 
 const interceptor = createInterceptor({
@@ -19,7 +19,7 @@ beforeAll(async () => {
 
   // Handle the request in an actual server
   // to inspect the raw request headers.
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.get('/', (req, res) => {
       rawRequestHeaders = req.rawHeaders
       res.status(200).end()
@@ -29,12 +29,12 @@ beforeAll(async () => {
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
 })
 
 test('request headers casing', async () => {
   await createXMLHttpRequest((req) => {
-    req.open('GET', server.http.makeUrl('/'))
+    req.open('GET', httpServer.http.makeUrl('/'))
     req.setRequestHeader('X-Custom-Token', 'abc-123')
   })
 

--- a/test/events/request.test.ts
+++ b/test/events/request.test.ts
@@ -9,7 +9,7 @@ import { interceptClientRequest } from '../../src/interceptors/ClientRequest'
 import { createXMLHttpRequest, httpRequest } from '../helpers'
 
 let requests: IsomorphicRequest[] = []
-let server: ServerApi
+let httpServer: ServerApi
 const interceptor = createInterceptor({
   modules: [interceptClientRequest, interceptXMLHttpRequest],
   resolver() {},
@@ -20,7 +20,7 @@ interceptor.on('request', (request) => {
 })
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.post('/user', (req, res) => {
       res.status(201).end()
     })
@@ -35,12 +35,12 @@ afterEach(() => {
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
 })
 
 it('ClientRequest: emits the "request" event upon the request', (done) => {
   const request = http.request(
-    server.http.makeUrl('/user'),
+    httpServer.http.makeUrl('/user'),
     {
       method: 'POST',
       headers: {
@@ -52,7 +52,7 @@ it('ClientRequest: emits the "request" event upon the request', (done) => {
       const [request] = requests
 
       expect(request.method).toEqual('POST')
-      expect(request.url.href).toEqual(server.http.makeUrl('/user'))
+      expect(request.url.href).toEqual(httpServer.http.makeUrl('/user'))
       expect(request.headers.get('content-type')).toEqual('application/json')
       expect(request.body).toEqual(JSON.stringify({ userId: 'abc-123' }))
       done()
@@ -64,7 +64,7 @@ it('ClientRequest: emits the "request" event upon the request', (done) => {
 
 it('XMLHttpRequest: emits the "request" event upon the request', async () => {
   await createXMLHttpRequest((request) => {
-    request.open('POST', server.http.makeUrl('/user'))
+    request.open('POST', httpServer.http.makeUrl('/user'))
     request.setRequestHeader('Content-Type', 'application/json')
     request.send(JSON.stringify({ userId: 'abc-123' }))
   })
@@ -79,7 +79,7 @@ it('XMLHttpRequest: emits the "request" event upon the request', async () => {
 
   const [request] = requests
   expect(request.method).toEqual('POST')
-  expect(request.url.href).toEqual(server.http.makeUrl('/user'))
+  expect(request.url.href).toEqual(httpServer.http.makeUrl('/user'))
   expect(request.headers.get('content-type')).toEqual('application/json')
   expect(request.body).toEqual(
     JSON.stringify({

--- a/test/integrations/got.test.ts
+++ b/test/integrations/got.test.ts
@@ -6,11 +6,11 @@ import { ServerApi, createServer } from '@open-draft/test-server'
 import { createInterceptor } from '../../src'
 import { interceptClientRequest } from '../../src/interceptors/ClientRequest'
 
-let server: ServerApi
+let httpServer: ServerApi
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
   resolver(request) {
-    if (request.url.toString() === server.http.makeUrl('/test')) {
+    if (request.url.toString() === httpServer.http.makeUrl('/test')) {
       return {
         status: 200,
         body: 'mocked-body',
@@ -20,7 +20,7 @@ const interceptor = createInterceptor({
 })
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.get('/user', (req, res) => {
       return res.status(200).json({ id: 1 })
     })
@@ -31,18 +31,18 @@ beforeAll(async () => {
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
 })
 
 test('mocks response to a request made with "got"', async () => {
-  const res = await got(server.http.makeUrl('/test'))
+  const res = await got(httpServer.http.makeUrl('/test'))
 
   expect(res.statusCode).toBe(200)
   expect(res.body).toBe('mocked-body')
 })
 
 test('bypasses an unhandled request made with "got"', async () => {
-  const res = await got(server.http.makeUrl('/user'))
+  const res = await got(httpServer.http.makeUrl('/user'))
 
   expect(res.statusCode).toBe(200)
   expect(res.body).toEqual(`{"id":1}`)

--- a/test/intercept/fetch/fetch.test.ts
+++ b/test/intercept/fetch/fetch.test.ts
@@ -16,7 +16,7 @@ async function prepareFetch(
 }
 
 let pool: IsomorphicRequest[] = []
-let server: ServerApi
+let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: nodeInterceptors,
@@ -26,7 +26,7 @@ const interceptor = createInterceptor({
 })
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     const handleUserRequest: RequestHandler = (req, res) => {
       res.status(200).send('user-body').end()
     }
@@ -48,12 +48,12 @@ afterEach(() => {
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
 })
 
 test('intercepts an HTTP GET request', async () => {
   const request = await prepareFetch(
-    fetch(server.http.makeUrl('/user?id=123'), {
+    fetch(httpServer.http.makeUrl('/user?id=123'), {
       headers: {
         'x-custom-header': 'yes',
       },
@@ -63,7 +63,9 @@ test('intercepts an HTTP GET request', async () => {
 
   expect(request).toBeTruthy()
   expect(request.url).toBeInstanceOf(URL)
-  expect(request.url.toString()).toEqual(server.http.makeUrl('/user?id=123'))
+  expect(request.url.toString()).toEqual(
+    httpServer.http.makeUrl('/user?id=123')
+  )
   expect(request).toHaveProperty('method', 'GET')
   expect(request.url.searchParams.get('id')).toEqual('123')
   expect(request.headers.get('accept')).toEqual('*/*')
@@ -72,7 +74,7 @@ test('intercepts an HTTP GET request', async () => {
 
 test('intercepts an HTTP POST request', async () => {
   const request = await prepareFetch(
-    fetch(server.http.makeUrl('/user?id=123'), {
+    fetch(httpServer.http.makeUrl('/user?id=123'), {
       method: 'POST',
       headers: {
         'x-custom-header': 'yes',
@@ -84,7 +86,9 @@ test('intercepts an HTTP POST request', async () => {
 
   expect(request).toBeTruthy()
   expect(request.url).toBeInstanceOf(URL)
-  expect(request.url.toString()).toEqual(server.http.makeUrl('/user?id=123'))
+  expect(request.url.toString()).toEqual(
+    httpServer.http.makeUrl('/user?id=123')
+  )
   expect(request).toHaveProperty('method', 'POST')
   expect(request.headers.get('accept')).toEqual('*/*')
   expect(request.headers.get('x-custom-header')).toEqual('yes')
@@ -94,7 +98,7 @@ test('intercepts an HTTP POST request', async () => {
 
 test('intercepts an HTTP PUT request', async () => {
   const request = await prepareFetch(
-    fetch(server.http.makeUrl('/user?id=123'), {
+    fetch(httpServer.http.makeUrl('/user?id=123'), {
       method: 'PUT',
       headers: {
         'x-custom-header': 'yes',
@@ -105,7 +109,9 @@ test('intercepts an HTTP PUT request', async () => {
 
   expect(request).toBeTruthy()
   expect(request.url).toBeInstanceOf(URL)
-  expect(request.url.toString()).toEqual(server.http.makeUrl('/user?id=123'))
+  expect(request.url.toString()).toEqual(
+    httpServer.http.makeUrl('/user?id=123')
+  )
   expect(request).toHaveProperty('method', 'PUT')
   expect(request.headers.get('accept')).toEqual('*/*')
   expect(request.headers.get('x-custom-header')).toEqual('yes')
@@ -114,7 +120,7 @@ test('intercepts an HTTP PUT request', async () => {
 
 test('intercepts an HTTP DELETE request', async () => {
   const request = await prepareFetch(
-    fetch(server.http.makeUrl('/user?id=123'), {
+    fetch(httpServer.http.makeUrl('/user?id=123'), {
       method: 'DELETE',
       headers: {
         'x-custom-header': 'yes',
@@ -125,7 +131,9 @@ test('intercepts an HTTP DELETE request', async () => {
 
   expect(request).toBeTruthy()
   expect(request.url).toBeInstanceOf(URL)
-  expect(request.url.toString()).toEqual(server.http.makeUrl('/user?id=123'))
+  expect(request.url.toString()).toEqual(
+    httpServer.http.makeUrl('/user?id=123')
+  )
   expect(request).toHaveProperty('method', 'DELETE')
   expect(request.headers.get('accept')).toEqual('*/*')
   expect(request.headers.get('x-custom-header')).toEqual('yes')
@@ -134,7 +142,7 @@ test('intercepts an HTTP DELETE request', async () => {
 
 test('intercepts an HTTP PATCH request', async () => {
   const request = await prepareFetch(
-    fetch(server.http.makeUrl('/user?id=123'), {
+    fetch(httpServer.http.makeUrl('/user?id=123'), {
       method: 'PATCH',
       headers: {
         'x-custom-header': 'yes',
@@ -145,7 +153,9 @@ test('intercepts an HTTP PATCH request', async () => {
 
   expect(request).toBeTruthy()
   expect(request.url).toBeInstanceOf(URL)
-  expect(request.url.toString()).toEqual(server.http.makeUrl('/user?id=123'))
+  expect(request.url.toString()).toEqual(
+    httpServer.http.makeUrl('/user?id=123')
+  )
   expect(request).toHaveProperty('method', 'PATCH')
   expect(request.headers.get('accept')).toEqual('*/*')
   expect(request.headers.get('x-custom-header')).toEqual('yes')
@@ -154,7 +164,7 @@ test('intercepts an HTTP PATCH request', async () => {
 
 test('intercepts an HTTP HEAD request', async () => {
   const request = await prepareFetch(
-    fetch(server.http.makeUrl('/user?id=123'), {
+    fetch(httpServer.http.makeUrl('/user?id=123'), {
       method: 'HEAD',
       headers: {
         'x-custom-header': 'yes',
@@ -165,7 +175,9 @@ test('intercepts an HTTP HEAD request', async () => {
 
   expect(request).toBeTruthy()
   expect(request.url).toBeInstanceOf(URL)
-  expect(request.url.toString()).toEqual(server.http.makeUrl('/user?id=123'))
+  expect(request.url.toString()).toEqual(
+    httpServer.http.makeUrl('/user?id=123')
+  )
   expect(request).toHaveProperty('method', 'HEAD')
   expect(request.headers.get('accept')).toEqual('*/*')
   expect(request.headers.get('x-custom-header')).toEqual('yes')
@@ -174,7 +186,7 @@ test('intercepts an HTTP HEAD request', async () => {
 
 test('intercepts an HTTPS GET request', async () => {
   const request = await prepareFetch(
-    fetch(server.https.makeUrl('/user?id=123'), {
+    fetch(httpServer.https.makeUrl('/user?id=123'), {
       headers: {
         'x-custom-header': 'yes',
       },
@@ -185,7 +197,9 @@ test('intercepts an HTTPS GET request', async () => {
 
   expect(request).toBeTruthy()
   expect(request.url).toBeInstanceOf(URL)
-  expect(request.url.toString()).toEqual(server.https.makeUrl('/user?id=123'))
+  expect(request.url.toString()).toEqual(
+    httpServer.https.makeUrl('/user?id=123')
+  )
   expect(request).toHaveProperty('method', 'GET')
   expect(request.headers.get('accept')).toEqual('*/*')
   expect(request.headers.get('x-custom-header')).toEqual('yes')
@@ -194,7 +208,7 @@ test('intercepts an HTTPS GET request', async () => {
 
 test('intercepts an HTTPS POST request', async () => {
   const request = await prepareFetch(
-    fetch(server.https.makeUrl('/user?id=123'), {
+    fetch(httpServer.https.makeUrl('/user?id=123'), {
       method: 'POST',
       headers: {
         'x-custom-header': 'yes',
@@ -207,7 +221,9 @@ test('intercepts an HTTPS POST request', async () => {
 
   expect(request).toBeTruthy()
   expect(request.url).toBeInstanceOf(URL)
-  expect(request.url.toString()).toEqual(server.https.makeUrl('/user?id=123'))
+  expect(request.url.toString()).toEqual(
+    httpServer.https.makeUrl('/user?id=123')
+  )
   expect(request).toHaveProperty('method', 'POST')
   expect(request.headers.get('accept')).toEqual('*/*')
   expect(request.headers.get('x-custom-header')).toEqual('yes')
@@ -217,7 +233,7 @@ test('intercepts an HTTPS POST request', async () => {
 
 test('intercepts an HTTPS PUT request', async () => {
   const request = await prepareFetch(
-    fetch(server.https.makeUrl('/user?id=123'), {
+    fetch(httpServer.https.makeUrl('/user?id=123'), {
       method: 'PUT',
       headers: {
         'x-custom-header': 'yes',
@@ -229,7 +245,9 @@ test('intercepts an HTTPS PUT request', async () => {
 
   expect(request).toBeTruthy()
   expect(request.url).toBeInstanceOf(URL)
-  expect(request.url.toString()).toEqual(server.https.makeUrl('/user?id=123'))
+  expect(request.url.toString()).toEqual(
+    httpServer.https.makeUrl('/user?id=123')
+  )
   expect(request).toHaveProperty('method', 'PUT')
   expect(request.headers.get('accept')).toEqual('*/*')
   expect(request.headers.get('x-custom-header')).toEqual('yes')
@@ -238,7 +256,7 @@ test('intercepts an HTTPS PUT request', async () => {
 
 test('intercepts an HTTPS DELETE request', async () => {
   const request = await prepareFetch(
-    fetch(server.https.makeUrl('/user?id=123'), {
+    fetch(httpServer.https.makeUrl('/user?id=123'), {
       method: 'DELETE',
       headers: {
         'x-custom-header': 'yes',
@@ -250,7 +268,9 @@ test('intercepts an HTTPS DELETE request', async () => {
 
   expect(request).toBeTruthy()
   expect(request.url).toBeInstanceOf(URL)
-  expect(request.url.toString()).toEqual(server.https.makeUrl('/user?id=123'))
+  expect(request.url.toString()).toEqual(
+    httpServer.https.makeUrl('/user?id=123')
+  )
   expect(request).toHaveProperty('method', 'DELETE')
   expect(request.headers.get('accept')).toEqual('*/*')
   expect(request.headers.get('x-custom-header')).toEqual('yes')
@@ -259,7 +279,7 @@ test('intercepts an HTTPS DELETE request', async () => {
 
 test('intercepts an HTTPS PATCH request', async () => {
   const request = await prepareFetch(
-    fetch(server.https.makeUrl('/user?id=123'), {
+    fetch(httpServer.https.makeUrl('/user?id=123'), {
       method: 'PATCH',
       headers: {
         'x-custom-header': 'yes',
@@ -271,7 +291,9 @@ test('intercepts an HTTPS PATCH request', async () => {
 
   expect(request).toBeTruthy()
   expect(request.url).toBeInstanceOf(URL)
-  expect(request.url.toString()).toEqual(server.https.makeUrl('/user?id=123'))
+  expect(request.url.toString()).toEqual(
+    httpServer.https.makeUrl('/user?id=123')
+  )
   expect(request).toHaveProperty('method', 'PATCH')
   expect(request.headers.get('accept')).toEqual('*/*')
   expect(request.headers.get('x-custom-header')).toEqual('yes')
@@ -280,7 +302,7 @@ test('intercepts an HTTPS PATCH request', async () => {
 
 test('intercepts an HTTPS HEAD request', async () => {
   const request = await prepareFetch(
-    fetch(server.https.makeUrl('/user?id=123'), {
+    fetch(httpServer.https.makeUrl('/user?id=123'), {
       method: 'HEAD',
       headers: {
         'x-custom-header': 'yes',
@@ -292,7 +314,9 @@ test('intercepts an HTTPS HEAD request', async () => {
 
   expect(request).toBeTruthy()
   expect(request.url).toBeInstanceOf(URL)
-  expect(request.url.toString()).toEqual(server.https.makeUrl('/user?id=123'))
+  expect(request.url.toString()).toEqual(
+    httpServer.https.makeUrl('/user?id=123')
+  )
   expect(request).toHaveProperty('method', 'HEAD')
   expect(request.headers.get('accept')).toEqual('*/*')
   expect(request.headers.get('x-custom-header')).toEqual('yes')
@@ -300,6 +324,9 @@ test('intercepts an HTTPS HEAD request', async () => {
 })
 
 test('always sets "credentials" to "omit" when using "fetch" polyfills (node-fetch)', async () => {
-  const request = await prepareFetch(fetch(server.http.makeUrl('/user')), pool)
+  const request = await prepareFetch(
+    fetch(httpServer.http.makeUrl('/user')),
+    pool
+  )
   expect(request.credentials).toEqual('omit')
 })

--- a/test/regressions/http-post-body.test.ts
+++ b/test/regressions/http-post-body.test.ts
@@ -10,7 +10,7 @@ import { getRequestOptionsByUrl } from '../../src/utils/getRequestOptionsByUrl'
 import { IsomorphicRequest } from '../../src/createInterceptor'
 
 let pool: IsomorphicRequest[] = []
-let server: ServerApi
+let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
@@ -21,7 +21,7 @@ const interceptor = createInterceptor({
 })
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.post('/user', (req, res) => {
       req.pipe(res)
     })
@@ -36,7 +36,7 @@ afterEach(() => {
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
 })
 
 test('supports original HTTPS request with a body written via "req.write()"', (done) => {
@@ -44,7 +44,7 @@ test('supports original HTTPS request with a body written via "req.write()"', (d
 
   const req = https.request(
     {
-      ...getRequestOptionsByUrl(new URL(server.https.makeUrl('/user'))),
+      ...getRequestOptionsByUrl(new URL(httpServer.https.makeUrl('/user'))),
       method: 'POST',
       agent: httpsAgent,
     },
@@ -74,7 +74,7 @@ test('supports original HTTPS request with a body given to "req.end()"', (done) 
 
   const req = https.request(
     {
-      ...getRequestOptionsByUrl(new URL(server.https.makeUrl('/user'))),
+      ...getRequestOptionsByUrl(new URL(httpServer.https.makeUrl('/user'))),
       method: 'POST',
       agent: httpsAgent,
     },
@@ -99,7 +99,7 @@ test('supports original HTTPS request with a body written via both "req.write()"
 
   const req = https.request(
     {
-      ...getRequestOptionsByUrl(new URL(server.https.makeUrl('/user'))),
+      ...getRequestOptionsByUrl(new URL(httpServer.https.makeUrl('/user'))),
       method: 'POST',
       agent: httpsAgent,
     },

--- a/test/regressions/http-timeout.ts
+++ b/test/regressions/http-timeout.ts
@@ -21,10 +21,10 @@ const interceptor = createInterceptor({
   },
 })
 
-let server: ServerApi
+let httpServer: ServerApi
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.get('/resource', (req, res) => {
       res.status(500).send('must-not-reach-server')
     })
@@ -35,11 +35,11 @@ beforeAll(async () => {
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
 })
 
 it('supports custom socket timeout on the HTTP request', (done) => {
-  const req = http.request(server.http.makeUrl('/resource'), (res) => {
+  const req = http.request(httpServer.http.makeUrl('/resource'), (res) => {
     res.on('data', () => null)
     res.on('end', () => {
       expect(res.statusCode).toEqual(301)

--- a/test/regressions/https-original-url.test.ts
+++ b/test/regressions/https-original-url.test.ts
@@ -9,7 +9,7 @@ import { createInterceptor } from '../../src'
 import { interceptClientRequest } from '../../src/interceptors/ClientRequest'
 import { getIncomingMessageBody } from '../../src/interceptors/ClientRequest/utils/getIncomingMessageBody'
 
-let server: ServerApi
+let httpServer: ServerApi
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
   resolver() {
@@ -18,7 +18,7 @@ const interceptor = createInterceptor({
 })
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.get('/resource', (req, res) => {
       res.status(200).send('hello')
     })
@@ -29,13 +29,13 @@ beforeAll(async () => {
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
 })
 
 it('performs the original https request', (done) => {
   https
     .request(
-      new URL(server.https.makeUrl('/resource')),
+      new URL(httpServer.https.makeUrl('/resource')),
       {
         method: 'GET',
         agent: httpsAgent,

--- a/test/regressions/xhr-propagate-headers.test.ts
+++ b/test/regressions/xhr-propagate-headers.test.ts
@@ -6,7 +6,7 @@ import { createInterceptor } from '../../src'
 import { createXMLHttpRequest } from '../helpers'
 import { interceptXMLHttpRequest } from '../../src/interceptors/XMLHttpRequest'
 
-let server: ServerApi
+let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
@@ -14,7 +14,7 @@ const interceptor = createInterceptor({
 })
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.get('/account', (req, res) => {
       return res
         .status(200)
@@ -34,12 +34,12 @@ beforeAll(async () => {
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
 })
 
 test('forward the request headers to the server', async () => {
   const req = await createXMLHttpRequest((req) => {
-    req.open('GET', server.http.makeUrl('/account'))
+    req.open('GET', httpServer.http.makeUrl('/account'))
     req.setRequestHeader('x-client-header', 'yes')
     req.setRequestHeader('x-multi-values', 'value1; value2')
   })

--- a/test/regressions/xhr-response-header-case-sensitivity.test.ts
+++ b/test/regressions/xhr-response-header-case-sensitivity.test.ts
@@ -6,7 +6,7 @@ import { createInterceptor } from '../../src'
 import { createXMLHttpRequest } from '../helpers'
 import { interceptXMLHttpRequest } from '../../src/interceptors/XMLHttpRequest'
 
-let server: ServerApi
+let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
@@ -14,7 +14,7 @@ const interceptor = createInterceptor({
 })
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.get('/account', (req, res) => {
       return res
         .status(200)
@@ -29,12 +29,12 @@ beforeAll(async () => {
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
 })
 
 test('getResponseHeader is case insensitive', async () => {
   const request = await createXMLHttpRequest((request) => {
-    request.open('GET', server.http.makeUrl('/account'))
+    request.open('GET', httpServer.http.makeUrl('/account'))
     request.setRequestHeader('x-request-header', 'test-value')
   })
 

--- a/test/response/axios.test.ts
+++ b/test/response/axios.test.ts
@@ -6,7 +6,7 @@ import { ServerApi, createServer } from '@open-draft/test-server'
 import { createInterceptor } from '../../src'
 import nodeInterceptors from '../../src/presets/node'
 
-let server: ServerApi
+let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: nodeInterceptors,
@@ -27,7 +27,7 @@ const interceptor = createInterceptor({
 })
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.get('/books', (req, res) => {
       res.status(200).json([
         {
@@ -46,7 +46,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
 })
 
 test('responds with a mocked response to an "axios()" request', async () => {
@@ -74,7 +74,7 @@ test('responds with a mocked response to an "axios.post()" request', async () =>
 })
 
 test('bypass the interceptor and return the original response', async () => {
-  const res = await axios.get(server.http.makeUrl('/books'))
+  const res = await axios.get(httpServer.http.makeUrl('/books'))
 
   expect(res.status).toEqual(200)
   expect(res.data).toEqual([

--- a/test/response/fetch.browser.test.ts
+++ b/test/response/fetch.browser.test.ts
@@ -22,7 +22,7 @@ interface SerializedResponse {
   json?: Record<string, any>
 }
 
-let server: ServerApi
+let httpServer: ServerApi
 
 async function prepareRuntime() {
   const context = await pageWith({
@@ -31,17 +31,17 @@ async function prepareRuntime() {
 
   await context.page.evaluate((httpUrl) => {
     window.serverHttpUrl = httpUrl
-  }, server.http.makeUrl('/'))
+  }, httpServer.http.makeUrl('/'))
 
   await context.page.evaluate((httpsUrl) => {
     window.serverHttpsUrl = httpsUrl
-  }, server.https.makeUrl('/'))
+  }, httpServer.https.makeUrl('/'))
 
   return context
 }
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.get('/', (req, res) => {
       res.status(200).json({ route: '/' }).end()
     })
@@ -52,7 +52,7 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
-  await server.close()
+  await httpServer.close()
 })
 
 describe('HTTP', () => {
@@ -71,7 +71,7 @@ describe('HTTP', () => {
           json,
         }))
       })
-    }, server.http.makeUrl('/'))
+    }, httpServer.http.makeUrl('/'))
     const headers = listToHeaders(response.headers)
 
     expect(response.type).toBe('default')
@@ -99,7 +99,7 @@ describe('HTTP', () => {
           ),
         }
       })
-    }, server.http.makeUrl('/get'))
+    }, httpServer.http.makeUrl('/get'))
     const headers = listToHeaders(response.headers)
 
     expect(response.type).toBe('cors')
@@ -130,7 +130,7 @@ describe('HTTPS', () => {
           json,
         }))
       })
-    }, server.https.makeUrl('/'))
+    }, httpServer.https.makeUrl('/'))
     const headers = listToHeaders(response.headers)
 
     expect(response.type).toBe('default')
@@ -158,7 +158,7 @@ describe('HTTPS', () => {
           ),
         }
       })
-    }, server.https.makeUrl('/get'))
+    }, httpServer.https.makeUrl('/get'))
     const headers = listToHeaders(response.headers)
 
     expect(response.type).toBe('cors')
@@ -191,7 +191,7 @@ test('bypasses any request when the interceptor is restored', async () => {
         }
       })
     },
-    server.http.makeUrl('/')
+    httpServer.http.makeUrl('/')
   )
 
   expect(httpResponse.type).toBe('cors')
@@ -211,7 +211,7 @@ test('bypasses any request when the interceptor is restored', async () => {
         }
       })
     },
-    server.http.makeUrl('/get')
+    httpServer.http.makeUrl('/get')
   )
 
   expect(httpsResponse.type).toBe('cors')

--- a/test/response/http.test.ts
+++ b/test/response/http.test.ts
@@ -6,7 +6,7 @@ import { createInterceptor } from '../../src'
 import { httpGet, httpRequest } from '../helpers'
 import { interceptClientRequest } from '../../src/interceptors/ClientRequest'
 
-let server: ServerApi
+let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
@@ -29,7 +29,7 @@ const interceptor = createInterceptor({
 })
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.get('/', (req, res) => {
       res.status(200).send('/')
     })
@@ -43,7 +43,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
 })
 
 test('responds to an HTTP request issued by "http.request" and handled in the middleware', async () => {
@@ -56,7 +56,7 @@ test('responds to an HTTP request issued by "http.request" and handled in the mi
 })
 
 test('bypasses an HTTP request issued by "http.request" not handled in the middleware', async () => {
-  const { res, resBody } = await httpRequest(server.http.makeUrl('/get'))
+  const { res, resBody } = await httpRequest(httpServer.http.makeUrl('/get'))
 
   expect(res.statusCode).toBe(200)
   expect(resBody).toEqual('/get')
@@ -72,7 +72,7 @@ test('responds to an HTTP request issued by "http.get" and handled in the middle
 })
 
 test('bypasses an HTTP request issued by "http.get" not handled in the middleware', async () => {
-  const { res, resBody } = await httpGet(server.http.makeUrl('/get'))
+  const { res, resBody } = await httpGet(httpServer.http.makeUrl('/get'))
 
   expect(res.statusCode).toBe(200)
   expect(resBody).toEqual('/get')
@@ -85,7 +85,7 @@ test('produces a request error when the middleware throws an exception', async (
 
 test('bypasses any request when the interceptor is restored', async () => {
   interceptor.restore()
-  const { res, resBody } = await httpGet(server.http.makeUrl('/'))
+  const { res, resBody } = await httpGet(httpServer.http.makeUrl('/'))
 
   expect(res.statusCode).toBe(200)
   expect(resBody).toEqual('/')

--- a/test/response/https-callback.test.ts
+++ b/test/response/https-callback.test.ts
@@ -8,12 +8,12 @@ import { createInterceptor } from '../../src'
 import { interceptClientRequest } from '../../src/interceptors/ClientRequest'
 import { getRequestOptionsByUrl } from '../../src/utils/getRequestOptionsByUrl'
 
-let server: ServerApi
+let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
   resolver(request) {
-    if ([server.https.makeUrl('/get')].includes(request.url.href)) {
+    if ([httpServer.https.makeUrl('/get')].includes(request.url.href)) {
       return
     }
 
@@ -26,7 +26,7 @@ const interceptor = createInterceptor({
 })
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.get('/get', (req, res) => {
       res.status(200).send('/').end()
     })
@@ -41,7 +41,7 @@ afterEach(() => {
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
 })
 
 test('calls a custom callback once when the request is bypassed', (done) => {
@@ -61,7 +61,7 @@ test('calls a custom callback once when the request is bypassed', (done) => {
 
   https.get(
     {
-      ...getRequestOptionsByUrl(new URL(server.https.makeUrl('/get'))),
+      ...getRequestOptionsByUrl(new URL(httpServer.https.makeUrl('/get'))),
       agent: httpsAgent,
     },
     responseCallback
@@ -85,7 +85,9 @@ test('calls a custom callback once when the response is mocked', (done) => {
 
   https.get(
     {
-      ...getRequestOptionsByUrl(new URL(server.https.makeUrl('/arbitrary'))),
+      ...getRequestOptionsByUrl(
+        new URL(httpServer.https.makeUrl('/arbitrary'))
+      ),
       agent: httpsAgent,
     },
     responseCallback

--- a/test/response/https.test.ts
+++ b/test/response/https.test.ts
@@ -6,7 +6,7 @@ import { createInterceptor } from '../../src'
 import { httpsGet, httpsRequest } from '../helpers'
 import { interceptClientRequest } from '../../src/interceptors/ClientRequest'
 
-let server: ServerApi
+let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
@@ -29,7 +29,7 @@ const interceptor = createInterceptor({
 })
 
 beforeAll(async () => {
-  server = await createServer((app) => {
+  httpServer = await createServer((app) => {
     app.get('/', (req, res) => {
       res.status(200).send('/').end()
     })
@@ -43,7 +43,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   interceptor.restore()
-  await server.close()
+  await httpServer.close()
 })
 
 test('responds to an HTTPS request issued by "https.request" and handled in the middleware', async () => {
@@ -56,9 +56,12 @@ test('responds to an HTTPS request issued by "https.request" and handled in the 
 })
 
 test('bypasses an HTTPS request issued by "https.request" not handled in the middleware', async () => {
-  const { res, resBody } = await httpsRequest(server.https.makeUrl('/get'), {
-    agent: httpsAgent,
-  })
+  const { res, resBody } = await httpsRequest(
+    httpServer.https.makeUrl('/get'),
+    {
+      agent: httpsAgent,
+    }
+  )
 
   expect(res.statusCode).toEqual(200)
   expect(resBody).toEqual('/get')
@@ -74,7 +77,7 @@ test('responds to an HTTPS request issued by "https.get" and handled in the midd
 })
 
 test('bypasses an HTTPS request issued by "https.get" not handled in the middleware', async () => {
-  const { res, resBody } = await httpsGet(server.https.makeUrl('/get'), {
+  const { res, resBody } = await httpsGet(httpServer.https.makeUrl('/get'), {
     agent: httpsAgent,
   })
 
@@ -89,7 +92,7 @@ test('produces a request error when the middleware throws an exception', async (
 
 test('bypasses any request when the interceptor is restored', async () => {
   interceptor.restore()
-  const { res, resBody } = await httpsGet(server.https.makeUrl('/'), {
+  const { res, resBody } = await httpsGet(httpServer.https.makeUrl('/'), {
     agent: httpsAgent,
   })
 


### PR DESCRIPTION
When using a test HTTP server, always call it `httpServer` in tests. 