### PR TITLE
fix: place the default export for "fetch" last

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
       "browser": {
         "types": "./lib/browser/interceptors/fetch/index.d.ts",
         "require": "./lib/browser/interceptors/fetch/index.js",
-        "default": "./lib/browser/interceptors/fetch/index.js",
-        "import": "./lib/browser/interceptors/fetch/index.mjs"
+        "import": "./lib/browser/interceptors/fetch/index.mjs",
+        "default": "./lib/browser/interceptors/fetch/index.js"
       },
       "types": "./lib/node/interceptors/fetch/index.d.ts",
       "require": "./lib/node/interceptors/fetch/index.js",


### PR DESCRIPTION
When compiling with webpack, it throws an error since the default was out of order:

using: 
`import { FetchInterceptor } from '@mswjs/interceptors/fetch'`

error:
```
Module not found: Error: Default condition should be last one
 @ ./src/index.js 11:0-57 32:4-19
 
webpack 5.75.0 compiled with 1 error in 1012 ms
```