### PR TITLE
fix: set required node to "12.x"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Artem Zakharchenko",
   "license": "MIT",
   "engines": {
-    "node": ">=12.20.0"
+    "node": ">=12.x"
   },
   "scripts": {
     "start": "tsc --build -w",


### PR DESCRIPTION
Our current required `node` version is rather strict. We do not rely on features from `12.20` directly. Any 12.x release should be compatible. 