### PR TITLE
fix(fetch): remove internal `console.log` statement

### DIFF
--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -80,8 +80,6 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
 
       this.log('no mocked response received!')
 
-      console.log('or req headers', Array.from(request.headers.entries()))
-
       return pureFetch(request).then((response) => {
         const responseClone = response.clone() as ResponsePolyfill
         this.log('original fetch performed', responseClone)


### PR DESCRIPTION
Useless information, polluting the console