### PR TITLE
fix(fetch): treat middleware exceptions as TypeError

### DIFF
--- a/test/modules/fetch/fetch-exception.browser.test.ts
+++ b/test/modules/fetch/fetch-exception.browser.test.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '../../playwright.extend'
+
+test('treats middleware exceptions as TypeError: Failed to fetch', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(require.resolve('./fetch-exception.runtime.js'))
+
+  const errors: Array<string> = []
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      errors.push(message.text())
+    }
+  })
+
+  const fetchRejectionError = await page.evaluate(() => {
+    return fetch('http://localhost:3001/resource').catch(
+      (error: TypeError & { cause: Error }) => {
+        // Serialize the error to retrieve it in the test.
+        return {
+          name: error.name,
+          message: error.message,
+          cause: {
+            name: error.cause.name,
+            message: error.cause.message,
+          },
+        }
+      }
+    )
+  })
+
+  expect(fetchRejectionError).toEqual({
+    name: 'TypeError',
+    message: 'Failed to fetch',
+    cause: {
+      name: 'Error',
+      message: 'Network error',
+    },
+  })
+  expect(errors).toEqual(['GET http://localhost:3001/resource net::ERR_FAILED'])
+})

--- a/test/modules/fetch/fetch-exception.runtime.js
+++ b/test/modules/fetch/fetch-exception.runtime.js
@@ -1,0 +1,9 @@
+import { FetchInterceptor } from '@mswjs/interceptors/fetch'
+
+const interceptor = new FetchInterceptor()
+
+interceptor.on('request', async (request) => {
+  throw new Error('Network error')
+})
+
+interceptor.apply()

--- a/test/modules/fetch/fetch-exception.test.ts
+++ b/test/modules/fetch/fetch-exception.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment node
+import { vi, it, expect, beforeAll, afterAll } from 'vitest'
+import { FetchInterceptor } from '../../../src/interceptors/fetch'
+
+const interceptor = new FetchInterceptor()
+
+beforeAll(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => void 0)
+
+  interceptor.apply()
+  interceptor.on('request', (request) => {
+    throw new Error('Network error')
+  })
+})
+
+afterAll(() => {
+  vi.restoreAllMocks()
+  interceptor.dispose()
+})
+
+it('treats middleware exceptions as TypeError: Failed to fetch', async () => {
+  await fetch('http://localhost:3001/resource').catch(
+    (error: TypeError & { cause: Error }) => {
+      expect(console.error).toHaveBeenCalledWith(
+        'GET http://localhost:3001/resource net::ERR_FAILED'
+      )
+      expect(error).toBeInstanceOf(TypeError)
+      expect(error.message).toBe('Failed to fetch')
+      // Internal: preserve the original middleware error.
+      expect(error.cause).toEqual(new Error('Network error'))
+    }
+  )
+})


### PR DESCRIPTION
- Fixes https://github.com/mswjs/msw/issues/1557

Since we now ship the fetch interceptor in the Node preset by default, we are mocking the `globalThis.fetch` function calls directly instead of tapping into the underlying `http.ClientRequest` as before. Previously, erroring the underlying client request bubbled to whichever fetch implementation the user was using, and that implementation faithfully handled those errors as `TypeError`.

Now, we become that fetch implementation (in the case of middleware exceptions) so we need to forward middleware exceptions as `TypeError` to the consumer. 

- [ ] Backport this to 0.17.x so the fix is there. 