### PR TITLE
docs: add "new" to BatchInterceptor calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ import { BatchInterceptor } from '@mswjs/interceptors'
 import { ClientRequestInterceptor } from '@mswjs/interceptors/lib/interceptors/ClientRequest'
 import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/lib/interceptors/XMLHttpRequest'
 
-const interceptor = BatchInterceptor({
+const interceptor = new BatchInterceptor({
   name: 'my-interceptor',
   interceptors: [
     new ClientRequestInterceptor(),
@@ -175,7 +175,7 @@ This preset combines `ClientRequestInterceptor`, `XMLHttpRequestInterceptor` and
 import { BatchInterceptor } from '@mswjs/interceptors'
 import nodeInterceptors from '@mswjs/interceptors/lib/presets/node'
 
-const interceptor = BatchInterceptor({
+const interceptor = new BatchInterceptor({
   name: 'my-interceptor',
   interceptors: nodeInterceptors,
 })
@@ -193,7 +193,7 @@ This preset combines `XMLHttpRequestInterceptor` and `FetchInterceptor` and is m
 import { BatchInterceptor } from '@mswjs/interceptors'
 import browserInterceptors from '@mswjs/interceptors/lib/presets/browser'
 
-const interceptor = BatchInterceptor({
+const interceptor = new BatchInterceptor({
   name: 'my-interceptor',
   interceptors: browserInterceptors,
 })
@@ -303,7 +303,7 @@ Applies multiple request interceptors at the same time.
 import { BatchInterceptor } from '@mswjs/interceptors'
 import nodeInterceptors from '@mswjs/interceptors/lib/presets/node'
 
-const interceptor = BatchInterceptor({
+const interceptor = new BatchInterceptor({
   name: 'my-interceptor',
   interceptors: nodeInterceptors,
 })


### PR DESCRIPTION
Without this `this` isn't defined.