### PR TITLE
fix(fetch): respect AbortSignal during response patching

### DIFF
--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -68,16 +68,8 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
 
       const mockedResponse = resolverResult.data
 
-      if (mockedResponse) {
+      if (mockedResponse && !request.signal?.aborted) {
         this.log('received mocked response:', mockedResponse)
-        
-        if (request.signal.aborted) {
-          this.log('request aborted, ignoring mocked response');
-
-          // Throws an "AbortError" DOMException
-          await pureFetch(request)
-        }
-
         const responseCloine = mockedResponse.clone()
 
         this.emitter.emit(

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -70,6 +70,14 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
 
       if (mockedResponse) {
         this.log('received mocked response:', mockedResponse)
+        
+        if (request.signal.aborted) {
+          this.log('request aborted, ignoring mocked response');
+
+          // Throws an "AbortError" DOMException
+          await pureFetch(request)
+        }
+
         const responseCloine = mockedResponse.clone()
 
         this.emitter.emit(


### PR DESCRIPTION
Fixes #368

---

Makes aborting fetch requests consistent between patched and unpatched responses.

