### PR TITLE
fix(xhr): do not pass response `Content-Encoding` to `TextDecoder`

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts
@@ -483,11 +483,7 @@ export const createXMLHttpRequestOverride = (
     public get responseText(): string {
       this.log('responseText()')
 
-      const encoding = this.getResponseHeader('Content-Encoding') as
-        | BufferEncoding
-        | undefined
-
-      return decodeBuffer(this._responseBuffer, encoding || undefined)
+      return decodeBuffer(this._responseBuffer)
     }
 
     public get response(): unknown {

--- a/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.browser.test.ts
+++ b/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.browser.test.ts
@@ -7,7 +7,6 @@ import { HttpServer } from '@open-draft/test-server/http'
 import { RequestHandler } from 'express-serve-static-core'
 import { createBrowserXMLHttpRequest, XMLHttpResponse } from '../../../helpers'
 import { headersContaining } from '../../../jest.expect'
-import zlib from 'zlib'
 
 const httpServer = new HttpServer((app) => {
   const requestHandler: RequestHandler = (_req, res) => {
@@ -16,15 +15,6 @@ const httpServer = new HttpServer((app) => {
 
   app.get('/user', requestHandler)
   app.post('/user', requestHandler)
-
-  const handleCompressedRequest: RequestHandler = (_req, res) => {
-    res
-      .status(200)
-      .setHeader("Content-Encoding", "gzip")
-      .send(zlib.gzipSync(Buffer.from('compressed-body'))).end()
-  }
-
-  app.get('/compressed', handleCompressedRequest)
 })
 
 function prepareRuntime() {
@@ -64,28 +54,6 @@ test('intercepts an HTTP GET request', async () => {
     statusText: 'OK',
     headers: headersContaining({}),
     body: 'user-body',
-  })
-})
-
-test('intercepts a compressed HTTP GET request', async () => {
-  const context = await prepareRuntime()
-  const callXMLHttpRequest = createBrowserXMLHttpRequest(context)
-  const url = httpServer.http.url('/compressed')
-  const [request, response] = await callXMLHttpRequest({
-    method: 'GET',
-    url,
-  })
-
-  expect(request.method).toBe('GET')
-  expect(request.url).toBe(url)
-  expect(request.credentials).toBe('omit')
-  expect(request.body).toBe(null)
-
-  expect(response).toEqual<XMLHttpResponse>({
-    status: 200,
-    statusText: 'OK',
-    headers: headersContaining({}),
-    body: 'compressed-body',
   })
 })
 

--- a/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.browser.test.ts
+++ b/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.browser.test.ts
@@ -7,6 +7,7 @@ import { HttpServer } from '@open-draft/test-server/http'
 import { RequestHandler } from 'express-serve-static-core'
 import { createBrowserXMLHttpRequest, XMLHttpResponse } from '../../../helpers'
 import { headersContaining } from '../../../jest.expect'
+import zlib from 'zlib'
 
 const httpServer = new HttpServer((app) => {
   const requestHandler: RequestHandler = (_req, res) => {
@@ -15,6 +16,15 @@ const httpServer = new HttpServer((app) => {
 
   app.get('/user', requestHandler)
   app.post('/user', requestHandler)
+
+  const handleCompressedRequest: RequestHandler = (_req, res) => {
+    res
+      .status(200)
+      .setHeader("Content-Encoding", "gzip")
+      .send(zlib.gzipSync(Buffer.from('compressed-body'))).end()
+  }
+
+  app.get('/compressed', handleCompressedRequest)
 })
 
 function prepareRuntime() {
@@ -54,6 +64,28 @@ test('intercepts an HTTP GET request', async () => {
     statusText: 'OK',
     headers: headersContaining({}),
     body: 'user-body',
+  })
+})
+
+test('intercepts a compressed HTTP GET request', async () => {
+  const context = await prepareRuntime()
+  const callXMLHttpRequest = createBrowserXMLHttpRequest(context)
+  const url = httpServer.http.url('/compressed')
+  const [request, response] = await callXMLHttpRequest({
+    method: 'GET',
+    url,
+  })
+
+  expect(request.method).toBe('GET')
+  expect(request.url).toBe(url)
+  expect(request.credentials).toBe('omit')
+  expect(request.body).toBe(null)
+
+  expect(response).toEqual<XMLHttpResponse>({
+    status: 200,
+    statusText: 'OK',
+    headers: headersContaining({}),
+    body: 'compressed-body',
   })
 })
 

--- a/test/modules/XMLHttpRequest/regressions/xhr-compressed-response.browser.test.ts
+++ b/test/modules/XMLHttpRequest/regressions/xhr-compressed-response.browser.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment node
+ * @see https://github.com/mswjs/interceptors/issues/308
+ */
+import { HttpServer } from '@open-draft/test-server/http'
+import { pageWith } from 'page-with'
+import zlib from 'zlib'
+import { createBrowserXMLHttpRequest, XMLHttpResponse } from '../../../helpers'
+import { anyUuid, headersContaining } from '../../../jest.expect'
+
+const httpServer = new HttpServer((app) => {
+  app.get('/compressed', (_req, res) => {
+    res
+      .status(200)
+      .set('Content-Encoding', 'gzip')
+      .send(zlib.gzipSync(Buffer.from('compressed-body')))
+  })
+})
+
+beforeAll(async () => {
+  await httpServer.listen()
+})
+
+afterAll(async () => {
+  await httpServer.close()
+})
+
+test('intercepts a compressed HTTP request', async () => {
+  const context = await pageWith({
+    example: require.resolve('../intercept/XMLHttpRequest.browser.runtime.js'),
+  })
+
+  const pageErrorCallback = jest.fn()
+  context.page.on('pageerror', pageErrorCallback).on('console', (message) => {
+    if (message.type() === 'error') {
+      pageErrorCallback(message.text())
+    }
+  })
+
+  const callXMLHttpRequest = createBrowserXMLHttpRequest(context)
+  const url = httpServer.http.url('/compressed')
+  const [, response] = await callXMLHttpRequest({
+    method: 'GET',
+    url,
+  })
+
+  expect(response).toEqual<XMLHttpResponse>({
+    status: 200,
+    statusText: 'OK',
+    headers: headersContaining({}),
+    body: 'compressed-body',
+  })
+
+  // Playwright prints console errors on the next tick.
+  await context.page.waitForTimeout(0)
+  expect(pageErrorCallback).not.toHaveBeenCalled()
+})

--- a/test/modules/XMLHttpRequest/regressions/xhr-compressed-response.test.ts
+++ b/test/modules/XMLHttpRequest/regressions/xhr-compressed-response.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ * @see https://github.com/mswjs/interceptors/issues/308
+ */
+import { HttpServer } from '@open-draft/test-server/http'
+import zlib from 'zlib'
+import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
+import { createXMLHttpRequest } from '../../../helpers'
+
+const httpServer = new HttpServer((app) => {
+  app.get('/compressed', (_req, res) => {
+    res
+      .status(200)
+      .set('Content-Encoding', 'gzip')
+      .send(zlib.gzipSync(Buffer.from('compressed-body')))
+  })
+})
+
+const interceptor = new XMLHttpRequestInterceptor()
+
+beforeAll(async () => {
+  interceptor.apply()
+  await httpServer.listen()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+  await httpServer.close()
+})
+
+test('bypasses a compressed HTTP request', async () => {
+  const request = await createXMLHttpRequest((request) => {
+    request.open('GET', httpServer.http.url('/compressed'))
+    request.send()
+  })
+
+  expect(request.status).toEqual(200)
+  expect(request.response).toEqual('compressed-body')
+  expect(request.responseText).toBe('compressed-body')
+})


### PR DESCRIPTION
- Fixes #308 

Thank you so much for working on this project, it is immensely useful!

TLDR: I am using the browser interceptors on a site that is serving responses with `Content-Encoding: br` or `gzip` or `deflate` etc. This breaks every request since `Content-Encoding` is typically for compression algorithms, like `gzip`, like this site responds with, but `TextDecoder` takes a character encoding, like `utf-8`. This breaks every request even if nothing is done by the user because the library logs the response, which implicitly calls `responseText()`. Avoiding passing the `Content-Encoding` to `TextDecoder` fixes the issue.

---

Currently, the interceptors break on every request without me doing anything because the `loadend` event logs the `response` which implicitly calls `responseText()`:

https://github.com/mswjs/interceptors/blob/d8f785d2571a6941fd67e7d2f74c43db6aa528b5/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts#L447

The `responseText()` method passes the response' `Content-Encoding` value to `decodeBuffer()` which passes it to `TextDecoder`.

However, it seems that the [`Content-Encoding`](https://github.com/mswjs/interceptors/blob/main/src/interceptors/XMLHttpRequest/XMLHttpRequestOverride.ts#L483-L491) header is conventionally for denoting the response' compression such as `gzip`, `br`, `deflate` etc.

> Content encoding is mainly used to compress the message data without losing information about the origin media type

See the [example syntax](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding#syntax) and [directives](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding#directives).

Meanwhile, `TextDecoder` appears to be more concerned with [character encoding](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API/Encodings), such as `utf-8`.

For this reason, I recommend not passing through the `Content-Encoding` value to `TextDecoder`, since it leads to errors on every request of this form:

```
Uncaught RangeError: Failed to construct 'TextDecoder': The encoding label provided ('br') is invalid.
```

I confirmed that this change fixes the issue.

Once again thank you for all your great work on this project!