### PR TITLE
fix(ClientRequest): set null body for GET/HEAD requests

### DIFF
--- a/src/interceptors/ClientRequest/utils/createRequest.test.ts
+++ b/src/interceptors/ClientRequest/utils/createRequest.test.ts
@@ -60,3 +60,26 @@ it('creates a fetch Request with an empty body', async () => {
   expect(request.headers.get('Accept')).toBe('application/json')
   expect(request.body).toBe(null)
 })
+
+it('creates a fetch Request with an empty string body', async () => {
+  const clientRequest = new NodeClientRequest(
+    [
+      new URL('https://api.github.com'),
+      {
+        method: 'HEAD',
+      },
+      () => {},
+    ],
+    {
+      emitter,
+      log,
+    }
+  )
+  clientRequest.write('')
+
+  const request = createRequest(clientRequest)
+
+  expect(request.method).toBe('HEAD')
+  expect(request.url).toBe('https://api.github.com/')
+  expect(request.body).toBe(null)
+})

--- a/src/interceptors/ClientRequest/utils/createRequest.ts
+++ b/src/interceptors/ClientRequest/utils/createRequest.ts
@@ -21,10 +21,15 @@ export function createRequest(clientRequest: NodeClientRequest): Request {
     }
   }
 
+  const method = clientRequest.method || 'GET'
+
   return new Request(clientRequest.url, {
-    method: clientRequest.method || 'GET',
+    method,
     headers,
     credentials: 'same-origin',
-    body: clientRequest.requestBuffer,
+    body:
+      method === 'HEAD' || method === 'GET'
+        ? null
+        : clientRequest.requestBuffer,
   })
 }


### PR DESCRIPTION
Creating a GET or HEAD fetch Request with a non-null/undefined body throws a `TypeError`. Some (possibly misbehaving) clients (notably the Stripe Node library) write an empty string to the request buffer even for GET/HEAD, causing a failure when intercepting any of those requests.

A test has been added to `createRequest.test.ts` that fails without this change.