### PR TITLE
fix: change upload property to object

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -130,7 +130,7 @@ export const createXMLHttpRequestOverride = (
       this.responseText = ''
       this.responseXML = null
       this.responseURL = ''
-      this.upload = null as any
+      this.upload = {} as any
       this.timeout = 0
 
       this._requestHeaders = new Headers()


### PR DESCRIPTION
change `upload` to object to avoid `upload.onprogress` runtime error.
some npm file upload deps use `xhr.upload.onprogress = () => {}` for pogress reporting. 
Changing `upload` to an object will at least **_temporarily_** avoid this runtime error and unblock teams on writing tests.

Reference:
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/upload