### PR TITLE
feat(xmlhttprequestoverride): add a stub addEventListener method to t…

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -138,7 +138,7 @@ export const createXMLHttpRequestOverride = (
       this.responseText = ''
       this.responseXML = null
       this.responseURL = ''
-      this.upload = {} as any
+      this.upload = { addEventListener: () => {} } as any
       this.timeout = 0
 
       this._requestHeaders = new Headers()


### PR DESCRIPTION
This change enables unit tests that require integration with code that adds an event listener to the upload function. 

As an illustrative example, the Uppy file upload library has an XHR uploader plugin that adds event listeners to `upload` events. If the `addEventListener` stub is not included, then Uppy cannot function properly in a MSW-mocked environment.