### PR TITLE
fix(ClientRequest): ensure "options._defaultAgent" is always set based on the protocol

### DIFF
--- a/src/interceptors/ClientRequest/http.request.ts
+++ b/src/interceptors/ClientRequest/http.request.ts
@@ -15,7 +15,7 @@ export function request(
   observer: Observer
 ) {
   return (...args: ClientRequestArgs): ClientRequest => {
-    log('intercepted request:', args)
+    log('request call (protocol "%s"):', protocol, args)
 
     const clientRequestArgs = normalizeClientRequestArgs(
       `${protocol}:`,


### PR DESCRIPTION
- Fixes https://github.com/mswjs/msw/issues/1150

## Changes

- The `options._defaultAgent` is now always set if it hasn't been explicitly provided. It's always set to the `<protocol>.globalAgent` as per [Node.js implementation](https://github.com/nodejs/node/blob/418ff70b810f0e7112d48baaa72932a56cfa213b/lib/_http_client.js#L130).
- Respective unit test added.
