### PR TITLE
fix(cloneIncomingMessage): inherit prototype properties

### DIFF
--- a/src/interceptors/ClientRequest/utils/cloneIncomingMessage.test.ts
+++ b/src/interceptors/ClientRequest/utils/cloneIncomingMessage.test.ts
@@ -12,6 +12,7 @@ test('clones a given IncomingMessage', () => {
   expect(clone.statusCode).toEqual(200)
   expect(clone.statusMessage).toEqual('OK')
   expect(clone.headers).toHaveProperty('x-powered-by', 'msw')
+  expect(clone).toBeInstanceOf(IncomingMessage);
 
   // Cloned IncomingMessage must be marked respectively.
   expect(clone[IS_CLONE]).toEqual(true)

--- a/src/interceptors/ClientRequest/utils/cloneIncomingMessage.test.ts
+++ b/src/interceptors/ClientRequest/utils/cloneIncomingMessage.test.ts
@@ -1,21 +1,25 @@
 import { Socket } from 'net'
 import { IncomingMessage } from 'http'
+import { Stream, Readable, EventEmitter } from 'stream'
 import { cloneIncomingMessage, IS_CLONE } from './cloneIncomingMessage'
 
 test('clones a given IncomingMessage', () => {
-  const source = new IncomingMessage(new Socket())
-  source.statusCode = 200
-  source.statusMessage = 'OK'
-  source.headers = { 'x-powered-by': 'msw' }
-  const clone = cloneIncomingMessage(source)
+  const message = new IncomingMessage(new Socket())
+  message.statusCode = 200
+  message.statusMessage = 'OK'
+  message.headers = { 'x-powered-by': 'msw' }
+  const clone = cloneIncomingMessage(message)
+
+  // Prototypes must be preserved.
+  expect(clone).toBeInstanceOf(IncomingMessage)
+  expect(clone).toBeInstanceOf(EventEmitter)
+  expect(clone).toBeInstanceOf(Stream)
+  expect(clone).toBeInstanceOf(Readable)
 
   expect(clone.statusCode).toEqual(200)
   expect(clone.statusMessage).toEqual('OK')
   expect(clone.headers).toHaveProperty('x-powered-by', 'msw')
-  expect(clone).toBeInstanceOf(IncomingMessage);
 
   // Cloned IncomingMessage must be marked respectively.
   expect(clone[IS_CLONE]).toEqual(true)
-
-  expect(clone).toHaveProperty('_events')
 })

--- a/src/interceptors/ClientRequest/utils/cloneIncomingMessage.ts
+++ b/src/interceptors/ClientRequest/utils/cloneIncomingMessage.ts
@@ -18,7 +18,6 @@ export function cloneIncomingMessage(
     mixin(prototype, p);
   });
   Object.setPrototypeOf(stream, prototype);
-
   Object.defineProperty(stream, IS_CLONE, {
     enumerable: true,
     value: true,
@@ -26,7 +25,7 @@ export function cloneIncomingMessage(
   return stream as unknown as ClonedIncomingMessage
 }
 
-function getPrototypes<T extends object>(target: T) {
+function getPrototypes(target: object) {
   const prototypes = [];
   let current = target;
   while (current = Object.getPrototypeOf(current)) {
@@ -35,11 +34,11 @@ function getPrototypes<T extends object>(target: T) {
   return prototypes;
 }
 
-function mixin<T extends object, U extends object>(target: T, source: U) {
+function mixin(target: object, source: object) {
   const properties = [
     ...Object.getOwnPropertyNames(source),
     ...Object.getOwnPropertySymbols(source),
-  ] as Array<keyof U>;
+  ] as Array<keyof typeof source>;
   for (const property of properties) {
     if (target.hasOwnProperty(property)) {
       continue

--- a/src/interceptors/ClientRequest/utils/cloneIncomingMessage.ts
+++ b/src/interceptors/ClientRequest/utils/cloneIncomingMessage.ts
@@ -7,6 +7,9 @@ export interface ClonedIncomingMessage extends IncomingMessage {
   [IS_CLONE]: boolean
 }
 
+/**
+ * Clones a given `http.IncomingMessage` instance.
+ */
 export function cloneIncomingMessage(
   message: IncomingMessage
 ): ClonedIncomingMessage {
@@ -30,6 +33,9 @@ export function cloneIncomingMessage(
   return clone as unknown as ClonedIncomingMessage
 }
 
+/**
+ * Returns a list of all prototypes the given object extends.
+ */
 function getPrototypes(source: object): object[] {
   const prototypes: object[] = []
   let current = source
@@ -41,6 +47,12 @@ function getPrototypes(source: object): object[] {
   return prototypes
 }
 
+/**
+ * Inherits a given target object properties and symbols
+ * onto the given source object.
+ * @param source Object which should acquire properties.
+ * @param target Object to inherit the properties from.
+ */
 function inheritProperties(source: object, target: object): void {
   const properties = [
     ...Object.getOwnPropertyNames(source),

--- a/src/interceptors/ClientRequest/utils/cloneIncomingMessage.ts
+++ b/src/interceptors/ClientRequest/utils/cloneIncomingMessage.ts
@@ -13,13 +13,10 @@ export function cloneIncomingMessage(
   const stream = message.pipe(new PassThrough());
   mixin(stream, message);
 
-  const prototype = {};
+  const prototype = Object.create(IncomingMessage.prototype);
   getPrototypes(stream).forEach(p => {
     mixin(prototype, p);
   });
-  getPrototypes(message).forEach(p => {
-    mixin(prototype, p);
-  })
   Object.setPrototypeOf(stream, prototype);
 
   Object.defineProperty(stream, IS_CLONE, {


### PR DESCRIPTION
Fix #212 

The current implementation will clone the properties defined in `instance`.
But the `headers` property defined in `prototype` in Node.js v16 or higher.

So this PR aims to support prototype inheriting in `cloneIncomingMessage`.

> The final pitfalls is this is not support `instanceof IncomingMessage` and `instanceof PassThrough`. If the msw uses those operators,  I think this must not be merged.

Fixed.