### PR TITLE
fix: update to "@open-draft/logger@0.3.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
   },
   "dependencies": {
     "@open-draft/deferred-promise": "^2.1.0",
-    "@open-draft/logger": "^0.2.0",
+    "@open-draft/logger": "^0.3.0",
     "@open-draft/until": "^2.0.0",
     "headers-polyfill": "^3.1.0",
     "outvariant": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1004,10 +1004,10 @@
   resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-2.1.0.tgz#4fb33ebdf5c05a0e47a26490ed9037ca36275a66"
   integrity sha512-Rzd5JrXZX8zErHzgcGyngh4fmEbSHqTETdGj9rXtejlqMIgXFlyKBA7Jn1Xp0Ls0M0Y22+xHcWiEzbmdWl0BOA==
 
-"@open-draft/logger@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@open-draft/logger/-/logger-0.2.0.tgz#74bc6233698ccd96e974410d1c2b5a1d932e5f13"
-  integrity sha512-/s7NLIXIvLcRUlrs94GFj7hcxH87JZaJNr9SlDhdvDIS8ke9GcflqjNzs47kTOG7dH2AjMZ9rJgX3l7tREUVxA==
+"@open-draft/logger@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/logger/-/logger-0.3.0.tgz#2b3ab1242b360aa0adb28b85f5d7da1c133a0954"
+  integrity sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==
   dependencies:
     is-node-process "^1.2.0"
     outvariant "^1.4.0"


### PR DESCRIPTION
- Fixes [this broken CI](https://github.com/mswjs/msw/actions/runs/4688831418/jobs/8321120998?pr=1436) where Jest failed to resolve `@open-draft/logger` because I opted out from the browser resolution in JSDOM. With 0.3.0, the logger comes with a single neutral build because it's API is universal anyway. 