### PR TITLE
fix(XMLHttpRequest): resolve the "Illegal invocation" exception (conditional setter)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "devDependencies": {
     "@commitlint/cli": "^16.0.2",
     "@commitlint/config-conventional": "^16.0.0",
-    "@open-draft/test-server": "^0.4.2",
+    "@open-draft/test-server": "^0.5.1",
     "@ossjs/release": "^0.4.0",
     "@playwright/test": "^1.31.1",
     "@types/cors": "^2.8.12",

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -46,19 +46,6 @@ export class XMLHttpRequestController {
     this.responseBuffer = new Uint8Array()
 
     this.request = createProxy(initialRequest, {
-      setProperty: ([propertyName, nextValue], invoke) => {
-        /**
-         * @note Setting the "withCredentials" property on the XHR proxy
-         * causes the "TypeError: Illegal invocation" error. Instead,
-         * define the property on the original XHR instance itself.
-         */
-        if (propertyName === 'withCredentials') {
-          define(this.request, 'withCredentials', nextValue)
-          return true
-        }
-
-        return invoke()
-      },
       methodCall: ([methodName, args], invoke) => {
         switch (methodName) {
           case 'open': {
@@ -264,14 +251,17 @@ export class XMLHttpRequestController {
     Object.defineProperties(this.request, {
       response: {
         enumerable: true,
+        configurable: false,
         get: () => this.response,
       },
       responseText: {
         enumerable: true,
+        configurable: false,
         get: () => this.responseText,
       },
       responseXML: {
         enumerable: true,
+        configurable: false,
         get: () => this.responseXML,
       },
     })

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -46,6 +46,34 @@ export class XMLHttpRequestController {
     this.responseBuffer = new Uint8Array()
 
     this.request = createProxy(initialRequest, {
+      setProperty: ([propertyName, nextValue], invoke) => {
+        switch (propertyName) {
+          case 'onabort':
+          case 'onerror':
+          case 'onload':
+          case 'onloadend':
+          case 'onloadstart':
+          case 'onprogress':
+          case 'ontimeout':
+          case 'onreadystatechange': {
+            const eventName = propertyName.slice(
+              2
+            ) as keyof XMLHttpRequestEventTargetEventMap
+
+            /**
+             * @note Proxy callbacks to event listeners because JSDOM has trouble
+             * translating these properties to callbacks. It seemed to be operating
+             * on events exclusively.
+             */
+            this.request.addEventListener(eventName, nextValue as any)
+            return invoke()
+          }
+
+          default: {
+            return invoke()
+          }
+        }
+      },
       methodCall: ([methodName, args], invoke) => {
         switch (methodName) {
           case 'open': {
@@ -72,8 +100,8 @@ export class XMLHttpRequestController {
               keyof XMLHttpRequestEventTargetEventMap,
               Function
             ]
-            this.registerEvent(eventName, listener)
 
+            this.registerEvent(eventName, listener)
             this.log('addEventListener', eventName, listener.name)
 
             return invoke()
@@ -107,8 +135,7 @@ export class XMLHttpRequestController {
                   this.request,
                   /**
                    * The `response` property is the right way to read
-                   * the ambiguous response body, as the request's "responseTyoe"
-                   * may differ.
+                   * the ambiguous response body, as the request's "responseType" may differ.
                    * @see https://xhr.spec.whatwg.org/#the-response-attribute
                    */
                   this.request.response
@@ -156,22 +183,6 @@ export class XMLHttpRequestController {
             })
 
             break
-          }
-
-          case 'onabort':
-          case 'onerror':
-          case 'onload':
-          case 'onloadend':
-          case 'onloadstart':
-          case 'onprogress':
-          case 'ontimeout':
-          case 'onreadystatechange': {
-            const [listener] = args as [Function]
-            this.registerEvent(
-              methodName as keyof XMLHttpRequestEventTargetEventMap,
-              listener
-            )
-            return invoke()
           }
 
           default: {

--- a/src/interceptors/XMLHttpRequest/utils/createResponse.ts
+++ b/src/interceptors/XMLHttpRequest/utils/createResponse.ts
@@ -2,7 +2,7 @@ import { stringToHeaders } from 'headers-polyfill'
 
 export function createResponse(
   request: XMLHttpRequest,
-  responseBody: Uint8Array
+  responseBody: BodyInit | null
 ): Response {
   return new Response(responseBody, {
     status: request.status,

--- a/src/utils/createProxy.test.ts
+++ b/src/utils/createProxy.test.ts
@@ -31,15 +31,18 @@ it('does not interfere with default methods', () => {
 })
 
 it('spies on the constructor', () => {
-  const constructorCall = vi.fn((args, next) => next())
-  const ProxyClass = createProxy(
-    class {
-      constructor(public name: string, public age: number) {}
-    },
-    {
-      constructorCall,
-    }
-  )
+  const OriginalClass = class {
+    constructor(public name: string, public age: number) {}
+  }
+
+  const constructorCall = vi.fn<
+    [ConstructorParameters<typeof OriginalClass>, Function],
+    typeof OriginalClass
+  >((args, next) => next())
+
+  const ProxyClass = createProxy(OriginalClass, {
+    constructorCall,
+  })
 
   new ProxyClass('John', 32)
 

--- a/src/utils/createProxy.test.ts
+++ b/src/utils/createProxy.test.ts
@@ -1,0 +1,92 @@
+import { vi, it, expect } from 'vitest'
+import { createProxy } from './createProxy'
+
+it('does not interfere with default constructors', () => {
+  const ProxyClass = createProxy(
+    class {
+      constructor(public name: string) {}
+    },
+    {}
+  )
+
+  const instance = new ProxyClass('John')
+  expect(instance.name).toBe('John')
+})
+
+it('does not interfere with default getters', () => {
+  const proxy = createProxy({ foo: 'initial' }, {})
+  expect(proxy.foo).toBe('initial')
+})
+
+it('does not interfere with default setters', () => {
+  const proxy = createProxy({ foo: 'initial' }, {})
+  proxy.foo = 'next'
+
+  expect(proxy.foo).toBe('next')
+})
+
+it('does not interfere with default methods', () => {
+  const proxy = createProxy({ getValue: () => 'initial' }, {})
+  expect(proxy.getValue()).toBe('initial')
+})
+
+it('spies on the constructor', () => {
+  const constructorCall = vi.fn((args, next) => next())
+  const ProxyClass = createProxy(
+    class {
+      constructor(public name: string, public age: number) {}
+    },
+    {
+      constructorCall,
+    }
+  )
+
+  new ProxyClass('John', 32)
+
+  expect(constructorCall).toHaveBeenCalledTimes(1)
+  expect(constructorCall).toHaveBeenCalledWith(
+    ['John', 32],
+    expect.any(Function)
+  )
+})
+
+it('spies on property getters', () => {
+  const getProperty = vi.fn((args, next) => next())
+  const proxy = createProxy({ foo: 'initial' }, { getProperty })
+
+  proxy.foo
+
+  expect(getProperty).toHaveBeenCalledTimes(1)
+  expect(getProperty).toHaveBeenCalledWith(['foo', proxy], expect.any(Function))
+})
+
+it('spies on property setters', () => {
+  const setProperty = vi.fn((args, next) => next())
+  const proxy = createProxy({ foo: 'initial' }, { setProperty })
+
+  proxy.foo = 'next'
+
+  expect(setProperty).toHaveBeenCalledTimes(1)
+  expect(setProperty).toHaveBeenCalledWith(
+    ['foo', 'next'],
+    expect.any(Function)
+  )
+})
+
+it('spies on method calls', () => {
+  const methodCall = vi.fn((args, next) => next())
+  const proxy = createProxy(
+    {
+      greet: (name: string) => `hello ${name}`,
+    },
+    { methodCall }
+  )
+
+  proxy.greet('Clair')
+
+  expect(methodCall).toHaveBeenCalledTimes(1)
+  expect(methodCall).toHaveBeenCalledWith(
+    ['greet', ['Clair']],
+    expect.any(Function)
+  )
+})

--- a/src/utils/createProxy.ts
+++ b/src/utils/createProxy.ts
@@ -41,28 +41,21 @@ function optionsToProxyHandler<T extends Record<string, any>>(
     }
   }
 
-  if (typeof setProperty !== 'undefined') {
-    handler.set = function (target, propertyName, nextValue, receiver) {
-      const next = () => {
-        const targetDescriptors = Object.getOwnPropertyDescriptor(
-          target,
-          propertyName
-        )
+  handler.set = function (target, propertyName, nextValue) {
+    const next = () => {
+      return Reflect.defineProperty(target, propertyName, {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value: nextValue,
+      })
+    }
 
-        const resolvedTarget =
-          typeof targetDescriptors?.set == 'undefined' ? receiver : target
-
-        Object.defineProperty(resolvedTarget, propertyName, {
-          enumerable: true,
-          configurable: true,
-          value: nextValue,
-        })
-
-        return true
-      }
-
+    if (typeof setProperty !== 'undefined') {
       return setProperty.call(target, [propertyName, nextValue], next)
     }
+
+    return next()
   }
 
   handler.get = function (target, propertyName, receiver) {

--- a/test/features/events/request.test.ts
+++ b/test/features/events/request.test.ts
@@ -5,6 +5,7 @@ import { HttpServer } from '@open-draft/test-server/http'
 import { HttpRequestEventMap } from '../../../src'
 import {
   createXMLHttpRequest,
+  useCors,
   UUID_REGEXP,
   waitForClientRequest,
 } from '../../helpers'
@@ -13,6 +14,7 @@ import { BatchInterceptor } from '../../../src/BatchInterceptor'
 import { XMLHttpRequestInterceptor } from '../../../src/interceptors/XMLHttpRequest'
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.post('/user', (req, res) => {
     res.status(201).end()
   })

--- a/test/features/events/response.test.ts
+++ b/test/features/events/response.test.ts
@@ -5,7 +5,11 @@ import fetch from 'node-fetch'
 import waitForExpect from 'wait-for-expect'
 import { HttpServer, httpsAgent } from '@open-draft/test-server/http'
 import { HttpRequestEventMap } from '../../../src'
-import { createXMLHttpRequest, waitForClientRequest } from '../../helpers'
+import {
+  createXMLHttpRequest,
+  useCors,
+  waitForClientRequest,
+} from '../../helpers'
 import { XMLHttpRequestInterceptor } from '../../../src/interceptors/XMLHttpRequest'
 import { BatchInterceptor } from '../../../src/BatchInterceptor'
 import { ClientRequestInterceptor } from '../../../src/interceptors/ClientRequest'
@@ -17,6 +21,8 @@ declare namespace window {
 }
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
+
   app.get('/user', (_req, res) => {
     res.status(509).send('must-use-mocks')
   })

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -6,6 +6,7 @@ import { Page } from '@playwright/test'
 import { getRequestOptionsByUrl } from '../src/utils/getRequestOptionsByUrl'
 import { getIncomingMessageBody } from '../src/interceptors/ClientRequest/utils/getIncomingMessageBody'
 import { SerializedRequest } from '../src/RemoteHttpInterceptor'
+import { RequestHandler } from 'express'
 
 export const UUID_REGEXP =
   /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/
@@ -252,7 +253,8 @@ export function createRawBrowserXMLHttpRequest(page: Page) {
 
           const request = new XMLHttpRequest()
           if (typeof withCredentials !== 'undefined') {
-            request.withCredentials = withCredentials
+            Reflect.set(request, 'withCredentials', withCredentials)
+            // request.withCredentials = withCredentials
           }
           request.open(method, url)
 
@@ -311,4 +313,11 @@ export function sleep(duration: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, duration)
   })
+}
+
+export const useCors: RequestHandler = (req, res, next) => {
+  res.set({
+    'Access-Control-Allow-Origin': '*',
+  })
+  return next()
 }

--- a/test/modules/XMLHttpRequest/compliance/xhr-events-order.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-events-order.test.ts
@@ -5,9 +5,10 @@
 import { Mock, vi, it, expect, beforeAll, afterAll } from 'vitest'
 import { HttpServer } from '@open-draft/test-server/http'
 import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
-import { createXMLHttpRequest } from '../../../helpers'
+import { createXMLHttpRequest, useCors } from '../../../helpers'
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/', (_req, res) => {
     res.status(200).end()
   })

--- a/test/modules/XMLHttpRequest/compliance/xhr-modify-request.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-modify-request.test.ts
@@ -2,9 +2,10 @@
 import { vi, it, expect, beforeAll, afterAll } from 'vitest'
 import { HttpServer } from '@open-draft/test-server/http'
 import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
-import { createXMLHttpRequest } from '../../../helpers'
+import { createXMLHttpRequest, useCors } from '../../../helpers'
 
 const server = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/user', (req, res) => {
     res
       .set({

--- a/test/modules/XMLHttpRequest/compliance/xhr-request-headers.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-request-headers.test.ts
@@ -2,13 +2,14 @@
 import { it, expect, beforeAll, afterAll } from 'vitest'
 import { HttpServer } from '@open-draft/test-server/http'
 import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
-import { createXMLHttpRequest } from '../../../helpers'
+import { createXMLHttpRequest, useCors } from '../../../helpers'
 
 interface ResponseType {
   requestRawHeaders: Array<string>
 }
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.get<never, ResponseType>('/', (req, res) => {
     res
       .set({

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-headers-case-sensitivity.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-headers-case-sensitivity.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import { it, expect, beforeAll, afterAll } from 'vitest'
 import { HttpServer } from '@open-draft/test-server/http'
-import { createXMLHttpRequest } from '../../../helpers'
+import { createXMLHttpRequest, useCors } from '../../../helpers'
 import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/account', (req, res) => {
     return res
       .status(200)

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-headers.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-headers.test.ts
@@ -2,9 +2,10 @@
 import { it, expect, beforeAll, afterAll } from 'vitest'
 import { HttpServer } from '@open-draft/test-server/http'
 import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
-import { createXMLHttpRequest } from '../../../helpers'
+import { createXMLHttpRequest, useCors } from '../../../helpers'
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.head('/', (_req, res) => {
     res
       .set({

--- a/test/modules/XMLHttpRequest/compliance/xhr-timeout.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-timeout.test.ts
@@ -38,7 +38,7 @@ it('handles request timeout via the "ontimeout" callback', async () => {
       timeoutCalled.resolve(this.readyState)
     }
     req.send()
-  })
+  }).catch(console.error)
 
   const nextReadyState = await timeoutCalled
   expect(nextReadyState).toBe(4)
@@ -55,7 +55,7 @@ it('handles request timeout via the "timeout" event listener', async () => {
       timeoutCalled.resolve(this.readyState)
     })
     req.send()
-  })
+  }).catch(console.error)
 
   const nextReadyState = await timeoutCalled
   expect(nextReadyState).toBe(4)

--- a/test/modules/XMLHttpRequest/features/events.test.ts
+++ b/test/modules/XMLHttpRequest/features/events.test.ts
@@ -2,10 +2,11 @@
 import { vi, it, expect, beforeAll, afterAll } from 'vitest'
 import { HttpServer } from '@open-draft/test-server/http'
 import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
-import { createXMLHttpRequest, UUID_REGEXP } from '../../../helpers'
+import { createXMLHttpRequest, useCors, UUID_REGEXP } from '../../../helpers'
 import { HttpRequestEventMap } from '../../../../src'
 
 const server = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/bypassed', (req, res) => {
     res.status(201).set('Content-Type', 'text/plain').send('original response')
   })

--- a/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.test.ts
+++ b/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.test.ts
@@ -6,7 +6,7 @@ import {
   XMLHttpRequestEventListener,
   XMLHttpRequestInterceptor,
 } from '../../../../src/interceptors/XMLHttpRequest'
-import { createXMLHttpRequest, UUID_REGEXP } from '../../../helpers'
+import { createXMLHttpRequest, useCors, UUID_REGEXP } from '../../../helpers'
 import { toArrayBuffer, encodeBuffer } from '../../../../src/utils/bufferUtils'
 
 declare namespace window {
@@ -16,6 +16,8 @@ declare namespace window {
 }
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
+
   const handleUserRequest: RequestHandler = (_req, res) => {
     res.status(200).send('user-body').end()
   }

--- a/test/modules/XMLHttpRequest/regressions/xhr-compressed-response.browser.test.ts
+++ b/test/modules/XMLHttpRequest/regressions/xhr-compressed-response.browser.test.ts
@@ -3,9 +3,11 @@
  */
 import { HttpServer } from '@open-draft/test-server/http'
 import zlib from 'zlib'
+import { useCors } from '../../../helpers'
 import { test, expect } from '../../../playwright.extend'
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/compressed', (_req, res) => {
     res
       .status(200)

--- a/test/modules/XMLHttpRequest/regressions/xhr-compressed-response.test.ts
+++ b/test/modules/XMLHttpRequest/regressions/xhr-compressed-response.test.ts
@@ -6,9 +6,10 @@ import { it, expect, beforeAll, afterAll } from 'vitest'
 import { HttpServer } from '@open-draft/test-server/http'
 import zlib from 'zlib'
 import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
-import { createXMLHttpRequest } from '../../../helpers'
+import { createXMLHttpRequest, useCors } from '../../../helpers'
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/compressed', (_req, res) => {
     res
       .status(200)

--- a/test/modules/XMLHttpRequest/response/xhr-response-patching.browser.test.ts
+++ b/test/modules/XMLHttpRequest/response/xhr-response-patching.browser.test.ts
@@ -1,4 +1,5 @@
 import { HttpServer } from '@open-draft/test-server/http'
+import { useCors } from '../../../helpers'
 import { test, expect } from '../../../playwright.extend'
 
 declare namespace window {
@@ -6,6 +7,7 @@ declare namespace window {
 }
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/original', (req, res) => {
     res
       .set('access-control-expose-headers', 'x-custom-header')

--- a/test/modules/XMLHttpRequest/response/xhr.browser.test.ts
+++ b/test/modules/XMLHttpRequest/response/xhr.browser.test.ts
@@ -2,6 +2,7 @@ import { Page } from '@playwright/test'
 import { HttpServer } from '@open-draft/test-server/http'
 import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
 import { test, expect } from '../../../playwright.extend'
+import { useCors } from '../../../helpers'
 
 declare namespace window {
   export const interceptor: XMLHttpRequestInterceptor
@@ -10,6 +11,7 @@ declare namespace window {
 }
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/', (req, res) => {
     res.status(200).json({ route: '/' })
   })

--- a/test/modules/XMLHttpRequest/response/xhr.test.ts
+++ b/test/modules/XMLHttpRequest/response/xhr.test.ts
@@ -2,7 +2,7 @@
 import { vi, it, expect, beforeAll, afterAll } from 'vitest'
 import { HttpServer } from '@open-draft/test-server/http'
 import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
-import { createXMLHttpRequest } from '../../../helpers'
+import { createXMLHttpRequest, useCors } from '../../../helpers'
 
 declare namespace window {
   export const _resourceLoader: {
@@ -11,6 +11,7 @@ declare namespace window {
 }
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/', (req, res) => {
     res.status(200).send('/')
   })

--- a/test/modules/fetch/fetch-modify-request.browser.test.ts
+++ b/test/modules/fetch/fetch-modify-request.browser.test.ts
@@ -1,7 +1,9 @@
 import { HttpServer } from '@open-draft/test-server/http'
+import { useCors } from '../../helpers'
 import { test, expect } from '../../playwright.extend'
 
 const server = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/user', (req, res) => {
     res.set('X-Appended-Header', req.headers['x-appended-header']).end()
   })

--- a/test/modules/fetch/intercept/fetch.browser.test.ts
+++ b/test/modules/fetch/intercept/fetch.browser.test.ts
@@ -2,11 +2,13 @@ import { RequestHandler } from 'express'
 import { HttpServer } from '@open-draft/test-server/http'
 import { Page, Response } from '@playwright/test'
 import { test, expect } from '../../../playwright.extend'
-import { extractRequestFromPage } from '../../../helpers'
+import { extractRequestFromPage, useCors } from '../../../helpers'
 
 const EXAMPLE_PATH = require.resolve('./fetch.browser.runtime.js')
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
+
   const handleRequest: RequestHandler = (_req, res) => {
     res.status(200).send('user-body').end()
   }

--- a/test/modules/fetch/intercept/fetch.clone.browser.test.ts
+++ b/test/modules/fetch/intercept/fetch.clone.browser.test.ts
@@ -1,4 +1,5 @@
 import { HttpServer } from '@open-draft/test-server/http'
+import { useCors } from '../../../helpers'
 import { test, expect } from '../../../playwright.extend'
 
 declare namespace window {
@@ -6,6 +7,7 @@ declare namespace window {
 }
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/', (req, res) => {
     res.send('hello world')
   })

--- a/test/modules/fetch/intercept/fetch.request.browser.test.ts
+++ b/test/modules/fetch/intercept/fetch.request.browser.test.ts
@@ -1,8 +1,9 @@
 import { HttpServer } from '@open-draft/test-server/http'
-import { extractRequestFromPage } from '../../../helpers'
+import { extractRequestFromPage, useCors } from '../../../helpers'
 import { test, expect } from '../../../playwright.extend'
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.post('/user', (_req, res) => {
     res.status(200).send('mocked')
   })

--- a/test/modules/fetch/response/fetch-response-patching.browser.test.ts
+++ b/test/modules/fetch/response/fetch-response-patching.browser.test.ts
@@ -3,6 +3,7 @@ import { Page } from '@playwright/test'
 import { listToHeaders } from 'headers-polyfill'
 import { test, expect } from '../../../playwright.extend'
 import { FetchInterceptor } from '../../../../src/interceptors/fetch'
+import { useCors } from '../../../helpers'
 
 declare namespace window {
   export const interceptor: FetchInterceptor
@@ -10,6 +11,7 @@ declare namespace window {
 }
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/original', (req, res) => {
     res
       .set('access-control-expose-headers', 'x-custom-header')

--- a/test/modules/fetch/response/fetch.browser.test.ts
+++ b/test/modules/fetch/response/fetch.browser.test.ts
@@ -2,6 +2,7 @@ import { HttpServer } from '@open-draft/test-server/http'
 import { Page } from '@playwright/test'
 import { listToHeaders } from 'headers-polyfill'
 import { test, expect } from '../../../playwright.extend'
+import { useCors } from '../../../helpers'
 import { FetchInterceptor } from '../../../../src/interceptors/fetch'
 
 declare namespace window {
@@ -21,6 +22,7 @@ interface SerializedResponse {
 }
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/', (req, res) => {
     res.status(200).json({ route: '/' }).end()
   })

--- a/test/modules/http/compliance/http-req-write.test.ts
+++ b/test/modules/http/compliance/http-req-write.test.ts
@@ -7,7 +7,8 @@ import { waitForClientRequest } from '../../../helpers'
 import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
 
 const httpServer = new HttpServer((app) => {
-  app.post('/resource', express.text(), (req, res) => {
+  app.post('/resource', express.text({ type: '*/*' }), (req, res) => {
+    console.log('POST /resource', req.body)
     res.send(req.body)
   })
 })
@@ -70,8 +71,10 @@ it('writes JSON request body', async () => {
   req.write(':"value"')
   req.end('}')
 
-  const { text } = await waitForClientRequest(req)
-  const expectedBody = JSON.stringify({ key: 'value' })
+  const { res, text } = await waitForClientRequest(req)
+  const expectedBody = `{"key":"value"}`
+
+  console.log(res.statusCode, res.statusMessage)
 
   expect(interceptedRequestBody).toHaveBeenCalledWith(expectedBody)
   expect(getInternalRequestBody(req).toString()).toEqual(expectedBody)
@@ -91,7 +94,7 @@ it('writes Buffer request body', async () => {
   req.end(Buffer.from('}'))
 
   const { text } = await waitForClientRequest(req)
-  const expectedBody = JSON.stringify({ key: 'value' })
+  const expectedBody = `{"key":"value"}`
 
   expect(interceptedRequestBody).toHaveBeenCalledWith(expectedBody)
   expect(getInternalRequestBody(req).toString()).toEqual(expectedBody)

--- a/test/modules/http/http-performance.test.ts
+++ b/test/modules/http/http-performance.test.ts
@@ -1,7 +1,7 @@
 import { it, expect, beforeAll, afterAll } from 'vitest'
 import { HttpServer } from '@open-draft/test-server/http'
 import { ClientRequestInterceptor } from '../../../src/interceptors/ClientRequest'
-import { httpGet, PromisifiedResponse } from '../../helpers'
+import { httpGet, PromisifiedResponse, useCors } from '../../helpers'
 
 function arrayWith<V>(length: number, mapFn: (index: number) => V): V[] {
   return new Array(length).fill(null).map((_, index) => mapFn(index))
@@ -22,6 +22,7 @@ function parallelRequests(
 }
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.get<{ index: number }>('/number/:index', (req, res) => {
     return res.send(`real ${req.params.index}`)
   })

--- a/test/playwright.extend.ts
+++ b/test/playwright.extend.ts
@@ -31,6 +31,11 @@ export const test = base.extend<TestFixutures>({
       )
 
       page.on('pageerror', console.error)
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') {
+          console.error('[RUNTIME ERROR]:', msg.text())
+        }
+      })
 
       await page.goto(compilation.previewUrl, { waitUntil: 'networkidle' })
 

--- a/test/third-party/axios.test.ts
+++ b/test/third-party/axios.test.ts
@@ -3,8 +3,10 @@ import { it, expect, beforeAll, afterAll } from 'vitest'
 import axios from 'axios'
 import { HttpServer } from '@open-draft/test-server/http'
 import { ClientRequestInterceptor } from '../../src/interceptors/ClientRequest'
+import { useCors } from '../helpers'
 
 const httpServer = new HttpServer((app) => {
+  app.use(useCors)
   app.get('/books', (req, res) => {
     res.status(200).json([
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1004,10 +1004,10 @@
   resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-2.1.0.tgz#4fb33ebdf5c05a0e47a26490ed9037ca36275a66"
   integrity sha512-Rzd5JrXZX8zErHzgcGyngh4fmEbSHqTETdGj9rXtejlqMIgXFlyKBA7Jn1Xp0Ls0M0Y22+xHcWiEzbmdWl0BOA==
 
-"@open-draft/test-server@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@open-draft/test-server/-/test-server-0.4.2.tgz#45bef308e72209cccd2778c821834621d99db790"
-  integrity sha512-J9wbdQkPx5WKcDNtgfnXsx5ew4UJd6BZyGr89YlHeaUkOShkO2iO5QIyCCsG4qpjIvr2ZTkEYJA9ujOXXyO6Pg==
+"@open-draft/test-server@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@open-draft/test-server/-/test-server-0.5.1.tgz#e9aa5ae61b16185a8893e36f80b133b74ccbb5fb"
+  integrity sha512-RYyjRVfddPMmVWePP49OQ/zmJL5D0kr+/LsLILYftC067LDPdZwUm75s9h+2+gqyVHU8qcWiWPXwYouDHUmVNw==
   dependencies:
     "@types/body-parser" "^1.19.0"
     "@types/cors" "^2.8.9"


### PR DESCRIPTION
- Fixes #339
- Fixes an issue where setting XHR callbacks like `ontimeout` did nothing because we've treated them as _method calls_ and not property setters. 

## Root cause for `Illegal invocation` on setters

Turns out, having a `handler.set` in the Proxy handlers added _conditionally_ is quite an issue. If the setter function is always added to the proxy, there are no illegal invocations anymore. 

## Root cause for `xhr.responseType` not being respected

JSDOM sets a bunch of property descriptors on both XMLHttpRequest implementation _and_ its prototype. We were not forwarding any of the prototype descriptors in our proxy, and that's why setting `xhr.responseType` didn't propagate to JSDOM and didn't affect the returned response. 

> This is fixed on the XHR controller level as this is something specific to XHR in JSDOM. 