### PR TITLE
Tests for handling request options from parsed url #188

### DIFF
--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.test.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.test.ts
@@ -241,6 +241,27 @@ test('handles [RequestOptions, callback] input', () => {
   expect(callback?.name).toEqual('cb')
 })
 
+// example of this pattern being used
+// https://github.com/EventSource/eventsource/blob/master/lib/eventsource.js#L84-L139
+test('handles [RequestOptions, callback] input when creating input options with url.parse', () => {
+  const initialOptions = {...parse('https://mswjs.io/resource'), headers: {'Content-Type': 'text/plain'}}
+
+  const [url, options, callback] = normalizeClientRequestArgs(
+    'https:',
+    initialOptions,
+    function cb() {}
+  )
+
+  // URL must be derived from request options.
+  expect(url.href).toEqual('https://mswjs.io/resource')
+
+  // Request headers must be preserved
+  expect(options.headers).toEqual(initialOptions.headers)
+
+  // Callback must be preserved.
+  expect(callback?.name).toEqual('cb')
+})
+
 test('handles [Empty RequestOptions, callback] input', () => {
   const [_, options, callback] = normalizeClientRequestArgs(
     'https:',

--- a/test/modules/http/intercept/https.request.test.ts
+++ b/test/modules/http/intercept/https.request.test.ts
@@ -3,6 +3,7 @@
  */
 import * as http from 'http'
 import * as https from 'https'
+import { parse } from 'url'
 import { RequestHandler } from 'express'
 import { ServerApi, createServer, httpsAgent } from '@open-draft/test-server'
 import { createInterceptor } from '../../../../src'
@@ -238,4 +239,12 @@ test('intercepts an http.request request given RequestOptions without a protocol
     },
     expect.any(http.IncomingMessage)
   )
+})
+
+test('keeps headers when RequestOptions is created from url.parse', (done) => {
+  const requestOptions = {...parse('https://mswjs.io/resource'), headers: {'authorization': 'auth-token'}}
+  https.request(requestOptions, () => done()).end(() => {
+    const [request] = requests
+    expect(request.headers.get('authorization')).toEqual(requestOptions.headers.authorization)
+  })
 })


### PR DESCRIPTION
# Related Issue
#188 
# Motivation
Some node libraries (notably the eventsource library) use the `url.parse` method to generate a RequestOption payload to pass to `https.request`. When this happens the interceptor strips any provided headers (and possibly other configuration) from the request.
Here is an example repo of this behavior causing the launch darkly client to fail when mock service worker is running:
https://github.com/dg-harris/ld-msw-authentication-issue