### PR TITLE
fix: export "Interceptor", "BatchInterceptor" classes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export * from './glossary'
+export * from './Interceptor'
+export * from './BatchInterceptor'
 export * from './RemoteInterceptor'
 
 /* Utils */


### PR DESCRIPTION
The main classes of the libraries were not exported after the recent refactor. 