### PR TITLE
fix(NodeRequestClient): account for undefined "agent" when terminating a request

### DIFF
--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -425,6 +425,6 @@ export class NodeClientRequest extends ClientRequest {
    */
   private terminate(): void {
     // @ts-ignore
-    this.agent.destroy()
+    this.agent?.destroy()
   }
 }

--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -424,6 +424,12 @@ export class NodeClientRequest extends ClientRequest {
    * Terminates a pending request.
    */
   private terminate(): void {
+    /**
+     * @note Some request clients (e.g. Octokit) create a ClientRequest
+     * in a way that it has no Agent set. Now, whether that's correct is
+     * debatable, but we should still handle this case gracefully.
+     * @see https://github.com/mswjs/interceptors/issues/304
+     */
     // @ts-ignore
     this.agent?.destroy()
   }


### PR DESCRIPTION
- Closes #304 
- Related to https://github.com/mswjs/msw/issues/1515 

This should account for `NodeRequestClient.agent` being potentially undefined.