### PR TITLE
fix(fetch): use native ref to parse request props

### DIFF
--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -22,7 +22,7 @@ export const interceptFetch: Interceptor = (observer, resolver) => {
   window.fetch = async (input, init) => {
     const ref = new Request(input, init)
     const url = typeof input === 'string' ? input : input.url
-    const method = init?.method || 'GET'
+    const method = ref.method
 
     debug('[%s] %s', method, url)
 
@@ -30,8 +30,8 @@ export const interceptFetch: Interceptor = (observer, resolver) => {
       id: uuidv4(),
       url: new URL(url, location.origin),
       method: method,
-      headers: new Headers(init?.headers || {}),
-      credentials: init?.credentials || 'same-origin',
+      headers: new Headers(ref.headers),
+      credentials: ref.credentials,
       body: await ref.text(),
     }
     debug('isomorphic request', isoRequest)

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -32,7 +32,7 @@ export const interceptFetch: Interceptor = (observer, resolver) => {
       method: method,
       headers: new Headers(request.headers),
       credentials: request.credentials,
-      body: await request.text(),
+      body: await request.clone().text(),
     }
     debug('isomorphic request', isoRequest)
     observer.emit('request', isoRequest)
@@ -58,7 +58,7 @@ export const interceptFetch: Interceptor = (observer, resolver) => {
 
     debug('no mocked response found, bypassing...')
 
-    return pureFetch(input, init).then(async (response) => {
+    return pureFetch(request).then(async (response) => {
       const cloneResponse = response.clone()
       debug('original fetch performed', cloneResponse)
 

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -20,9 +20,9 @@ export const interceptFetch: Interceptor = (observer, resolver) => {
   debug('replacing "window.fetch"...')
 
   window.fetch = async (input, init) => {
-    const ref = new Request(input, init)
+    const request = new Request(input, init)
     const url = typeof input === 'string' ? input : input.url
-    const method = ref.method
+    const method = request.method
 
     debug('[%s] %s', method, url)
 
@@ -30,15 +30,15 @@ export const interceptFetch: Interceptor = (observer, resolver) => {
       id: uuidv4(),
       url: new URL(url, location.origin),
       method: method,
-      headers: new Headers(ref.headers),
-      credentials: ref.credentials,
-      body: await ref.text(),
+      headers: new Headers(request.headers),
+      credentials: request.credentials,
+      body: await request.text(),
     }
     debug('isomorphic request', isoRequest)
     observer.emit('request', isoRequest)
 
     debug('awaiting for the mocked response...')
-    const response = await resolver(isoRequest, ref)
+    const response = await resolver(isoRequest, request)
     debug('mocked response', response)
 
     if (response) {

--- a/test/modules/fetch/intercept/fetch.request.test.ts
+++ b/test/modules/fetch/intercept/fetch.request.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment node
+ */
+import { Request } from 'node-fetch'
+import { createServer, ServerApi } from '@open-draft/test-server'
+import { createInterceptor, IsomorphicRequest, Resolver } from '../../../../src'
+import nodeInterceptors from '../../../../src/presets/node'
+import { fetch } from '../../../helpers'
+
+let httpServer: ServerApi
+
+const resolver = jest.fn<ReturnType<Resolver>, Parameters<Resolver>>()
+const interceptor = createInterceptor({
+  modules: nodeInterceptors,
+  resolver,
+})
+
+beforeAll(async () => {
+  httpServer = await createServer((app) => {
+    app.post('/user', (_req, res) => {
+      res.status(200).send('mocked')
+    })
+  })
+
+  interceptor.apply()
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+afterAll(async () => {
+  interceptor.restore()
+  await httpServer.close()
+})
+
+test('intercepts fetch requests constructed via a "Request" instance', async () => {
+  const request = new Request(httpServer.http.makeUrl('/user'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'plain/text',
+      'User-Agent': 'interceptors',
+    },
+    body: 'hello world',
+  })
+  const { res } = await fetch(request)
+
+  // There's no mocked response returned from the resolver
+  // so this request must hit an actual (test) server.
+  expect(res.status).toEqual(200)
+  expect(await res.text()).toEqual('mocked')
+
+  expect(resolver).toHaveBeenCalledTimes(1)
+  const [capturedRequest] = resolver.mock.calls[0]
+
+  expect(capturedRequest).toMatchObject<Partial<IsomorphicRequest>>({
+    method: 'POST',
+    url: new URL(httpServer.http.makeUrl('/user')),
+    body: 'hello world',
+  })
+  expect(capturedRequest.headers.all()).toMatchObject({
+    'content-type': 'plain/text',
+    'user-agent': 'interceptors',
+  })
+})


### PR DESCRIPTION
The first argument passed to `fetch` may be a `Request` which will be used as the base of the second argument. E.g.,

```ts
const request = new Request('', { method: 'POST' });
fetch(request); // <- This is a POST fetch.
```

Parsing the request properties only from the second argument `init` will not cover this case.
We can parse from `ref` that is constructed from the native `Request` constructor here.

I haven't add test cases since I think it better to add after the test tool supports passing `Request`s.