### PR TITLE
feat(ClientRequest): set "credentials" to "same-origin"

### DIFF
--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -373,7 +373,7 @@ export class NodeClientRequest extends ClientRequest {
       id: uuidv4(),
       url: this.url,
       method: this.options.method || 'GET',
-      credentials: 'omit',
+      credentials: 'same-origin',
       headers,
       body,
     }

--- a/test/features/events/request.test.ts
+++ b/test/features/events/request.test.ts
@@ -92,7 +92,7 @@ test('XMLHttpRequest: emits the "request" event upon the request', async () => {
     headers: headersContaining({
       'content-type': 'application/json',
     }),
-    credentials: 'omit',
+    credentials: 'same-origin',
     body: JSON.stringify({ userId: 'abc-123' }),
   })
 })

--- a/test/features/events/response.test.ts
+++ b/test/features/events/response.test.ts
@@ -90,7 +90,7 @@ test('ClientRequest: emits the "response" event upon a mocked response', async (
       headers: headersContaining({
         'x-request-custom': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     {
@@ -129,7 +129,7 @@ test('ClientRequest: emits the "response" event upon the original response', asy
       headers: headersContaining({
         'x-request-custom': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: 'request-body',
     },
     {
@@ -204,7 +204,7 @@ test('XMLHttpRequest: emits the "response" event upon the original response', as
       headers: headersContaining({
         'x-request-custom': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: 'request-body',
     },
     {
@@ -239,7 +239,7 @@ test('fetch: emits the "response" event upon a mocked response', async () => {
       headers: headersContaining({
         'x-request-custom': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     {
@@ -276,7 +276,7 @@ test('fetch: emits the "response" event upon the original response', async () =>
       headers: headersContaining({
         'x-request-custom': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: 'request-body',
     },
     {

--- a/test/modules/fetch/intercept/fetch.request.test.ts
+++ b/test/modules/fetch/intercept/fetch.request.test.ts
@@ -62,7 +62,7 @@ test('intercepts fetch requests constructed via a "Request" instance', async () 
         'content-type': 'text/plain',
         'user-agent': 'interceptors',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: 'hello world',
     },
     expect.any(http.IncomingMessage)

--- a/test/modules/fetch/intercept/fetch.test.ts
+++ b/test/modules/fetch/intercept/fetch.test.ts
@@ -60,7 +60,7 @@ test('intercepts an HTTP HEAD request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -83,7 +83,7 @@ test('intercepts an HTTP GET request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -109,7 +109,7 @@ test('intercepts an HTTP POST request', async () => {
         accept: '*/*',
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: JSON.stringify({ body: true }),
     },
     expect.any(http.IncomingMessage)
@@ -134,7 +134,7 @@ test('intercepts an HTTP PUT request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: 'request-payload',
     },
     expect.any(http.IncomingMessage)
@@ -158,7 +158,7 @@ test('intercepts an HTTP DELETE request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -183,7 +183,7 @@ test('intercepts an HTTP PATCH request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: 'request-payload',
     },
     expect.any(http.IncomingMessage)
@@ -208,7 +208,7 @@ test('intercepts an HTTPS HEAD request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -232,7 +232,7 @@ test('intercepts an HTTPS GET request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -258,7 +258,7 @@ test('intercepts an HTTPS POST request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: JSON.stringify({ body: true }),
     },
     expect.any(http.IncomingMessage)
@@ -284,7 +284,7 @@ test('intercepts an HTTPS PUT request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: 'request-payload',
     },
     expect.any(http.IncomingMessage)
@@ -309,7 +309,7 @@ test('intercepts an HTTPS DELETE request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -334,7 +334,7 @@ test('intercepts an HTTPS PATCH request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)

--- a/test/modules/http/intercept/http.get.test.ts
+++ b/test/modules/http/intercept/http.get.test.ts
@@ -53,7 +53,7 @@ test('intercepts an http.get request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -78,7 +78,7 @@ test('intercepts an http.get request given RequestOptions without a protocol', a
       method: 'GET',
       url: new URL(httpServer.http.makeUrl('/user?id=123')),
       headers: headersContaining({}),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.anything()

--- a/test/modules/http/intercept/http.request.test.ts
+++ b/test/modules/http/intercept/http.request.test.ts
@@ -62,7 +62,7 @@ test('intercepts a HEAD request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -89,7 +89,7 @@ test('intercepts a GET request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -117,7 +117,7 @@ test('intercepts a POST request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: 'post-payload',
     },
     expect.any(http.IncomingMessage)
@@ -145,7 +145,7 @@ test('intercepts a PUT request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: 'put-payload',
     },
     expect.any(http.IncomingMessage)
@@ -173,7 +173,7 @@ test('intercepts a PATCH request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: 'patch-payload',
     },
     expect.any(http.IncomingMessage)
@@ -200,7 +200,7 @@ test('intercepts a DELETE request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -226,7 +226,7 @@ test('intercepts an http.request given RequestOptions without a protocol', async
       method: 'GET',
       url: new URL(httpServer.http.makeUrl('/user?id=123')),
       headers: headersContaining({}),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)

--- a/test/modules/http/intercept/https.get.test.ts
+++ b/test/modules/http/intercept/https.get.test.ts
@@ -56,7 +56,7 @@ test('intercepts a GET request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -82,7 +82,7 @@ test('intercepts an https.get request given RequestOptions without a protocol', 
       method: 'GET',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
       headers: headersContaining({}),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)

--- a/test/modules/http/intercept/https.request.test.ts
+++ b/test/modules/http/intercept/https.request.test.ts
@@ -66,7 +66,7 @@ test('intercepts a HEAD request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -94,7 +94,7 @@ test('intercepts a GET request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -123,7 +123,7 @@ test('intercepts a POST request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: 'post-payload',
     },
     expect.any(http.IncomingMessage)
@@ -152,7 +152,7 @@ test('intercepts a PUT request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: 'put-payload',
     },
     expect.any(http.IncomingMessage)
@@ -181,7 +181,7 @@ test('intercepts a PATCH request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: 'patch-payload',
     },
     expect.any(http.IncomingMessage)
@@ -209,7 +209,7 @@ test('intercepts a DELETE request', async () => {
       headers: headersContaining({
         'x-custom-header': 'yes',
       }),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)
@@ -233,7 +233,7 @@ test('intercepts an http.request request given RequestOptions without a protocol
       method: 'GET',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
       headers: headersContaining({}),
-      credentials: 'omit',
+      credentials: 'same-origin',
       body: '',
     },
     expect.any(http.IncomingMessage)


### PR DESCRIPTION
- Originates from https://github.com/mswjs/msw/pull/1155

## Changes

The `credentials` in `ClientRequest` are now always set to `same-origin`. That is to align with the same default value for `window.fetch`, which is often polyfilled via `ClientRequest`.

Note that `credentials` for `XMLHttpReqiest` remains intact: it depends on `.withCredentials`, which requires you to set it to `true` in order to achieve the `include` behavior. 