### PR TITLE
fix(ClientRequest): stream response chunks as they come in

### DIFF
--- a/test/modules/http/response/readable-stream.test.ts
+++ b/test/modules/http/response/readable-stream.test.ts
@@ -1,0 +1,76 @@
+import { it, expect, beforeAll, afterAll } from 'vitest'
+import https from 'https'
+import { DeferredPromise } from '@open-draft/deferred-promise'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+import { sleep } from '../../../helpers'
+
+type ResponseChunks = Array<{ buffer: Buffer; timestamp: number }>
+
+const encoder = new TextEncoder()
+
+const interceptor = new ClientRequestInterceptor()
+interceptor.on('request', (request) => {
+  const stream = new ReadableStream({
+    async start(controller) {
+      controller.enqueue(encoder.encode('first'))
+      await sleep(500)
+
+      controller.enqueue(encoder.encode('second'))
+      await sleep(500)
+
+      controller.enqueue(encoder.encode('third'))
+      await sleep(500)
+      controller.close()
+    },
+  })
+
+  request.respondWith(
+    new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+      },
+    })
+  )
+})
+
+beforeAll(async () => {
+  interceptor.apply()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+})
+
+it('supports delays when enqueuing chunks', async () => {
+  const responseChunksPromise = new DeferredPromise<ResponseChunks>()
+
+  const request = https.get('https://api.example.com/stream', (response) => {
+    const chunks: ResponseChunks = []
+
+    response.on('data', (data) => {
+      chunks.push({
+        buffer: Buffer.from(data),
+        timestamp: Date.now(),
+      })
+    })
+
+    response.once('end', () => {
+      responseChunksPromise.resolve(chunks)
+    })
+  })
+
+  request.on('error', responseChunksPromise.reject)
+
+  const responseChunks = await responseChunksPromise
+
+  const textChunks = responseChunks.map((chunk) =>
+    chunk.buffer.toString('utf8')
+  )
+  expect(textChunks).toEqual(['first', 'second', 'third'])
+
+  // Ensure that the chunks were sent over time,
+  // respecting the delay set in the mocked stream.
+  const chunkTimings = responseChunks.map((chunk) => chunk.timestamp)
+  expect(chunkTimings[1] - chunkTimings[0]).toBeGreaterThanOrEqual(500)
+  expect(chunkTimings[2] - chunkTimings[1]).toBeGreaterThanOrEqual(500)
+})


### PR DESCRIPTION
- Reported in https://github.com/mswjs/msw/discussions/1464#discussioncomment-5789415

## Changes

Sets the `res` on `ClientRequest` instance _immediately_ (previously, only when the response stream has finished reading). 

Instead of pushing to the `IncomingMessage`, emit its `data` events for each read chunk of the response stream. This is necessary because with a simple `this.response.push(value)`, the end readable stream only contained _the first chunk_. For some reason, any other chunks were ignored with the previous implementation (they never emitted the `data` event on `IncomingMessage`). 

> This is potentially dangerous but let's see what the tests tell us. 