### PR TITLE
feat: change "IDLE" ready state to "INACTIVE"

### DIFF
--- a/src/Interceptor.test.ts
+++ b/src/Interceptor.test.ts
@@ -36,12 +36,12 @@ describe('persistence', () => {
 })
 
 describe('readyState', () => {
-  it('sets the state to "IDLE" when the interceptor is created', () => {
+  it('sets the state to "INACTIVE" when the interceptor is created', () => {
     const interceptor = new Interceptor(symbol)
-    expect(interceptor.readyState).toBe(InterceptorReadyState.IDLE)
+    expect(interceptor.readyState).toBe(InterceptorReadyState.INACTIVE)
   })
 
-  it('leaves state as "IDLE" if the interceptor failed the environment check', async () => {
+  it('leaves state as "INACTIVE" if the interceptor failed the environment check', async () => {
     class MyInterceptor extends Interceptor<any> {
       protected checkEnvironment(): boolean {
         return false
@@ -50,10 +50,10 @@ describe('readyState', () => {
     const interceptor = new MyInterceptor(symbol)
     interceptor.apply()
 
-    expect(interceptor.readyState).toBe(InterceptorReadyState.IDLE)
+    expect(interceptor.readyState).toBe(InterceptorReadyState.INACTIVE)
 
     await nextTickAsync(() => {
-      expect(interceptor.readyState).toBe(InterceptorReadyState.IDLE)
+      expect(interceptor.readyState).toBe(InterceptorReadyState.INACTIVE)
     })
   })
 

--- a/src/Interceptor.ts
+++ b/src/Interceptor.ts
@@ -23,7 +23,7 @@ export function deleteGlobalSymbol(symbol: Symbol): void {
 }
 
 export enum InterceptorReadyState {
-  IDLE = 'IDLE',
+  INACTIVE = 'INACTIVE',
   APPLYING = 'APPLYING',
   APPLIED = 'APPLIED',
   DISPOSING = 'DISPOSING',
@@ -41,7 +41,7 @@ export class Interceptor<EventMap extends InterceptorEventMap> {
   public readyState: InterceptorReadyState
 
   constructor(private readonly symbol: Symbol) {
-    this.readyState = InterceptorReadyState.IDLE
+    this.readyState = InterceptorReadyState.INACTIVE
 
     this.emitter = new AsyncEventEmitter()
     this.subscriptions = []


### PR DESCRIPTION
`readyState` is a public property, thus a breaking change. 

- Fixes #302 