### PR TITLE
feat: use events model

### DIFF
--- a/src/interceptors/ClientRequest/NodeClientRequest.test.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.test.ts
@@ -44,14 +44,14 @@ test('gracefully finishes the request when it has a mocked response', (done) => 
     }),
     {
       observer: new EventEmitter(),
-      resolver() {
-        return {
+      resolver(event) {
+        event.respondWith({
           status: 301,
           headers: {
             'x-custom-header': 'yes',
           },
           body: 'mocked-response',
-        }
+        })
       },
     }
   )
@@ -80,12 +80,12 @@ test('responds with a mocked response when requesting an existing hostname', (do
     normalizeClientRequestArgs('http:', httpServer.http.makeUrl('/comment')),
     {
       observer: new EventEmitter(),
-      async resolver() {
+      async resolver(event) {
         await waitFor(250)
-        return {
+        event.respondWith({
           status: 201,
           body: 'mocked-response',
-        }
+        })
       },
     }
   )
@@ -175,12 +175,12 @@ test('does not emit ENOTFOUND error connecting to an inactive server given mocke
     normalizeClientRequestArgs('http:', 'http://non-existing-url.com'),
     {
       observer: new EventEmitter(),
-      async resolver() {
+      async resolver(event) {
         await waitFor(250)
-        return {
+        event.respondWith({
           status: 200,
           statusText: 'Works',
-        }
+        })
       },
     }
   )
@@ -201,12 +201,12 @@ test('does not emit ECONNREFUSED error connecting to an inactive server given mo
     normalizeClientRequestArgs('http:', 'http://localhost:9876'),
     {
       observer: new EventEmitter(),
-      async resolver() {
+      async resolver(event) {
         await waitFor(250)
-        return {
+        event.respondWith({
           status: 200,
           statusText: 'Works',
-        }
+        })
       },
     }
   )
@@ -257,12 +257,12 @@ test('does not send request body to the original server given mocked response', 
     }),
     {
       observer: new EventEmitter(),
-      async resolver() {
+      async resolver(event) {
         await waitFor(200)
-        return {
+        event.respondWith({
           status: 301,
           body: 'mock created!',
-        }
+        })
       },
     }
   )

--- a/src/interceptors/ClientRequest/index.ts
+++ b/src/interceptors/ClientRequest/index.ts
@@ -21,7 +21,10 @@ type PureModules = Map<
 /**
  * Intercepts requests issued by native "http" and "https" modules.
  */
-export const interceptClientRequest: Interceptor = (observer, resolver) => {
+export const interceptClientRequest: Interceptor<'http'> = (
+  observer,
+  resolver
+) => {
   const pureModules: PureModules = new Map()
   const modules: [Protocol, RequestModule][] = [
     ['http', http],

--- a/src/interceptors/XMLHttpRequest/index.ts
+++ b/src/interceptors/XMLHttpRequest/index.ts
@@ -11,7 +11,10 @@ const pureXMLHttpRequest =
 /**
  * Intercepts requests issued via `XMLHttpRequest`.
  */
-export const interceptXMLHttpRequest: Interceptor = (observer, resolver) => {
+export const interceptXMLHttpRequest: Interceptor<'http'> = (
+  observer,
+  resolver
+) => {
   if (pureXMLHttpRequest) {
     debug('patching "XMLHttpRequest" module...')
 

--- a/src/utils/createResolverEvent.ts
+++ b/src/utils/createResolverEvent.ts
@@ -1,0 +1,79 @@
+import { invariant } from 'outvariant'
+import type {
+  MaybePromise,
+  ResolverEvent,
+  HttpRequestEvent,
+  WebSocketEvent,
+  ResolverEventsMap,
+} from '../createInterceptor'
+
+export type EventProperties =
+  | {
+      source: HttpRequestEvent['source']
+      target: HttpRequestEvent['target']
+      request: HttpRequestEvent['request']
+    }
+  | {
+      source: WebSocketEvent['source']
+      target: WebSocketEvent['target']
+      message: WebSocketEvent['message']
+    }
+
+export type EventReturnType<Properties extends EventProperties> =
+  ExtractEventReturnType<ResolverEventsMap[Properties['source']]>
+
+export type ExtractEventReturnType<Event extends ResolverEvent> = Parameters<
+  Event['respondWith']
+>[0] extends MaybePromise<infer DataType>
+  ? DataType | undefined
+  : never
+
+export function createResolverEvent<Properties extends EventProperties>(
+  properties: Properties
+): [
+  ResolverEventsMap[Properties['source']],
+  () => Promise<EventReturnType<Properties>>
+] {
+  let calledTimes = 0
+  let autoResolveTimeout: NodeJS.Timeout
+  let remoteResolve: (data: EventReturnType<Properties>) => void
+  const responsePromise = new Promise<EventReturnType<Properties>>(
+    (resolve) => {
+      remoteResolve = resolve
+    }
+  )
+    .then((data) => {
+      calledTimes++
+      return data
+    })
+    .finally(() => {
+      clearTimeout(autoResolveTimeout)
+    })
+
+  const event: ResolverEvent = {
+    ...properties,
+    timeStamp: Date.now(),
+    respondWith(data: any) {
+      invariant(
+        calledTimes === 0,
+        'Failed to call "event.respondWith": cannot respond to a resolver event multiple times.'
+      )
+
+      remoteResolve(data)
+    },
+  }
+
+  function respondedWithCalled() {
+    // Immediately resolve the "event.respondWith" Promise
+    // unless "event.respondWith" is called in the resolver.
+    // This prevents this Promise from hanging indefinitely
+    // if "event.respondWith" was never called (introspection).
+    autoResolveTimeout = setTimeout(() => {
+      remoteResolve(undefined)
+    }, 0)
+
+    return responsePromise
+  }
+
+  return [event as ResolverEventsMap[Properties['source']], respondedWithCalled]
+}

--- a/test/features/events/response.test.ts
+++ b/test/features/events/response.test.ts
@@ -19,15 +19,15 @@ let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: nodeInterceptors,
-  resolver(request) {
-    if (request.url.pathname === '/user') {
-      return {
+  resolver(event) {
+    if (event.request.url.pathname === '/user') {
+      event.respondWith({
         status: 200,
         headers: {
           'x-response-type': 'mocked',
         },
         body: 'mocked-response-text',
-      }
+      })
     }
   },
 })

--- a/test/features/remote/child.js
+++ b/test/features/remote/child.js
@@ -18,6 +18,8 @@ function makeRequest() {
     })
 }
 
+console.log('footer')
+
 process.on('message', (message) => {
   if (message === 'make:request') {
     makeRequest()

--- a/test/features/remote/remote.test.ts
+++ b/test/features/remote/remote.test.ts
@@ -10,8 +10,8 @@ const child = spawn('node', [CHILD_PATH], {
 
 createRemoteResolver({
   process: child,
-  resolver() {
-    return {
+  resolver(event) {
+    event.respondWith({
       status: 200,
       headers: {
         'Content-Type': 'application/json',
@@ -19,7 +19,7 @@ createRemoteResolver({
       body: JSON.stringify({
         mockedFromParent: true,
       }),
-    }
+    })
   },
 })
 

--- a/test/modules/XMLHttpRequest/compliance/xhr-add-event-listener.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-add-event-listener.test.ts
@@ -8,9 +8,9 @@ import { createXMLHttpRequest } from '../../../helpers'
 
 const interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
-  resolver(request) {
-    if (request.url.href === 'https://test.mswjs.io/user') {
-      return {
+  resolver(event) {
+    if (event.request.url.href === 'https://test.mswjs.io/user') {
+      event.respondWith({
         status: 200,
         statusText: 'OK',
         headers: {
@@ -20,7 +20,7 @@ const interceptor = createInterceptor({
         body: JSON.stringify({
           mocked: true,
         }),
-      }
+      })
     }
   },
 })

--- a/test/modules/XMLHttpRequest/compliance/xhr-events-order.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-events-order.test.ts
@@ -10,19 +10,21 @@ let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
-  resolver(request) {
-    switch (request.url.pathname) {
+  resolver(event) {
+    switch (event.request.url.pathname) {
       case '/user': {
-        return {
+        event.respondWith({
           status: 200,
-        }
+        })
+        break
       }
 
       case '/numbers-mock': {
-        return {
+        event.respondWith({
           status: 200,
           body: JSON.stringify([1, 2, 3]),
-        }
+        })
+        break
       }
     }
   },

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-body-empty.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-body-empty.test.ts
@@ -7,15 +7,15 @@ import { createXMLHttpRequest } from '../../../helpers'
 
 const interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
-  resolver() {
-    return {
+  resolver(event) {
+    event.respondWith({
       status: 401,
       statusText: 'Unathorized',
       // @ts-nocheck JavaScript clients and type-casting may
       // circument the mocked response body type signature,
       // setting in invalid value.
       body: null as any,
-    }
+    })
   },
 })
 

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-body-json-invalid.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-body-json-invalid.test.ts
@@ -7,21 +7,23 @@ import { createXMLHttpRequest } from '../../../helpers'
 
 const interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
-  resolver(request) {
-    switch (request.url.pathname) {
+  resolver(event) {
+    switch (event.request.url.pathname) {
       case '/no-body': {
-        return {
+        event.respondWith({
           status: 204,
-        }
+        })
+        break
       }
 
       case '/invalid-json': {
-        return {
+        event.respondWith({
           headers: {
             'Content-Type': 'application/json',
           },
           body: `{"invalid: js'on`,
-        }
+        })
+        break
       }
     }
   },

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-body-xml.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-body-xml.test.ts
@@ -11,12 +11,12 @@ const XML_STRING = '<node key="value">Content</node>'
 describe('Content-Type: application/xml', () => {
   const interceptor = createInterceptor({
     modules: [interceptXMLHttpRequest],
-    resolver() {
-      return {
+    resolver(event) {
+      event.respondWith({
         headers: { 'Content-Type': 'application/xml' },
         status: 200,
         body: XML_STRING,
-      }
+      })
     },
   })
 
@@ -43,12 +43,12 @@ describe('Content-Type: application/xml', () => {
 describe('Content-Type: text/xml', () => {
   const interceptor = createInterceptor({
     modules: [interceptXMLHttpRequest],
-    resolver() {
-      return {
+    resolver(event) {
+      event.respondWith({
         headers: { 'Content-Type': 'text/xml' },
         status: 200,
         body: XML_STRING,
-      }
+      })
     },
   })
 

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-headers.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-headers.test.ts
@@ -10,17 +10,17 @@ let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
-  resolver(req) {
-    if (!req.url.searchParams.has('mock')) {
+  resolver(event) {
+    if (!event.request.url.searchParams.has('mock')) {
       return
     }
 
-    return {
+    event.respondWith({
       headers: {
         etag: '123',
         'x-response-type': 'mock',
       },
-    }
+    })
   },
 })
 

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-type.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-type.test.ts
@@ -7,8 +7,8 @@ import { createXMLHttpRequest, readBlob } from '../../../helpers'
 
 const interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
-  resolver() {
-    return {
+  resolver(event) {
+    event.respondWith({
       headers: {
         'Content-Type': 'application/json',
       },
@@ -16,7 +16,7 @@ const interceptor = createInterceptor({
         firstName: 'John',
         lastName: 'Maverick',
       }),
-    }
+    })
   },
 })
 

--- a/test/modules/XMLHttpRequest/compliance/xhr-timeout.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-timeout.test.ts
@@ -17,7 +17,9 @@ const interceptor = createInterceptor({
 beforeAll(async () => {
   httpServer = await createServer((app) => {
     app.get('/', (_req, res) => {
-      res.send('ok')
+      setTimeout(() => {
+        res.send('ok')
+      }, 50)
     })
   })
 

--- a/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.browser.runtime.js
+++ b/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.browser.runtime.js
@@ -3,16 +3,16 @@ import { interceptXMLHttpRequest } from '@mswjs/interceptors/lib/interceptors/XM
 
 const interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
-  resolver(request) {
+  resolver(event) {
     window.dispatchEvent(
       new CustomEvent('resolver', {
         detail: JSON.stringify({
-          id: request.id,
-          method: request.method,
-          url: request.url.href,
-          headers: request.headers.all(),
-          credentials: request.credentials,
-          body: request.body,
+          id: event.request.id,
+          method: event.request.method,
+          url: event.request.url.href,
+          headers: event.request.headers.all(),
+          credentials: event.request.credentials,
+          body: event.request.body,
         }),
       })
     )

--- a/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.test.ts
+++ b/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.test.ts
@@ -3,7 +3,12 @@
  */
 import { RequestHandler } from 'express-serve-static-core'
 import { ServerApi, createServer } from '@open-draft/test-server'
-import { createInterceptor, IsomorphicRequest, Resolver } from '../../../../src'
+import {
+  createInterceptor,
+  HttpRequestEvent,
+  IsomorphicRequest,
+  Resolver,
+} from '../../../../src'
 import { interceptXMLHttpRequest } from '../../../../src/interceptors/XMLHttpRequest'
 import { createXMLHttpRequest } from '../../../helpers'
 import { anyUuid, headersContaining } from '../../../jest.expect'
@@ -55,8 +60,10 @@ test('intercepts an HTTP HEAD request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(XMLHttpRequest),
+    request: {
       id: anyUuid(),
       method: 'HEAD',
       url: new URL(url),
@@ -66,8 +73,9 @@ test('intercepts an HTTP HEAD request', async () => {
       credentials: 'omit',
       body: '',
     },
-    expect.any(XMLHttpRequest)
-  )
+    timeStamp: expect.any(Number),
+    respondWith: expect.any(Function),
+  })
 })
 
 test('intercepts an HTTP GET request', async () => {
@@ -79,8 +87,10 @@ test('intercepts an HTTP GET request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(XMLHttpRequest),
+    request: {
       id: anyUuid(),
       method: 'GET',
       url: new URL(url),
@@ -90,8 +100,9 @@ test('intercepts an HTTP GET request', async () => {
       credentials: 'omit',
       body: '',
     },
-    expect.any(XMLHttpRequest)
-  )
+    timeStamp: expect.any(Number),
+    respondWith: expect.any(Function),
+  })
 })
 
 test('intercepts an HTTP POST request', async () => {
@@ -103,8 +114,10 @@ test('intercepts an HTTP POST request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(XMLHttpRequest),
+    request: {
       id: anyUuid(),
       method: 'POST',
       url: new URL(url),
@@ -114,8 +127,9 @@ test('intercepts an HTTP POST request', async () => {
       credentials: 'omit',
       body: 'post-payload',
     },
-    expect.any(XMLHttpRequest)
-  )
+    timeStamp: expect.any(Number),
+    respondWith: expect.any(Function),
+  })
 })
 
 test('intercepts an HTTP PUT request', async () => {
@@ -127,8 +141,10 @@ test('intercepts an HTTP PUT request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(XMLHttpRequest),
+    request: {
       id: anyUuid(),
       method: 'PUT',
       url: new URL(url),
@@ -138,8 +154,9 @@ test('intercepts an HTTP PUT request', async () => {
       credentials: 'omit',
       body: 'put-payload',
     },
-    expect.any(XMLHttpRequest)
-  )
+    timeStamp: expect.any(Number),
+    respondWith: expect.any(Function),
+  })
 })
 
 test('intercepts an HTTP DELETE request', async () => {
@@ -151,8 +168,10 @@ test('intercepts an HTTP DELETE request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(XMLHttpRequest),
+    request: {
       id: anyUuid(),
       method: 'DELETE',
       url: new URL(url),
@@ -162,8 +181,9 @@ test('intercepts an HTTP DELETE request', async () => {
       credentials: 'omit',
       body: '',
     },
-    expect.any(XMLHttpRequest)
-  )
+    timeStamp: expect.any(Number),
+    respondWith: expect.any(Function),
+  })
 })
 
 test('intercepts an HTTPS HEAD request', async () => {
@@ -175,8 +195,10 @@ test('intercepts an HTTPS HEAD request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(XMLHttpRequest),
+    request: {
       id: anyUuid(),
       method: 'HEAD',
       url: new URL(url),
@@ -186,8 +208,9 @@ test('intercepts an HTTPS HEAD request', async () => {
       credentials: 'omit',
       body: '',
     },
-    expect.any(XMLHttpRequest)
-  )
+    timeStamp: expect.any(Number),
+    respondWith: expect.any(Function),
+  })
 })
 
 test('intercepts an HTTPS GET request', async () => {
@@ -199,8 +222,10 @@ test('intercepts an HTTPS GET request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(XMLHttpRequest),
+    request: {
       id: anyUuid(),
       method: 'GET',
       url: new URL(url),
@@ -210,8 +235,9 @@ test('intercepts an HTTPS GET request', async () => {
       credentials: 'omit',
       body: '',
     },
-    expect.any(XMLHttpRequest)
-  )
+    timeStamp: expect.any(Number),
+    respondWith: expect.any(Function),
+  })
 })
 
 test('intercepts an HTTPS POST request', async () => {
@@ -223,8 +249,10 @@ test('intercepts an HTTPS POST request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(XMLHttpRequest),
+    request: {
       id: anyUuid(),
       method: 'POST',
       url: new URL(url),
@@ -234,8 +262,9 @@ test('intercepts an HTTPS POST request', async () => {
       credentials: 'omit',
       body: 'post-payload',
     },
-    expect.any(XMLHttpRequest)
-  )
+    timeStamp: expect.any(Number),
+    respondWith: expect.any(Function),
+  })
 })
 
 test('intercepts an HTTPS PUT request', async () => {
@@ -247,8 +276,10 @@ test('intercepts an HTTPS PUT request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(XMLHttpRequest),
+    request: {
       id: anyUuid(),
       method: 'PUT',
       url: new URL(url),
@@ -258,8 +289,9 @@ test('intercepts an HTTPS PUT request', async () => {
       credentials: 'omit',
       body: 'put-payload',
     },
-    expect.any(XMLHttpRequest)
-  )
+    timeStamp: expect.any(Number),
+    respondWith: expect.any(Function),
+  })
 })
 
 test('intercepts an HTTPS DELETE request', async () => {
@@ -271,8 +303,10 @@ test('intercepts an HTTPS DELETE request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(XMLHttpRequest),
+    request: {
       id: anyUuid(),
       method: 'DELETE',
       url: new URL(url),
@@ -282,8 +316,9 @@ test('intercepts an HTTPS DELETE request', async () => {
       credentials: 'omit',
       body: '',
     },
-    expect.any(XMLHttpRequest)
-  )
+    timeStamp: expect.any(Number),
+    respondWith: expect.any(Function),
+  })
 })
 
 test('sets "credentials" to "include" on isomorphic request when "withCredentials" is true', async () => {
@@ -295,10 +330,12 @@ test('sets "credentials" to "include" on isomorphic request when "withCredential
 
   expect(resolver).toHaveBeenCalledTimes(1)
   expect(resolver).toHaveBeenCalledWith(
-    expect.objectContaining<Partial<IsomorphicRequest>>({
-      credentials: 'include',
-    }),
-    expect.any(XMLHttpRequest)
+    expect.objectContaining<Partial<HttpRequestEvent>>({
+      target: expect.any(XMLHttpRequest),
+      request: expect.objectContaining<Partial<IsomorphicRequest>>({
+        credentials: 'include',
+      }),
+    })
   )
 })
 
@@ -310,10 +347,12 @@ test('sets "credentials" to "omit" on isomorphic request when "withCredentials" 
 
   expect(resolver).toHaveBeenCalledTimes(1)
   expect(resolver).toHaveBeenCalledWith(
-    expect.objectContaining<Partial<IsomorphicRequest>>({
-      credentials: 'omit',
-    }),
-    expect.any(XMLHttpRequest)
+    expect.objectContaining<Partial<HttpRequestEvent>>({
+      target: expect.any(XMLHttpRequest),
+      request: expect.objectContaining<Partial<IsomorphicRequest>>({
+        credentials: 'omit',
+      }),
+    })
   )
 })
 
@@ -326,9 +365,11 @@ test('sets "credentials" to "omit" on isomorphic request when "withCredentials" 
 
   expect(resolver).toHaveBeenCalledTimes(1)
   expect(resolver).toHaveBeenCalledWith(
-    expect.objectContaining<Partial<IsomorphicRequest>>({
-      credentials: 'omit',
-    }),
-    expect.any(XMLHttpRequest)
+    expect.objectContaining<Partial<HttpRequestEvent>>({
+      target: expect.any(XMLHttpRequest),
+      request: expect.objectContaining<Partial<IsomorphicRequest>>({
+        credentials: 'omit',
+      }),
+    })
   )
 })

--- a/test/modules/XMLHttpRequest/response/xhr.browser.runtime.js
+++ b/test/modules/XMLHttpRequest/response/xhr.browser.runtime.js
@@ -3,31 +3,31 @@ import { interceptXMLHttpRequest } from '@mswjs/interceptors/lib/interceptors/XM
 
 window.interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
-  resolver(request) {
+  resolver(event) {
     window.dispatchEvent(
       new CustomEvent('resolver', {
         detail: JSON.stringify({
-          id: request.id,
-          method: request.method,
-          url: request.url.href,
-          headers: request.headers.all(),
-          credentials: request.credentials,
-          body: request.body,
+          id: event.request.id,
+          method: event.request.method,
+          url: event.request.url.href,
+          headers: event.request.headers.all(),
+          credentials: event.request.credentials,
+          body: event.request.body,
         }),
       })
     )
 
     const { serverHttpUrl, serverHttpsUrl } = window
 
-    if ([serverHttpUrl, serverHttpsUrl].includes(request.url.href)) {
-      return {
+    if ([serverHttpUrl, serverHttpsUrl].includes(event.request.url.href)) {
+      event.respondWith({
         status: 201,
         statusText: 'Created',
         headers: {
           'Content-Type': 'application/hal+json',
         },
         body: JSON.stringify({ mocked: true }),
-      }
+      })
     }
   },
 })

--- a/test/modules/XMLHttpRequest/response/xhr.test.ts
+++ b/test/modules/XMLHttpRequest/response/xhr.test.ts
@@ -10,24 +10,26 @@ let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: [interceptXMLHttpRequest],
-  resolver(request) {
+  resolver(event) {
     const shouldMock =
       [httpServer.http.makeUrl(), httpServer.https.makeUrl()].includes(
-        request.url.href
-      ) || ['/login'].includes(request.url.pathname)
+        event.request.url.href
+      ) || ['/login'].includes(event.request.url.pathname)
 
     if (shouldMock) {
-      return {
+      event.respondWith({
         status: 301,
         statusText: 'Moved Permantently',
         headers: {
           'Content-Type': 'application/hal+json',
         },
         body: 'foo',
-      }
+      })
+
+      return
     }
 
-    if (request.url.href === 'https://error.me/') {
+    if (event.request.url.href === 'https://error.me/') {
       throw new Error('Custom exception message')
     }
   },

--- a/test/modules/fetch/intercept/fetch.body.runtime.js
+++ b/test/modules/fetch/intercept/fetch.body.runtime.js
@@ -3,8 +3,8 @@ import { interceptFetch } from '@mswjs/interceptors/lib/interceptors/fetch'
 
 const interceptor = createInterceptor({
   modules: [interceptFetch],
-  resolver(request) {
-    window.requestBody = request.body
+  resolver(event) {
+    window.requestBody = event.request.body
   },
 })
 

--- a/test/modules/fetch/intercept/fetch.browser.runtime.js
+++ b/test/modules/fetch/intercept/fetch.browser.runtime.js
@@ -3,16 +3,16 @@ import { interceptFetch } from '@mswjs/interceptors/lib/interceptors/fetch'
 
 const interceptor = createInterceptor({
   modules: [interceptFetch],
-  resolver(request) {
+  resolver(event) {
     window.dispatchEvent(
       new CustomEvent('resolver', {
         detail: JSON.stringify({
-          id: request.id,
-          method: request.method,
-          url: request.url.href,
-          headers: request.headers.all(),
-          credentials: request.credentials,
-          body: request.body,
+          id: event.request.id,
+          method: event.request.method,
+          url: event.request.url.href,
+          headers: event.request.headers.all(),
+          credentials: event.request.credentials,
+          body: event.request.body,
         }),
       })
     )

--- a/test/modules/fetch/intercept/fetch.request.test.ts
+++ b/test/modules/fetch/intercept/fetch.request.test.ts
@@ -53,8 +53,10 @@ test('intercepts fetch requests constructed via a "Request" instance', async () 
   expect(await res.text()).toEqual('mocked')
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'POST',
       url: new URL(httpServer.http.makeUrl('/user')),
@@ -65,6 +67,7 @@ test('intercepts fetch requests constructed via a "Request" instance', async () 
       credentials: 'same-origin',
       body: 'hello world',
     },
-    expect.any(http.IncomingMessage)
-  )
+    timeStamp: expect.any(Number),
+    respondWith: expect.any(Function),
+  })
 })

--- a/test/modules/fetch/intercept/fetch.test.ts
+++ b/test/modules/fetch/intercept/fetch.test.ts
@@ -52,8 +52,10 @@ test('intercepts an HTTP HEAD request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'HEAD',
       url: new URL(httpServer.http.makeUrl('/user?id=123')),
@@ -63,8 +65,9 @@ test('intercepts an HTTP HEAD request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an HTTP GET request', async () => {
@@ -75,8 +78,10 @@ test('intercepts an HTTP GET request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'GET',
       url: new URL(httpServer.http.makeUrl('/user?id=123')),
@@ -86,8 +91,9 @@ test('intercepts an HTTP GET request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an HTTP POST request', async () => {
@@ -100,20 +106,22 @@ test('intercepts an HTTP POST request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'POST',
       url: new URL(httpServer.http.makeUrl('/user?id=123')),
       headers: headersContaining({
-        accept: '*/*',
         'x-custom-header': 'yes',
       }),
       credentials: 'same-origin',
       body: JSON.stringify({ body: true }),
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an HTTP PUT request', async () => {
@@ -122,12 +130,14 @@ test('intercepts an HTTP PUT request', async () => {
     headers: {
       'x-custom-header': 'yes',
     },
-    body: 'request-payload',
+    body: 'put-payload',
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'PUT',
       url: new URL(httpServer.http.makeUrl('/user?id=123')),
@@ -135,10 +145,11 @@ test('intercepts an HTTP PUT request', async () => {
         'x-custom-header': 'yes',
       }),
       credentials: 'same-origin',
-      body: 'request-payload',
+      body: 'put-payload',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an HTTP DELETE request', async () => {
@@ -150,8 +161,10 @@ test('intercepts an HTTP DELETE request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'DELETE',
       url: new URL(httpServer.http.makeUrl('/user?id=123')),
@@ -161,8 +174,9 @@ test('intercepts an HTTP DELETE request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an HTTP PATCH request', async () => {
@@ -171,12 +185,14 @@ test('intercepts an HTTP PATCH request', async () => {
     headers: {
       'x-custom-header': 'yes',
     },
-    body: 'request-payload',
+    body: 'patch-payload',
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'PATCH',
       url: new URL(httpServer.http.makeUrl('/user?id=123')),
@@ -184,10 +200,11 @@ test('intercepts an HTTP PATCH request', async () => {
         'x-custom-header': 'yes',
       }),
       credentials: 'same-origin',
-      body: 'request-payload',
+      body: 'patch-payload',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an HTTPS HEAD request', async () => {
@@ -200,8 +217,10 @@ test('intercepts an HTTPS HEAD request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'HEAD',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -211,8 +230,9 @@ test('intercepts an HTTPS HEAD request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an HTTPS GET request', async () => {
@@ -224,8 +244,10 @@ test('intercepts an HTTPS GET request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'GET',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -235,8 +257,9 @@ test('intercepts an HTTPS GET request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an HTTPS POST request', async () => {
@@ -250,8 +273,10 @@ test('intercepts an HTTPS POST request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'POST',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -261,8 +286,9 @@ test('intercepts an HTTPS POST request', async () => {
       credentials: 'same-origin',
       body: JSON.stringify({ body: true }),
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an HTTPS PUT request', async () => {
@@ -272,12 +298,14 @@ test('intercepts an HTTPS PUT request', async () => {
     headers: {
       'x-custom-header': 'yes',
     },
-    body: 'request-payload',
+    body: 'put-payload',
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'PUT',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -285,10 +313,11 @@ test('intercepts an HTTPS PUT request', async () => {
         'x-custom-header': 'yes',
       }),
       credentials: 'same-origin',
-      body: 'request-payload',
+      body: 'put-payload',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an HTTPS DELETE request', async () => {
@@ -301,8 +330,10 @@ test('intercepts an HTTPS DELETE request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'DELETE',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -312,8 +343,9 @@ test('intercepts an HTTPS DELETE request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an HTTPS PATCH request', async () => {
@@ -326,8 +358,10 @@ test('intercepts an HTTPS PATCH request', async () => {
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'PATCH',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -337,6 +371,7 @@ test('intercepts an HTTPS PATCH request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })

--- a/test/modules/fetch/response/fetch.browser.runtime.js
+++ b/test/modules/fetch/response/fetch.browser.runtime.js
@@ -3,17 +3,17 @@ import { interceptFetch } from '@mswjs/interceptors/lib/interceptors/fetch'
 
 window.interceptor = createInterceptor({
   modules: [interceptFetch],
-  resolver(request) {
+  resolver(event) {
     const { serverHttpUrl, serverHttpsUrl } = window
 
-    if ([serverHttpUrl, serverHttpsUrl].includes(request.url.href)) {
-      return {
+    if ([serverHttpUrl, serverHttpsUrl].includes(event.request.url.href)) {
+      event.respondWith({
         status: 201,
         headers: {
           'Content-Type': 'application/hal+json',
         },
         body: JSON.stringify({ mocked: true }),
-      }
+      })
     }
   },
 })

--- a/test/modules/fetch/response/fetch.test.ts
+++ b/test/modules/fetch/response/fetch.test.ts
@@ -10,19 +10,19 @@ let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: nodeInterceptors,
-  resolver(request) {
+  resolver(event) {
     if (
       [httpServer.http.makeUrl(), httpServer.https.makeUrl()].includes(
-        request.url.href
+        event.request.url.href
       )
     ) {
-      return {
+      event.respondWith({
         status: 201,
         headers: {
           'Content-Type': 'application/hal+json',
         },
         body: JSON.stringify({ mocked: true }),
-      }
+      })
     }
   },
 })

--- a/test/modules/http/compliance/http-rate-limit.test.ts
+++ b/test/modules/http/compliance/http-rate-limit.test.ts
@@ -7,16 +7,18 @@ import { interceptClientRequest } from '../../../../src/interceptors/ClientReque
 let httpServer: ServerApi
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
-  resolver(req) {
-    if (!req.url.searchParams.has('mock')) {
+  resolver(event) {
+    const { request } = event
+
+    if (!request.url.searchParams.has('mock')) {
       return
     }
 
-    return {
+    event.respondWith({
       status: 403,
       statusText: 'Forbidden',
       body: 'mocked-body',
-    }
+    })
   },
 })
 

--- a/test/modules/http/compliance/http-req-callback.test.ts
+++ b/test/modules/http/compliance/http-req-callback.test.ts
@@ -12,16 +12,18 @@ let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
-  resolver(req) {
-    if ([httpServer.https.makeUrl('/get')].includes(req.url.href)) {
+  resolver(event) {
+    const { request } = event
+
+    if ([httpServer.https.makeUrl('/get')].includes(request.url.href)) {
       return
     }
 
-    return {
+    event.respondWith({
       status: 403,
       statusText: 'Forbidden',
       body: 'mocked-body',
-    }
+    })
   },
 })
 

--- a/test/modules/http/compliance/http-req-write.test.ts
+++ b/test/modules/http/compliance/http-req-write.test.ts
@@ -14,8 +14,8 @@ let httpServer: ServerApi
 const interceptedRequestBody = jest.fn()
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
-  resolver(req) {
-    interceptedRequestBody(req.body)
+  resolver(event) {
+    interceptedRequestBody(event.request.body)
   },
 })
 

--- a/test/modules/http/compliance/http-res-set-encoding.test.ts
+++ b/test/modules/http/compliance/http-res-set-encoding.test.ts
@@ -9,18 +9,20 @@ import { interceptClientRequest } from '../../../../src/interceptors/ClientReque
 let httpServer: ServerApi
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
-  resolver(req) {
-    if (!req.url.searchParams.has('mock')) {
+  resolver(event) {
+    const { request } = event
+
+    if (!request.url.searchParams.has('mock')) {
       return
     }
 
-    return {
+    event.respondWith({
       status: 200,
       headers: {
         'Content-Type': 'text/plain',
       },
       body: 'hello world',
-    }
+    })
   },
 })
 

--- a/test/modules/http/http-performance.test.ts
+++ b/test/modules/http/http-performance.test.ts
@@ -27,13 +27,16 @@ function parallelRequests(
 let httpServer: ServerApi
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
-  resolver(req) {
-    if (req.url.pathname.startsWith('/user')) {
-      const id = req.url.searchParams.get('id')
-      return {
+  resolver(event) {
+    const { request } = event
+
+    if (request.url.pathname.startsWith('/user')) {
+      const id = request.url.searchParams.get('id')
+
+      event.respondWith({
         status: 200,
         body: `mocked ${id}`,
-      }
+      })
     }
   },
 })

--- a/test/modules/http/intercept/http.get.test.ts
+++ b/test/modules/http/intercept/http.get.test.ts
@@ -45,8 +45,10 @@ test('intercepts an http.get request', async () => {
   const { text } = await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'GET',
       url: new URL(url),
@@ -56,8 +58,9 @@ test('intercepts an http.get request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
   expect(await text()).toEqual('user-body')
 })
 
@@ -72,8 +75,10 @@ test('intercepts an http.get request given RequestOptions without a protocol', a
   const { text } = await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'GET',
       url: new URL(httpServer.http.makeUrl('/user?id=123')),
@@ -81,7 +86,8 @@ test('intercepts an http.get request given RequestOptions without a protocol', a
       credentials: 'same-origin',
       body: '',
     },
-    expect.anything()
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
   expect(await text()).toEqual('user-body')
 })

--- a/test/modules/http/intercept/http.request.test.ts
+++ b/test/modules/http/intercept/http.request.test.ts
@@ -54,8 +54,10 @@ test('intercepts a HEAD request', async () => {
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       url: new URL(url),
       method: 'HEAD',
@@ -65,8 +67,9 @@ test('intercepts a HEAD request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts a GET request', async () => {
@@ -81,8 +84,10 @@ test('intercepts a GET request', async () => {
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'GET',
       url: new URL(url),
@@ -92,8 +97,9 @@ test('intercepts a GET request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts a POST request', async () => {
@@ -109,8 +115,10 @@ test('intercepts a POST request', async () => {
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'POST',
       url: new URL(url),
@@ -120,8 +128,9 @@ test('intercepts a POST request', async () => {
       credentials: 'same-origin',
       body: 'post-payload',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts a PUT request', async () => {
@@ -137,8 +146,10 @@ test('intercepts a PUT request', async () => {
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'PUT',
       url: new URL(url),
@@ -148,8 +159,9 @@ test('intercepts a PUT request', async () => {
       credentials: 'same-origin',
       body: 'put-payload',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts a PATCH request', async () => {
@@ -165,8 +177,10 @@ test('intercepts a PATCH request', async () => {
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'PATCH',
       url: new URL(url),
@@ -176,8 +190,9 @@ test('intercepts a PATCH request', async () => {
       credentials: 'same-origin',
       body: 'patch-payload',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts a DELETE request', async () => {
@@ -192,8 +207,10 @@ test('intercepts a DELETE request', async () => {
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'DELETE',
       url: new URL(url),
@@ -203,8 +220,9 @@ test('intercepts a DELETE request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an http.request given RequestOptions without a protocol', async () => {
@@ -220,8 +238,10 @@ test('intercepts an http.request given RequestOptions without a protocol', async
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'GET',
       url: new URL(httpServer.http.makeUrl('/user?id=123')),
@@ -229,6 +249,7 @@ test('intercepts an http.request given RequestOptions without a protocol', async
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })

--- a/test/modules/http/intercept/https.get.test.ts
+++ b/test/modules/http/intercept/https.get.test.ts
@@ -48,8 +48,10 @@ test('intercepts a GET request', async () => {
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'GET',
       url: new URL(url),
@@ -59,8 +61,9 @@ test('intercepts a GET request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an https.get request given RequestOptions without a protocol', async () => {
@@ -76,8 +79,10 @@ test('intercepts an https.get request given RequestOptions without a protocol', 
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'GET',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -85,6 +90,7 @@ test('intercepts an https.get request given RequestOptions without a protocol', 
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })

--- a/test/modules/http/intercept/https.request.test.ts
+++ b/test/modules/http/intercept/https.request.test.ts
@@ -58,8 +58,10 @@ test('intercepts a HEAD request', async () => {
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'HEAD',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -69,8 +71,9 @@ test('intercepts a HEAD request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts a GET request', async () => {
@@ -86,8 +89,10 @@ test('intercepts a GET request', async () => {
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'GET',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -97,8 +102,9 @@ test('intercepts a GET request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts a POST request', async () => {
@@ -115,8 +121,10 @@ test('intercepts a POST request', async () => {
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'POST',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -126,8 +134,9 @@ test('intercepts a POST request', async () => {
       credentials: 'same-origin',
       body: 'post-payload',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts a PUT request', async () => {
@@ -144,8 +153,10 @@ test('intercepts a PUT request', async () => {
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'PUT',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -155,8 +166,9 @@ test('intercepts a PUT request', async () => {
       credentials: 'same-origin',
       body: 'put-payload',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts a PATCH request', async () => {
@@ -173,8 +185,10 @@ test('intercepts a PATCH request', async () => {
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'PATCH',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -184,8 +198,9 @@ test('intercepts a PATCH request', async () => {
       credentials: 'same-origin',
       body: 'patch-payload',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts a DELETE request', async () => {
@@ -201,8 +216,10 @@ test('intercepts a DELETE request', async () => {
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'DELETE',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -212,8 +229,9 @@ test('intercepts a DELETE request', async () => {
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })
 
 test('intercepts an http.request request given RequestOptions without a protocol', async () => {
@@ -227,8 +245,10 @@ test('intercepts an http.request request given RequestOptions without a protocol
   await waitForClientRequest(req)
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>(
-    {
+  expect(resolver).toHaveBeenCalledWith<Parameters<Resolver>>({
+    source: 'http',
+    target: expect.any(http.IncomingMessage),
+    request: {
       id: anyUuid(),
       method: 'GET',
       url: new URL(httpServer.https.makeUrl('/user?id=123')),
@@ -236,6 +256,7 @@ test('intercepts an http.request request given RequestOptions without a protocol
       credentials: 'same-origin',
       body: '',
     },
-    expect.any(http.IncomingMessage)
-  )
+    respondWith: expect.any(Function),
+    timeStamp: expect.any(Number),
+  })
 })

--- a/test/modules/http/regressions/http-concurrent-different-response-source.test.ts
+++ b/test/modules/http/regressions/http-concurrent-different-response-source.test.ts
@@ -10,18 +10,18 @@ let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
-  async resolver(request) {
+  async resolver(event) {
+    const { request } = event
+
     if (request.headers.get('x-bypass')) {
       return
     }
 
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve({
-          status: 201,
-          body: 'mocked-response',
-        })
-      }, 250)
+    await new Promise((resolve) => setTimeout(resolve, 250))
+
+    event.respondWith({
+      status: 201,
+      body: 'mocked-response',
     })
   },
 })

--- a/test/modules/http/regressions/http-concurrent-same-host.test.ts
+++ b/test/modules/http/regressions/http-concurrent-same-host.test.ts
@@ -10,11 +10,13 @@ let requests: IsomorphicRequest[] = []
 
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
-  resolver(request) {
+  resolver(event) {
+    const { request } = event
     requests.push(request)
-    return {
+
+    event.respondWith({
       status: 200,
-    }
+    })
   },
 })
 

--- a/test/modules/http/regressions/http-socket-timeout.ts
+++ b/test/modules/http/regressions/http-socket-timeout.ts
@@ -13,11 +13,11 @@ jest.setTimeout(5000)
 
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
-  resolver() {
-    return {
+  resolver(event) {
+    event.respondWith({
       status: 301,
       body: 'Hello world',
-    }
+    })
   },
 })
 

--- a/test/modules/http/response/http-https.test.ts
+++ b/test/modules/http/response/http-https.test.ts
@@ -12,16 +12,20 @@ let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
-  resolver(request) {
+  async resolver(event) {
+    const { request } = event
+
     if (request.url.pathname === '/non-existing') {
-      return {
+      event.respondWith({
         status: 301,
         statusText: 'Moved Permanently',
         headers: {
           'Content-Type': 'text/plain',
         },
         body: 'mocked',
-      }
+      })
+
+      return
     }
 
     if (request.url.href === 'http://error.me/') {

--- a/test/third-party/axios.test.ts
+++ b/test/third-party/axios.test.ts
@@ -10,9 +10,9 @@ let httpServer: ServerApi
 
 const interceptor = createInterceptor({
   modules: nodeInterceptors,
-  resolver(request) {
-    if (request.url.pathname === '/user') {
-      return {
+  resolver(event) {
+    if (event.request.url.pathname === '/user') {
+      event.respondWith({
         status: 200,
         headers: {
           'content-type': 'application/json',
@@ -21,7 +21,7 @@ const interceptor = createInterceptor({
         body: JSON.stringify({
           mocked: true,
         }),
-      }
+      })
     }
   },
 })

--- a/test/third-party/got.test.ts
+++ b/test/third-party/got.test.ts
@@ -9,12 +9,12 @@ import { interceptClientRequest } from '../../src/interceptors/ClientRequest'
 let httpServer: ServerApi
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
-  resolver(request) {
-    if (request.url.toString() === httpServer.http.makeUrl('/test')) {
-      return {
+  resolver(event) {
+    if (event.request.url.toString() === httpServer.http.makeUrl('/test')) {
+      event.respondWith({
         status: 200,
         body: 'mocked-body',
-      }
+      })
     }
   },
 })

--- a/test/third-party/supertest.test.ts
+++ b/test/third-party/supertest.test.ts
@@ -11,8 +11,8 @@ let requests: IsomorphicRequest[] = []
 
 const interceptor = createInterceptor({
   modules: [interceptClientRequest],
-  resolver(req) {
-    requests.push(req)
+  resolver(event) {
+    requests.push(event.request)
   },
 })
 


### PR DESCRIPTION
> Behold, breaking changes.

- Prerequisite for https://github.com/mswjs/msw/pull/396

## Changes

- Migrates to the event-driven model of request interception.

## Roadmap

- [x] Fix the `remote` test.
- [ ] Review the event model in the context of WebSocket interceptor.