### PR TITLE
fix(XMLHttpRequest): prevent event handlers from being called twice

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -46,6 +46,28 @@ export class XMLHttpRequestController {
     this.responseBuffer = new Uint8Array()
 
     this.request = createProxy(initialRequest, {
+      setProperty: ([propertyName, nextValue], invoke) => {
+        switch (propertyName) {
+          case 'ontimeout': {
+            const eventName = propertyName.slice(
+              2
+            ) as keyof XMLHttpRequestEventTargetEventMap
+
+            /**
+             * @note Proxy callbacks to event listeners because JSDOM has trouble
+             * translating these properties to callbacks. It seemed to be operating
+             * on events exclusively.
+             */
+            this.request.addEventListener(eventName, nextValue as any)
+
+            return invoke()
+          }
+
+          default: {
+            return invoke()
+          }
+        }
+      },
       methodCall: ([methodName, args], invoke) => {
         switch (methodName) {
           case 'open': {

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -46,34 +46,6 @@ export class XMLHttpRequestController {
     this.responseBuffer = new Uint8Array()
 
     this.request = createProxy(initialRequest, {
-      setProperty: ([propertyName, nextValue], invoke) => {
-        switch (propertyName) {
-          case 'onabort':
-          case 'onerror':
-          case 'onload':
-          case 'onloadend':
-          case 'onloadstart':
-          case 'onprogress':
-          case 'ontimeout':
-          case 'onreadystatechange': {
-            const eventName = propertyName.slice(
-              2
-            ) as keyof XMLHttpRequestEventTargetEventMap
-
-            /**
-             * @note Proxy callbacks to event listeners because JSDOM has trouble
-             * translating these properties to callbacks. It seemed to be operating
-             * on events exclusively.
-             */
-            this.request.addEventListener(eventName, nextValue as any)
-            return invoke()
-          }
-
-          default: {
-            return invoke()
-          }
-        }
-      },
       methodCall: ([methodName, args], invoke) => {
         switch (methodName) {
           case 'open': {

--- a/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.test.ts
@@ -56,11 +56,17 @@ it.each<[name: string, getUrl: () => string]>([
   async (_, getUrl) => {
     const url = getUrl()
 
+    const onReadyStateChangeHandler = vi.fn(function (this: XMLHttpRequest) {
+      return this.readyState
+    })
     const onLoadStartHandler = vi.fn()
     const onProgressHandler = vi.fn()
     const onLoadHandler = vi.fn()
     const onLoadEndHandler = vi.fn()
 
+    const onReadyStateChangeListener = vi.fn(function (this: XMLHttpRequest) {
+      return this.readyState
+    })
     const loadStartListener = vi.fn()
     const progressListener = vi.fn()
     const loadListener = vi.fn()
@@ -69,11 +75,13 @@ it.each<[name: string, getUrl: () => string]>([
     const request = await createXMLHttpRequest((request) => {
       request.open('GET', url)
 
+      request.onreadystatechange = onReadyStateChangeHandler
       request.onloadstart = onLoadStartHandler
       request.onprogress = onProgressHandler
       request.onload = onLoadHandler
       request.onloadend = onLoadEndHandler
 
+      request.addEventListener('readystatechange', onReadyStateChangeListener)
       request.addEventListener('loadstart', loadStartListener)
       request.addEventListener('progress', progressListener)
       request.addEventListener('load', loadListener)
@@ -86,11 +94,19 @@ it.each<[name: string, getUrl: () => string]>([
     expect(request.status).toBe(200)
     expect(request.responseText).toBe('hello')
 
+    expect(onReadyStateChangeHandler).toHaveBeenCalledTimes(3)
+    expect(onReadyStateChangeHandler).toHaveNthReturnedWith(1, 2)
+    expect(onReadyStateChangeHandler).toHaveNthReturnedWith(2, 3)
+    expect(onReadyStateChangeHandler).toHaveNthReturnedWith(3, 4)
     expect(onLoadStartHandler).toHaveBeenCalledTimes(1)
     expect(onProgressHandler).toHaveBeenCalledTimes(1)
     expect(onLoadHandler).toHaveBeenCalledTimes(1)
     expect(onLoadEndHandler).toHaveBeenCalledTimes(1)
 
+    expect(onReadyStateChangeListener).toHaveBeenCalledTimes(3)
+    expect(onReadyStateChangeListener).toHaveNthReturnedWith(1, 2)
+    expect(onReadyStateChangeListener).toHaveNthReturnedWith(2, 3)
+    expect(onReadyStateChangeListener).toHaveNthReturnedWith(3, 4)
     expect(loadStartListener).toHaveBeenCalledTimes(1)
     expect(progressListener).toHaveBeenCalledTimes(1)
     expect(loadListener).toHaveBeenCalledTimes(1)
@@ -104,11 +120,17 @@ it.each<[name: string, getUrl: () => string]>([
 ])(`dispatches relevant events upon a %s error response`, async (_, getUrl) => {
   const url = getUrl()
 
+  const onReadyStateChangeHandler = vi.fn(function (this: XMLHttpRequest) {
+    return this.readyState
+  })
   const onLoadStartHandler = vi.fn()
   const onProgressHandler = vi.fn()
   const onLoadHandler = vi.fn()
   const onLoadEndHandler = vi.fn()
 
+  const onReadyStateChangeListener = vi.fn(function (this: XMLHttpRequest) {
+    return this.readyState
+  })
   const loadStartListener = vi.fn()
   const progressListener = vi.fn()
   const loadListener = vi.fn()
@@ -117,11 +139,13 @@ it.each<[name: string, getUrl: () => string]>([
   const request = await createXMLHttpRequest((request) => {
     request.open('GET', url)
 
+    request.onreadystatechange = onReadyStateChangeHandler
     request.onloadstart = onLoadStartHandler
     request.onprogress = onProgressHandler
     request.onload = onLoadHandler
     request.onloadend = onLoadEndHandler
 
+    request.addEventListener('readystatechange', onReadyStateChangeListener)
     request.addEventListener('loadstart', loadStartListener)
     request.addEventListener('progress', progressListener)
     request.addEventListener('load', loadListener)
@@ -134,11 +158,19 @@ it.each<[name: string, getUrl: () => string]>([
   expect(request.status).toBe(500)
   expect(request.responseText).toBe('Internal Server Error')
 
+  expect(onReadyStateChangeHandler).toHaveBeenCalledTimes(3)
+  expect(onReadyStateChangeHandler).toHaveNthReturnedWith(1, 2)
+  expect(onReadyStateChangeHandler).toHaveNthReturnedWith(2, 3)
+  expect(onReadyStateChangeHandler).toHaveNthReturnedWith(3, 4)
   expect(onLoadStartHandler).toHaveBeenCalledTimes(1)
   expect(onProgressHandler).toHaveBeenCalledTimes(1)
   expect(onLoadHandler).toHaveBeenCalledTimes(1)
   expect(onLoadEndHandler).toHaveBeenCalledTimes(1)
 
+  expect(onReadyStateChangeListener).toHaveBeenCalledTimes(3)
+  expect(onReadyStateChangeListener).toHaveNthReturnedWith(1, 2)
+  expect(onReadyStateChangeListener).toHaveNthReturnedWith(2, 3)
+  expect(onReadyStateChangeListener).toHaveNthReturnedWith(3, 4)
   expect(loadStartListener).toHaveBeenCalledTimes(1)
   expect(progressListener).toHaveBeenCalledTimes(1)
   expect(loadListener).toHaveBeenCalledTimes(1)
@@ -151,11 +183,17 @@ it.each<[name: string, getUrl: () => string]>([
 ])(`dispatches relevant events upon a %s request error`, async (_, getUrl) => {
   const url = getUrl()
 
+  const onReadyStateChangeHandler = vi.fn(function (this: XMLHttpRequest) {
+    return this.readyState
+  })
   const onLoadStartHandler = vi.fn()
   const onProgressHandler = vi.fn()
   const onLoadHandler = vi.fn()
   const onLoadEndHandler = vi.fn()
 
+  const onReadyStateChangeListener = vi.fn(function (this: XMLHttpRequest) {
+    return this.readyState
+  })
   const loadStartListener = vi.fn()
   const progressListener = vi.fn()
   const loadListener = vi.fn()
@@ -164,11 +202,13 @@ it.each<[name: string, getUrl: () => string]>([
   const request = await createXMLHttpRequest((request) => {
     request.open('GET', url)
 
+    request.onreadystatechange = onReadyStateChangeHandler
     request.onloadstart = onLoadStartHandler
     request.onprogress = onProgressHandler
     request.onload = onLoadHandler
     request.onloadend = onLoadEndHandler
 
+    request.addEventListener('readystatechange', onReadyStateChangeListener)
     request.addEventListener('loadstart', loadStartListener)
     request.addEventListener('progress', progressListener)
     request.addEventListener('load', loadListener)
@@ -181,11 +221,15 @@ it.each<[name: string, getUrl: () => string]>([
   expect(request.status).toBe(0)
   expect(request.responseText).toBe('')
 
+  expect(onReadyStateChangeHandler).toHaveBeenCalledTimes(1)
+  expect(onReadyStateChangeHandler).toHaveNthReturnedWith(1, 4)
   expect(onLoadStartHandler).not.toHaveBeenCalled()
   expect(onProgressHandler).not.toHaveBeenCalled()
   expect(onLoadHandler).not.toHaveBeenCalled()
   expect(onLoadEndHandler).toHaveBeenCalledTimes(1)
 
+  expect(onReadyStateChangeListener).toHaveBeenCalledTimes(1)
+  expect(onReadyStateChangeListener).toHaveNthReturnedWith(1, 4)
   expect(loadStartListener).not.toHaveBeenCalled()
   expect(progressListener).not.toHaveBeenCalled()
   expect(loadListener).not.toHaveBeenCalled()

--- a/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @note https://xhr.spec.whatwg.org/#event-handlers
+ */
+// @vitest-environment jsdom
+import { vi, it, expect, beforeAll, afterAll } from 'vitest'
+import { HttpServer } from '@open-draft/test-server/http'
+import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
+import { createXMLHttpRequest } from '../../../helpers'
+
+const interceptor = new XMLHttpRequestInterceptor()
+
+const httpServer = new HttpServer((app) => {
+  app.get('/resource', (req, res) => {
+    res.send('hello')
+  })
+  app.get('/error', (req, res) => {
+    res.status(500).send('Internal Server Error')
+  })
+  app.get('/exception', (req, res) => {
+    throw new Error('Server error')
+  })
+})
+
+beforeAll(async () => {
+  interceptor.apply()
+  interceptor.on('request', (request) => {
+    switch (true) {
+      case request.url.endsWith('/exception'): {
+        throw new Error('Network error')
+      }
+
+      case request.url.endsWith('/error'): {
+        return request.respondWith(
+          new Response('Internal Server Error', { status: 500 })
+        )
+      }
+
+      default:
+        return request.respondWith(new Response('hello'))
+    }
+  })
+
+  await httpServer.listen()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+  await httpServer.close()
+})
+
+it.each<[name: string, getUrl: () => string]>([
+  ['passthrough', () => httpServer.https.url('/resource')],
+  ['mocked', () => 'http://localhost/resource'],
+])(
+  `dispatches relevant events upon a successful %s response`,
+  async (_, getUrl) => {
+    const url = getUrl()
+
+    const onLoadStartHandler = vi.fn()
+    const onProgressHandler = vi.fn()
+    const onLoadHandler = vi.fn()
+    const onLoadEndHandler = vi.fn()
+
+    const loadStartListener = vi.fn()
+    const progressListener = vi.fn()
+    const loadListener = vi.fn()
+    const loadEndListener = vi.fn()
+
+    const request = await createXMLHttpRequest((request) => {
+      request.open('GET', url)
+
+      request.onloadstart = onLoadStartHandler
+      request.onprogress = onProgressHandler
+      request.onload = onLoadHandler
+      request.onloadend = onLoadEndHandler
+
+      request.addEventListener('loadstart', loadStartListener)
+      request.addEventListener('progress', progressListener)
+      request.addEventListener('load', loadListener)
+      request.addEventListener('loadend', loadEndListener)
+
+      request.send()
+    })
+
+    expect(request.readyState).toBe(4)
+    expect(request.status).toBe(200)
+    expect(request.responseText).toBe('hello')
+
+    expect(onLoadStartHandler).toHaveBeenCalledTimes(1)
+    expect(onProgressHandler).toHaveBeenCalledTimes(1)
+    expect(onLoadHandler).toHaveBeenCalledTimes(1)
+    expect(onLoadEndHandler).toHaveBeenCalledTimes(1)
+
+    expect(loadStartListener).toHaveBeenCalledTimes(1)
+    expect(progressListener).toHaveBeenCalledTimes(1)
+    expect(loadListener).toHaveBeenCalledTimes(1)
+    expect(loadEndListener).toHaveBeenCalledTimes(1)
+  }
+)
+
+it.each<[name: string, getUrl: () => string]>([
+  ['passthrough', () => httpServer.https.url('/error')],
+  ['mocked', () => 'http://localhost/error'],
+])(`dispatches relevant events upon a %s error response`, async (_, getUrl) => {
+  const url = getUrl()
+
+  const onLoadStartHandler = vi.fn()
+  const onProgressHandler = vi.fn()
+  const onLoadHandler = vi.fn()
+  const onLoadEndHandler = vi.fn()
+
+  const loadStartListener = vi.fn()
+  const progressListener = vi.fn()
+  const loadListener = vi.fn()
+  const loadEndListener = vi.fn()
+
+  const request = await createXMLHttpRequest((request) => {
+    request.open('GET', url)
+
+    request.onloadstart = onLoadStartHandler
+    request.onprogress = onProgressHandler
+    request.onload = onLoadHandler
+    request.onloadend = onLoadEndHandler
+
+    request.addEventListener('loadstart', loadStartListener)
+    request.addEventListener('progress', progressListener)
+    request.addEventListener('load', loadListener)
+    request.addEventListener('loadend', loadEndListener)
+
+    request.send()
+  })
+
+  expect(request.readyState).toBe(4)
+  expect(request.status).toBe(500)
+  expect(request.responseText).toBe('Internal Server Error')
+
+  expect(onLoadStartHandler).toHaveBeenCalledTimes(1)
+  expect(onProgressHandler).toHaveBeenCalledTimes(1)
+  expect(onLoadHandler).toHaveBeenCalledTimes(1)
+  expect(onLoadEndHandler).toHaveBeenCalledTimes(1)
+
+  expect(loadStartListener).toHaveBeenCalledTimes(1)
+  expect(progressListener).toHaveBeenCalledTimes(1)
+  expect(loadListener).toHaveBeenCalledTimes(1)
+  expect(loadEndListener).toHaveBeenCalledTimes(1)
+})
+
+it.each<[name: string, getUrl: () => string]>([
+  ['passthrough', () => httpServer.https.url('/exception')],
+  ['mocked', () => 'http://localhost/exception'],
+])(`dispatches relevant events upon a %s request error`, async (_, getUrl) => {
+  const url = getUrl()
+
+  const onLoadStartHandler = vi.fn()
+  const onProgressHandler = vi.fn()
+  const onLoadHandler = vi.fn()
+  const onLoadEndHandler = vi.fn()
+
+  const loadStartListener = vi.fn()
+  const progressListener = vi.fn()
+  const loadListener = vi.fn()
+  const loadEndListener = vi.fn()
+
+  const request = await createXMLHttpRequest((request) => {
+    request.open('GET', url)
+
+    request.onloadstart = onLoadStartHandler
+    request.onprogress = onProgressHandler
+    request.onload = onLoadHandler
+    request.onloadend = onLoadEndHandler
+
+    request.addEventListener('loadstart', loadStartListener)
+    request.addEventListener('progress', progressListener)
+    request.addEventListener('load', loadListener)
+    request.addEventListener('loadend', loadEndListener)
+
+    request.send()
+  })
+
+  expect(request.readyState).toBe(4)
+  expect(request.status).toBe(0)
+  expect(request.responseText).toBe('')
+
+  expect(onLoadStartHandler).not.toHaveBeenCalled()
+  expect(onProgressHandler).not.toHaveBeenCalled()
+  expect(onLoadHandler).not.toHaveBeenCalled()
+  expect(onLoadEndHandler).toHaveBeenCalledTimes(1)
+
+  expect(loadStartListener).not.toHaveBeenCalled()
+  expect(progressListener).not.toHaveBeenCalled()
+  expect(loadListener).not.toHaveBeenCalled()
+  expect(loadEndListener).toHaveBeenCalledTimes(1)
+})

--- a/test/modules/XMLHttpRequest/compliance/xhr-timeout.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-timeout.test.ts
@@ -32,7 +32,7 @@ it('handles request timeout via the "ontimeout" callback', async () => {
   const timeoutCalled = new DeferredPromise<number>()
 
   createXMLHttpRequest((req) => {
-    req.open('GET', httpServer.http.url('/'), true)
+    req.open('GET', httpServer.http.url('/'))
     req.timeout = 1
     req.ontimeout = function customTimeoutCallback() {
       timeoutCalled.resolve(this.readyState)
@@ -48,7 +48,7 @@ it('handles request timeout via the "timeout" event listener', async () => {
   const timeoutCalled = new DeferredPromise<number>()
 
   createXMLHttpRequest((req) => {
-    req.open('GET', httpServer.http.url('/'), true)
+    req.open('GET', httpServer.http.url('/'))
     req.timeout = 1
     req.addEventListener('timeout', function customTimeoutListener() {
       expect(this.readyState).toBe(4)


### PR DESCRIPTION
- Fixes #359

I still have 0 idea why JSDOM doesn't fire its setter for `onload`. It doesn't even have one. Narrowing down the workaround to concern itself only with `ontimeout`. All other event handlers seem to be working correctly (added tests). 