### PR TITLE
fix(ClientRequest): fix race condition when emitting "response"

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "web-encoding": "^1.1.5"
   },
   "dependencies": {
+    "@open-draft/deferred-promise": "^2.1.0",
     "@open-draft/until": "^1.0.3",
     "@types/debug": "^4.1.7",
     "debug": "^4.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,6 +889,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@open-draft/deferred-promise@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-2.1.0.tgz#4fb33ebdf5c05a0e47a26490ed9037ca36275a66"
+  integrity sha512-Rzd5JrXZX8zErHzgcGyngh4fmEbSHqTETdGj9rXtejlqMIgXFlyKBA7Jn1Xp0Ls0M0Y22+xHcWiEzbmdWl0BOA==
+
 "@open-draft/test-server@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@open-draft/test-server/-/test-server-0.4.2.tgz#45bef308e72209cccd2778c821834621d99db790"


### PR DESCRIPTION
Spotted that there's a race condition between the mocked response body finished reading the the NodeClientRequest emitting the "response" event, allowing the consumer to read the response body that may not be yet fully read in the interceptor. 