### PR TITLE
fix: support 0 as an explicit status code

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -304,7 +304,7 @@ export const createXMLHttpRequestOverride = (
           // Trigger a loadstart event to indicate the initialization of the fetch.
           this.trigger('loadstart')
 
-          this.status = mockedResponse.status || 200
+          this.status = mockedResponse.status ?? 200
           this.statusText = mockedResponse.statusText || 'OK'
           this._responseHeaders = mockedResponse.headers
             ? objectToHeaders(mockedResponse.headers)

--- a/src/utils/toIsoResponse.ts
+++ b/src/utils/toIsoResponse.ts
@@ -6,7 +6,7 @@ import { IsomorphicResponse, MockedResponse } from '../glossary'
  */
 export function toIsoResponse(response: MockedResponse): IsomorphicResponse {
   return {
-    status: response.status || 200,
+    status: response.status ?? 200,
     statusText: response.statusText || 'OK',
     headers: objectToHeaders(response.headers || {}),
     body: response.body,


### PR DESCRIPTION
Bumped into this in MSW, setting `ctx.status(0)` results in a `200` status in the mocked response. Guessing this change will more closely match the intent of the code since `status` is a `number`?