### PR TITLE
fix: improve node.js host resolution

### DIFF
--- a/src/utils/getUrlByRequestOptions.test.ts
+++ b/src/utils/getUrlByRequestOptions.test.ts
@@ -116,3 +116,20 @@ it('supports "hostname" instead of "host" and "port"', () => {
     'https://127.0.0.1:1234/resource'
   )
 })
+
+it('handles IPv6 hostnames', () => {
+  expect(
+    getUrlByRequestOptions({
+      host: '::1',
+      path: '/resource',
+    }).href
+  ).toBe('http://[::1]/resource')
+
+  expect(
+    getUrlByRequestOptions({
+      host: '::1',
+      port: 3001,
+      path: '/resource',
+    }).href
+  ).toBe('http://[::1]:3001/resource')
+})

--- a/src/utils/getUrlByRequestOptions.test.ts
+++ b/src/utils/getUrlByRequestOptions.test.ts
@@ -4,138 +4,115 @@ import { RequestOptions, Agent as HttpsAgent } from 'https'
 import { getUrlByRequestOptions } from './getUrlByRequestOptions'
 
 it('returns a URL based on the basic RequestOptions', () => {
-  const options: RequestOptions = {
-    protocol: 'https:',
-    host: '127.0.0.1',
-    path: '/resource',
-  }
-  const url = getUrlByRequestOptions(options)
-
-  expect(url).toBeInstanceOf(URL)
-  expect(url).toHaveProperty('port', '')
-  expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
+  expect(
+    getUrlByRequestOptions({
+      protocol: 'https:',
+      host: '127.0.0.1',
+      path: '/resource',
+    }).href
+  ).toBe('https://127.0.0.1/resource')
 })
 
 it('inherits protocol and port from http.Agent, if set', () => {
-  const options: RequestOptions = {
-    host: '127.0.0.1',
-    path: '/',
-    agent: new HttpAgent(),
-  }
-  const url = getUrlByRequestOptions(options)
-
-  expect(url).toBeInstanceOf(URL)
-  expect(url).toHaveProperty('protocol', 'http:')
-  expect(url).toHaveProperty('port', '')
-  expect(url).toHaveProperty('href', 'http://127.0.0.1/')
+  expect(
+    getUrlByRequestOptions({
+      host: '127.0.0.1',
+      path: '/',
+      agent: new HttpAgent(),
+    }).href
+  ).toBe('http://127.0.0.1/')
 })
 
 it('inherits protocol and port from https.Agent, if set', () => {
-  const options: RequestOptions = {
-    host: '127.0.0.1',
-    path: '/',
-    agent: new HttpsAgent({
-      port: 3080,
-    }),
-  }
-  const url = getUrlByRequestOptions(options)
-
-  expect(url).toBeInstanceOf(URL)
-  expect(url).toHaveProperty('protocol', 'https:')
-  expect(url).toHaveProperty('port', '3080')
-  expect(url).toHaveProperty('href', 'https://127.0.0.1:3080/')
+  expect(
+    getUrlByRequestOptions({
+      host: '127.0.0.1',
+      path: '/',
+      agent: new HttpsAgent({
+        port: 3080,
+      }),
+    }).href
+  ).toBe('https://127.0.0.1:3080/')
 })
 
 it('resolves protocol to "http" given no explicit protocol and no certificate', () => {
-  const options: RequestOptions = {
-    host: '127.0.0.1',
-    path: '/',
-  }
-  const url = getUrlByRequestOptions(options)
-
-  expect(url).toBeInstanceOf(URL)
-  expect(url).toHaveProperty('protocol', 'http:')
-  expect(url).toHaveProperty('port', '')
-  expect(url).toHaveProperty('href', 'http://127.0.0.1/')
+  expect(
+    getUrlByRequestOptions({
+      host: '127.0.0.1',
+      path: '/',
+    }).href
+  ).toBe('http://127.0.0.1/')
 })
 
 it('resolves protocol to "https" given no explicit protocol, but certificate', () => {
-  const options: RequestOptions = {
-    host: '127.0.0.1',
-    path: '/secure',
-    cert: '<!-- SSL certificate -->',
-  }
-  const url = getUrlByRequestOptions(options)
-
-  expect(url).toBeInstanceOf(URL)
-  expect(url).toHaveProperty('protocol', 'https:')
-  expect(url).toHaveProperty('port', '')
-  expect(url).toHaveProperty('href', 'https://127.0.0.1/secure')
+  expect(
+    getUrlByRequestOptions({
+      host: '127.0.0.1',
+      path: '/secure',
+      cert: '<!-- SSL certificate -->',
+    }).href
+  ).toBe('https://127.0.0.1/secure')
 })
 
 it('resolves protocol to "https" given no explicit protocol, but port is 443', () => {
-  const options: RequestOptions = {
-    host: '127.0.0.1',
-    port: 443,
-    path: '/resource',
-  }
-  const url = getUrlByRequestOptions(options)
-
-  expect(url).toBeInstanceOf(URL)
-  expect(url).toHaveProperty('port', '')
-  expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
+  expect(
+    getUrlByRequestOptions({
+      host: '127.0.0.1',
+      port: 443,
+      path: '/resource',
+    }).href
+  ).toBe('https://127.0.0.1/resource')
 })
 
 it('resolves protocol to "https" given no explicit protocol, but agent port is 443', () => {
-  const options: RequestOptions = {
-    host: '127.0.0.1',
-    agent: new HttpsAgent({
-      port: 443,
-    }),
-    path: '/resource',
-  }
-  const url = getUrlByRequestOptions(options)
-
-  expect(url).toBeInstanceOf(URL)
-  expect(url).toHaveProperty('port', '')
-  expect(url).toHaveProperty('href', 'https://127.0.0.1/resource')
+  expect(
+    getUrlByRequestOptions({
+      host: '127.0.0.1',
+      agent: new HttpsAgent({
+        port: 443,
+      }),
+      path: '/resource',
+    }).href
+  ).toBe('https://127.0.0.1/resource')
 })
 
-it('inherits "port" if given', () => {
-  const options = {
-    protocol: 'http:',
-    host: '127.0.0.1',
-    port: 4002,
-    path: '/',
-  }
-  const url = getUrlByRequestOptions(options)
-
-  expect(url).toBeInstanceOf(URL)
-  expect(url).toHaveProperty('port', '4002')
-  expect(url).toHaveProperty('protocol', 'http:')
-  expect(url).toHaveProperty('href', 'http://127.0.0.1:4002/')
+it('respects explicitly provided port', () => {
+  expect(
+    getUrlByRequestOptions({
+      protocol: 'http:',
+      host: '127.0.0.1',
+      port: 4002,
+      path: '/',
+    }).href
+  ).toBe('http://127.0.0.1:4002/')
 })
 
 it('inherits "username" and "password"', () => {
-  const options: RequestOptions = {
+  const url = getUrlByRequestOptions({
     protocol: 'https:',
     host: '127.0.0.1',
     path: '/user',
     auth: 'admin:abc-123',
-  }
-  const url = getUrlByRequestOptions(options)
+  })
 
   expect(url).toBeInstanceOf(URL)
   expect(url).toHaveProperty('username', 'admin')
   expect(url).toHaveProperty('password', 'abc-123')
-  expect(url).toHaveProperty('protocol', 'https:')
   expect(url).toHaveProperty('href', 'https://admin:abc-123@127.0.0.1/user')
 })
 
 it('resolves hostname to localhost if none provided', () => {
-  const url = getUrlByRequestOptions({})
+  expect(getUrlByRequestOptions({}).hostname).toBe('localhost')
+})
 
-  expect(url).toBeInstanceOf(URL)
-  expect(url).toHaveProperty('protocol', 'http:')
-  expect(url).toHaveProperty('href', 'http://localhost/')
+it('supports "hostname" instead of "host" and "port"', () => {
+  const options: RequestOptions = {
+    protocol: 'https:',
+    hostname: '127.0.0.1:1234',
+    path: '/resource',
+  }
+
+  expect(getUrlByRequestOptions(options).href).toBe(
+    'https://127.0.0.1:1234/resource'
+  )
 })

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -152,10 +152,17 @@ function getBaseUrl(options: ResolvedRequestOptions): URL {
 export function getUrlByRequestOptions(options: ResolvedRequestOptions): URL {
   debug('request options', options)
 
-  const baseUrl = getBaseUrl(options)
-  debug('base url:', baseUrl)
+  if (options.uri) {
+    debug(
+      'constructing url from explicitly provided "options.uri": %s',
+      options.uri
+    )
+    return new URL(options.uri.href)
+  }
 
-  const url = options.uri ? new URL(options.uri.href) : baseUrl
+  debug('figuring out url from request options...')
+
+  const url = getBaseUrl(options)
   debug('created url:', url)
 
   return url

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -119,7 +119,22 @@ function getHostname(host: string, port?: number): string {
   return `${host}${portString}`
 }
 
-function getBaseUrl(options: ResolvedRequestOptions): URL {
+/**
+ * Creates a `URL` instance from a given `RequestOptions` object.
+ */
+export function getUrlByRequestOptions(options: ResolvedRequestOptions): URL {
+  debug('request options', options)
+
+  if (options.uri) {
+    debug(
+      'constructing url from explicitly provided "options.uri": %s',
+      options.uri
+    )
+    return new URL(options.uri.href)
+  }
+
+  debug('figuring out url from request options...')
+
   const protocol = getProtocolByRequestOptions(options)
   debug('protocol', protocol)
 
@@ -143,26 +158,7 @@ function getBaseUrl(options: ResolvedRequestOptions): URL {
     : ''
   debug('auth string:', authString)
 
-  return new URL(`${protocol}//${authString}${hostname}${path}`)
-}
-
-/**
- * Creates a `URL` instance from a given `RequestOptions` object.
- */
-export function getUrlByRequestOptions(options: ResolvedRequestOptions): URL {
-  debug('request options', options)
-
-  if (options.uri) {
-    debug(
-      'constructing url from explicitly provided "options.uri": %s',
-      options.uri
-    )
-    return new URL(options.uri.href)
-  }
-
-  debug('figuring out url from request options...')
-
-  const url = getBaseUrl(options)
+  const url = new URL(`${protocol}//${authString}${hostname}${path}`)
   debug('created url:', url)
 
   return url

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -15,7 +15,6 @@ export type ResolvedRequestOptions = RequestOptions & RequestSelf
 export const DEFAULT_PATH = '/'
 const DEFAULT_PROTOCOL = 'http:'
 const DEFAULT_HOST = 'localhost'
-const DEFAULT_PORT = 80
 const SSL_PORT = 443
 
 function getAgent(


### PR DESCRIPTION
- Fixes #353 

This should also make the URL resolution a bit faster in the case when `options.uri` is explicitly provided because we won't attempt to figure out URL parts from the options then. 