### PR TITLE
fix(xhr): removes @xmldom/xmldom, uses native DOMParser

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@open-draft/until": "^1.0.3",
     "@remix-run/web-fetch": "^4.3.1",
     "@types/debug": "^4.1.7",
-    "@xmldom/xmldom": "^0.8.3",
     "debug": "^4.3.3",
     "headers-polyfill": "^3.1.0",
     "outvariant": "^1.2.1",

--- a/src/interceptors/XMLHttpRequest/utils/isDomParserSupportedType.ts
+++ b/src/interceptors/XMLHttpRequest/utils/isDomParserSupportedType.ts
@@ -1,0 +1,14 @@
+export function isDomParserSupportedType(
+  type: string
+): type is DOMParserSupportedType {
+  const supportedTypes: Array<DOMParserSupportedType> = [
+    'application/xhtml+xml',
+    'application/xml',
+    'image/svg+xml',
+    'text/html',
+    'text/xml',
+  ]
+  return supportedTypes.some((supportedType) => {
+    return type.startsWith(supportedType)
+  })
+}

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-body-xml.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-body-xml.test.ts
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { Response } from '@remix-run/web-fetch'
-import { DOMParser } from '@xmldom/xmldom'
 import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
 import { createXMLHttpRequest } from '../../../helpers'
 
@@ -28,12 +27,12 @@ describe('Content-Type: application/xml', () => {
   })
 
   test('supports a mocked response with an XML response body', async () => {
-    const req = await createXMLHttpRequest((req) => {
-      req.open('GET', '/arbitrary-url')
-      req.send()
+    const request = await createXMLHttpRequest((request) => {
+      request.open('GET', '/arbitrary-url')
+      request.send()
     })
 
-    expect(req.responseXML).toStrictEqual(
+    expect(request.responseXML).toStrictEqual(
       new DOMParser().parseFromString(XML_STRING, 'application/xml')
     )
   })
@@ -59,12 +58,12 @@ describe('Content-Type: text/xml', () => {
   })
 
   test('supports a mocked response with an XML response body', async () => {
-    const req = await createXMLHttpRequest((req) => {
-      req.open('GET', '/arbitrary-url')
-      req.send()
+    const request = await createXMLHttpRequest((request) => {
+      request.open('GET', '/arbitrary-url')
+      request.send()
     })
 
-    expect(req.responseXML).toStrictEqual(
+    expect(request.responseXML).toStrictEqual(
       new DOMParser().parseFromString(XML_STRING, 'text/xml')
     )
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1516,11 +1516,6 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@xmldom/xmldom@^0.8.3":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.5.tgz#7f4b797cfda39355b512b4cfcc66b49b5d93d5f3"
-  integrity sha512-0dpjDLeCXYThL2YhqZcd/spuwoH+dmnFoND9ZxZkAYxp1IJUB2GP16ow2MJRsjVxy8j1Qv8BJRmN5GKnbDKCmQ==
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
- Closes #297 

## Changes

- `req.responseXML` will not rely on the native (global) `DOMParser`. It's present in the browser and it must be polyfilled in browser-like environments for XHR to work. 