### PR TITLE
fix(NodeClientRequest): suppress connection errors for mocked requests

### DIFF
--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestWriteArgs.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestWriteArgs.ts
@@ -12,7 +12,7 @@ export type ClientRequestWriteArgs = [
 export type NormalizedClientRequestWriteArgs = [
   chunk: string | Buffer,
   encoding?: BufferEncoding,
-  callback?: (error?: Error | null) => void
+  callback?: ClientRequestWriteCallback
 ]
 
 export function normalizeClientRequestWriteArgs(

--- a/test/regressions/http-concurrent-different-response-source.test.ts
+++ b/test/regressions/http-concurrent-different-response-source.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment node
+ */
+import { ServerApi, createServer } from '@open-draft/test-server'
+import { createInterceptor } from '../../src'
+import { httpGet } from '../helpers'
+import { interceptClientRequest } from '../../src/interceptors/ClientRequest'
+
+let httpServer: ServerApi
+
+const interceptor = createInterceptor({
+  modules: [interceptClientRequest],
+  async resolver(request) {
+    if (request.headers.get('x-bypass')) {
+      return
+    }
+
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve({
+          status: 201,
+          body: 'mocked-response',
+        })
+      }, 250)
+    })
+  },
+})
+
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    app.get('/', (req, res) => {
+      setTimeout(() => {
+        res.status(200).send('original-response')
+      }, 300)
+    })
+  })
+
+  interceptor.apply()
+})
+
+afterAll(async () => {
+  interceptor.restore()
+  await httpServer.close()
+})
+
+test('handles concurrent requests with different response sources', async () => {
+  const requests = await Promise.all([
+    httpGet(httpServer.http.makeUrl('/')),
+    httpGet(httpServer.http.makeUrl('/'), {
+      headers: {
+        'x-bypass': 'yes',
+      },
+    }),
+  ])
+
+  expect(requests[0].res.statusCode).toEqual(201)
+  expect(requests[0].resBody).toEqual('mocked-response')
+
+  expect(requests[1].res.statusCode).toEqual(200)
+  expect(requests[1].resBody).toEqual('original-response')
+})


### PR DESCRIPTION
## GitHub

- Fixes #168 

## Changes

- Captures and suppresses certain ClientRequest errors (i.e. `ECONNREFUSED`). This prevents the request instance from being destroyed. 
- Replays the first captured error while constructing the ClientRequest once using the "bypass" response source.

## Motivation

I've concluded my initial attempt to provide a custom `Agent.createConnection` to be unnecessary. While it's possible to prevent socket connection that way, it's problematic to let the ClientRequest believe the connection was made (otherwise it won't function properly). Preventing the socket connection altogether is also undesired as it effectively means that we'd have to _recreate_ that connection from scratch once using the "bypass" response source. This is precisely what makes Node.js request interception slow when using MSW (the deferred declaration of the "pure" ClientRequest instance).

With this implementation, we allow the ClientRequest instance to establish (lookup/validate) the connection as usual, but only _suppress any errors it may have_. We ignore those errors when the request has a mocked response (note that IP validation and all underlying error handling is still preserved, you must perform valid requests). If there's no mocked response, the first captured error is replayed (re-emitted). 

> I'm using the first captured error because in the normal ClientRequest flow the first error emitted will be the first error destroying the request instance, preventing any further errors from being emitted. 