### PR TITLE
fix(getIncomingMessageBody): Make `getIncomingMessageBody` return on empty body

### DIFF
--- a/src/interceptors/ClientRequest/utils/getIncomingMessageBody.test.ts
+++ b/src/interceptors/ClientRequest/utils/getIncomingMessageBody.test.ts
@@ -42,3 +42,12 @@ test('returns utf8 string given a gzipped response body with incorrect "content-
 
   expect(await pendingResponseBody).toEqual('three')
 })
+
+test('returns empty string given an empty body', async () => {
+  const message = new IncomingMessage(new Socket())
+
+  const pendingResponseBody = getIncomingMessageBody(message)
+  message.emit('end');
+
+  expect(await pendingResponseBody).toEqual("")
+})

--- a/src/interceptors/ClientRequest/utils/getIncomingMessageBody.test.ts
+++ b/src/interceptors/ClientRequest/utils/getIncomingMessageBody.test.ts
@@ -47,7 +47,7 @@ test('returns empty string given an empty body', async () => {
   const message = new IncomingMessage(new Socket())
 
   const pendingResponseBody = getIncomingMessageBody(message)
-  message.emit('end');
+  message.emit('end')
 
-  expect(await pendingResponseBody).toEqual("")
+  expect(await pendingResponseBody).toEqual('')
 })

--- a/src/interceptors/ClientRequest/utils/getIncomingMessageBody.ts
+++ b/src/interceptors/ClientRequest/utils/getIncomingMessageBody.ts
@@ -25,9 +25,16 @@ export function getIncomingMessageBody(
     stream.setEncoding(encoding)
     log('using encoding:', encoding)
 
+    let body = '';
+
     stream.once('data', (responseBody) => {
       log('response body read:', responseBody)
-      resolve(responseBody)
+      body += responseBody;
+    })
+
+    stream.once('end', () => {
+      log('response body end');
+      resolve(body);
     })
 
     stream.once('error', (error) => {

--- a/src/interceptors/ClientRequest/utils/getIncomingMessageBody.ts
+++ b/src/interceptors/ClientRequest/utils/getIncomingMessageBody.ts
@@ -27,7 +27,7 @@ export function getIncomingMessageBody(
 
     let body = '';
 
-    stream.once('data', (responseBody) => {
+    stream.on('data', (responseBody) => {
       log('response body read:', responseBody)
       body += responseBody;
     })

--- a/test/features/events/response.test.ts
+++ b/test/features/events/response.test.ts
@@ -188,10 +188,9 @@ test('XMLHttpRequest: emits the "response" event upon the original response', as
   })
 
   /**
-   * @note In Node.js "XMLHttpRequest" is often polyfilled by "ClientRequest".
-   * This results in both "XMLHttpRequest" and "ClientRequest" interceptors
-   * emitting the "request" event.
-   * @see https://github.com/mswjs/interceptors/issues/163
+   * @note There are two requests that happen:
+   * - OPTIONS /account
+   * - POST /account
    */
   expect(responseListener).toHaveBeenCalledTimes(2)
   expect(responseListener).toHaveBeenCalledWith<
@@ -204,7 +203,7 @@ test('XMLHttpRequest: emits the "response" event upon the original response', as
       headers: headersContaining({
         'x-request-custom': 'yes',
       }),
-      credentials: 'same-origin',
+      credentials: 'omit',
       body: 'request-body',
     },
     {


### PR DESCRIPTION
Fixes https://github.com/mswjs/interceptors/issues/222

## Changes

- Make `getIncomingMessageBody` resolve its promise even if body is empty. (It hangs indefinitely in the current code.)