### PR TITLE
fix(BatchInterceptor): remove listeners between fast refresh

### DIFF
--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -21,7 +21,6 @@ import { getIncomingMessageBody } from './utils/getIncomingMessageBody'
 import { bodyBufferToString } from './utils/bodyBufferToString'
 import {
   ClientRequestWriteArgs,
-  ClientRequestWriteCallback,
   normalizeClientRequestWriteArgs,
 } from './utils/normalizeClientRequestWriteArgs'
 import { cloneIncomingMessage } from './utils/cloneIncomingMessage'

--- a/src/utils/AsyncEventEmitter.test.ts
+++ b/src/utils/AsyncEventEmitter.test.ts
@@ -99,3 +99,39 @@ it('does not emit events once the emitter was deactivated', () => {
 
   expect(listener).not.toHaveBeenCalled()
 })
+
+describe('pruneListeners', () => {
+  it('prunes listeners for the given event name', () => {
+    const emitter = new AsyncEventEmitter<{ ping(): void; pong(): void }>()
+
+    emitter.on('ping', () => {})
+    emitter.on('ping', () => {})
+    emitter.on('pong', () => {})
+
+    emitter.pruneListeners('ping')
+
+    expect(emitter.listenerCount('ping')).toBe(0)
+    expect(emitter.listeners('ping')).toEqual([])
+    expect(emitter['_events']).toHaveProperty('ping', [])
+
+    expect(emitter.listenerCount('pong')).toBe(1)
+    expect(emitter.listeners('pong')).toHaveLength(1)
+  })
+
+  it('prunes all listeners', () => {
+    const emitter = new AsyncEventEmitter<{ ping(): void; pong(): void }>()
+
+    emitter.on('ping', () => {})
+    emitter.on('pong', () => {})
+
+    emitter.pruneListeners()
+
+    expect(emitter.listenerCount('ping')).toBe(0)
+    expect(emitter.listeners('ping')).toEqual([])
+
+    expect(emitter.listenerCount('pong')).toBe(0)
+    expect(emitter.listeners('pong')).toEqual([])
+
+    expect(emitter['_events']).toEqual({})
+  })
+})

--- a/src/utils/AsyncEventEmitter.ts
+++ b/src/utils/AsyncEventEmitter.ts
@@ -213,6 +213,7 @@ export class AsyncEventEmitter<
   ): void {
     if (event) {
       this._events[event] = []
+      return
     }
 
     this._events = {} as InternalEventMap<EventMap>


### PR DESCRIPTION
- Fixes https://github.com/mswjs/msw/issues/1271

## Changes

- Batch interceptor now prunes any existing listeners from the child interceptors. Such listeners may persist between fast refresh, causing the same request to be handled multiple times.
- This adds support to run interceptors in modern apps that use HMR (Fast Refresh). 

## Roadmap

- [ ] Ensure this also works for isolated interceptor usage (not batched). 
- [ ] Mention that you cannot attach listeners to interceptors if you then pass those interceptors to a `BatchInterceptor`. Always attach listeners to the batch interceptor. Maybe because of this accept class references and not instances? 