### PR TITLE
feat: add net.Socket-based interceptor

### DIFF
--- a/test/modules/http/socket.impl.ts
+++ b/test/modules/http/socket.impl.ts
@@ -1,0 +1,228 @@
+import net from 'net'
+import { Interceptor } from '../../../src'
+
+// net.createConnection()
+// Socket.connect()
+// lookup
+// emitLookup
+// socket._handle.connect()
+// -> afterComplete
+// socket.push(null), socket.read(), socket.emit('connect'), socket.emit('ready')
+
+export interface SocketEventMap {
+  connection: () => void
+}
+
+export class SocketInterceptor extends Interceptor<SocketEventMap> {
+  static interceptorSymbol = Symbol('SocketInterceptor')
+
+  constructor() {
+    super(SocketInterceptor.interceptorSymbol)
+  }
+
+  protected setup(): void {
+    console.log('setting up the interceptor...')
+
+    const pureNetCreateConnection = net.createConnection
+    this.subscriptions.push(() => {
+      net.createConnection = pureNetCreateConnection
+    })
+  }
+}
+
+class MockSocket extends net.Socket {
+  private _handle?: SocketHandle
+
+  constructor(...args) {
+    super(...args)
+
+    console.log('MockSocket.constructor')
+
+    this.connect({
+      port: 80,
+      path: '/resource',
+      host: 'api.example.com',
+    })
+  }
+
+  normalizeConnectArgs(
+    ...args:
+      | [options: net.NetConnectOpts, callback?: () => void]
+      | [port: number, host?: string, callback?: () => void]
+      | [path: string, callback?: () => void]
+  ): [options: net.NetConnectOpts, callback?: () => void] {
+    if (typeof args[0] === 'number') {
+      if (typeof args[1] === 'string') {
+        return [{ port: args[0], host: args[1] }, args[2]]
+      }
+
+      return [{ port: args[0] }, args[1]]
+    }
+
+    if (typeof args[0] === 'string') {
+      return [{ path: args[0] }, args[1]]
+    }
+
+    return args
+  }
+
+  connect(...args: unknown[]): this {
+    const [options, callback] = this.normalizeConnectArgs(...args)
+
+    /**
+     * @note Setting "_handle" is mandatory. Without it,
+     * Node considers the socket closed.
+     * The handle is set during ".connect()" method.
+     */
+    this._handle = new SocketHandle()
+
+    if (callback) {
+      this.once('connect', callback)
+    }
+
+    /**
+     * @note Skip the DNS lookup and the actual connection
+     * and treat the socket as connected.
+     *
+     * @todo We should still perform the connection, swallow
+     * connection errors, and replay them.
+     */
+    this.emit('connect')
+    this.emit('ready')
+
+    return this
+  }
+
+  write(
+    chunk: string,
+    encoding?: BufferEncoding,
+    callback?: (error?: Error) => void
+  ) {
+    console.log('MockSocket.write', chunk, encoding, callback)
+
+    /**
+     * @note Two empty lines at the end of a socket message
+     * indicate the end of the message.
+     */
+    if (chunk.endsWith('\r\n\r\n')) {
+      process.nextTick(() => {
+        this.push('HTTP/1.1 301 Moved Permanently\r\nConnection:close\r\n')
+        this.push('\r\n')
+      })
+    }
+
+    return super.write(chunk, encoding, callback)
+  }
+}
+
+function createSocketProxy(socket: net.Socket): net.Socket {
+  socket.connect = new Proxy(socket.connect, {
+    apply(target, thisArg, args) {
+      console.warn('Socket.connect', args)
+
+      // Returns this Socket instance.
+      // Also performs the DNS lookup for the supplied host if called directly.
+      // Doesn't get called directly when using "net.createConnection()".
+      return Reflect.apply(target, thisArg, args)
+    },
+  })
+
+  socket.write = new Proxy(socket.write, {
+    apply(target, thisArg, args) {
+      const [chunk, encoding, callback] = args
+      console.log('Socket.write', args)
+      // return Reflect.apply(target, thisArg, args)
+    },
+  })
+
+  socket.on('connect', () => {
+    console.log('Socket.connect!')
+  })
+
+  socket.on('lookup', (error, address, family, host) => {
+    console.log('Socket.lookup', { error, address, family, host })
+  })
+
+  socket.on('ready', () => {
+    socket.push('HTTP/1.1 301 Moved Permanently\r\nConnection:close\r\n\r\n')
+
+    // socket.emit('readable')
+    socket.emit('end')
+    socket.emit('close')
+  })
+
+  socket.on('data', (chunk) => {
+    console.log('Socket.data:', chunk.toString('utf8'))
+  })
+
+  // 1. resume
+  // 2. write (request message)
+  // 3. emit lookup
+  // 4. emit connect
+  // 5. emit ready.
+  // 6. emit data (response message)
+  // 7. emit readable
+  // 8. emit end
+  // 9. emit close
+
+  return socket
+}
+
+interface TcpWrap {
+  address: string
+  port: number
+  localAddress?: number
+  localPort?: number
+  oncomplete(
+    status: number,
+    handle: SocketHandle,
+    tcpWrap: TcpWrap,
+    readable?: boolean,
+    writable?: boolean
+  ): number
+}
+
+class SocketHandle {
+  connect(tcpWrap: TcpWrap, ip: string, port: number) {
+    return 0
+  }
+
+  connect6() {
+    return 0
+  }
+
+  readStart() {}
+
+  readStop() {}
+
+  setNoDelay() {}
+
+  writeLatin1String() {
+    return 0
+  }
+
+  close() {}
+
+  shutdown() {
+    return 0
+  }
+}
+
+net.createConnection = new Proxy(net.createConnection, {
+  apply(target, thisArg, args) {
+    console.log('net.createConnection()', args)
+
+    /**
+     * @note You can provide a custom "lookup" function to the
+     * network connection that the Socket will use to resolve
+     * the given host to an IP address and family.
+     * This is how we can suppress DNS lookup for non-existing hosts.
+     */
+    // args[0].lookup = function (host, dnsOptions, emitLookup) {
+    //   console.log('net.lookup:', host, dnsOptions, emitLookup)
+    //   // emitLookup(null, '127.0.0.1', 4)
+    // }
+
+    return new MockSocket(...args)
+  },
+})

--- a/test/modules/http/socket.impl.ts
+++ b/test/modules/http/socket.impl.ts
@@ -21,8 +21,6 @@ export class SocketInterceptor extends Interceptor<SocketEventMap> {
   }
 
   protected setup(): void {
-    console.log('setting up the interceptor...')
-
     const pureNetCreateConnection = net.createConnection
     this.subscriptions.push(() => {
       net.createConnection = pureNetCreateConnection
@@ -35,14 +33,7 @@ class MockSocket extends net.Socket {
 
   constructor(options?: net.SocketConstructorOpts) {
     super(options)
-
-    console.log('MockSocket.constructor')
-
-    this.connect({
-      port: 80,
-      path: '/resource',
-      host: 'api.example.com',
-    })
+    this.connect(options)
   }
 
   connect(...args: unknown[]): this {

--- a/test/modules/http/socket.impl.ts
+++ b/test/modules/http/socket.impl.ts
@@ -85,59 +85,6 @@ class MockSocket extends net.Socket {
   }
 }
 
-function createSocketProxy(socket: net.Socket): net.Socket {
-  socket.connect = new Proxy(socket.connect, {
-    apply(target, thisArg, args) {
-      console.warn('Socket.connect', args)
-
-      // Returns this Socket instance.
-      // Also performs the DNS lookup for the supplied host if called directly.
-      // Doesn't get called directly when using "net.createConnection()".
-      return Reflect.apply(target, thisArg, args)
-    },
-  })
-
-  socket.write = new Proxy(socket.write, {
-    apply(target, thisArg, args) {
-      const [chunk, encoding, callback] = args
-      console.log('Socket.write', args)
-      // return Reflect.apply(target, thisArg, args)
-    },
-  })
-
-  socket.on('connect', () => {
-    console.log('Socket.connect!')
-  })
-
-  socket.on('lookup', (error, address, family, host) => {
-    console.log('Socket.lookup', { error, address, family, host })
-  })
-
-  socket.on('ready', () => {
-    socket.push('HTTP/1.1 301 Moved Permanently\r\nConnection:close\r\n\r\n')
-
-    // socket.emit('readable')
-    socket.emit('end')
-    socket.emit('close')
-  })
-
-  socket.on('data', (chunk) => {
-    console.log('Socket.data:', chunk.toString('utf8'))
-  })
-
-  // 1. resume
-  // 2. write (request message)
-  // 3. emit lookup
-  // 4. emit connect
-  // 5. emit ready.
-  // 6. emit data (response message)
-  // 7. emit readable
-  // 8. emit end
-  // 9. emit close
-
-  return socket
-}
-
 interface TcpWrap {
   address: string
   port: number

--- a/test/modules/http/socket.test.ts
+++ b/test/modules/http/socket.test.ts
@@ -1,0 +1,20 @@
+import './socket.impl'
+
+import http from 'http'
+import { it, expect } from 'vitest'
+
+it('how sockets work', async () => {
+  await new Promise<void>((resolve, reject) => {
+    http
+      .get('http://api.example.com', (response) => {
+        console.log(response.statusCode, response.statusMessage)
+        expect(response.statusCode).toBe(301)
+        resolve()
+      })
+      .on('error', reject)
+  })
+
+  // SMTP example.
+  // const socket = net.createConnection(25, 'smtp.example.com')
+  // socket.write('HELO example.com\r\n')
+})

--- a/test/modules/http/socket.test.ts
+++ b/test/modules/http/socket.test.ts
@@ -1,20 +1,29 @@
 import './socket.impl'
 
+import net from 'net'
 import http from 'http'
 import { it, expect } from 'vitest'
 
-it('how sockets work', async () => {
+it('supports HTTP requests on the Socket level', async () => {
   await new Promise<void>((resolve, reject) => {
     http
-      .get('http://api.example.com', (response) => {
+      .get('http://api.example.com/resource', (response) => {
         console.log(response.statusCode, response.statusMessage)
         expect(response.statusCode).toBe(301)
+        expect(response.statusMessage).toBe('Moved Permanently')
         resolve()
       })
       .on('error', reject)
   })
+})
 
-  // SMTP example.
-  // const socket = net.createConnection(25, 'smtp.example.com')
-  // socket.write('HELO example.com\r\n')
+it('supports SMTP requests at the Socket level', async () => {
+  const socket = net.createConnection(25, 'gmail-smtp-in.l.google.com')
+  socket.write('FROM: <user@site.com>\r\n')
+  socket.write('TO: <user@site.com>\r\n')
+  socket.write('SUBJECT: Greeting\r\n')
+  socket.write('Hello, world!\r\n')
+  socket.write('.\r\n')
+
+  socket.on('error', console.error)
 })


### PR DESCRIPTION
> Before continuing, read this https://github.com/mswjs/interceptors/issues/399

- Related to #374 

A proof of concept of a Socket-based interceptor.

## Things I learned

- `net.createConnection()` accepts a `lookup` function that we can use to resolve non-existing hosts to whatever we want. It won't automatically give us a successful connection (because that's done by `socket._handler.connect()`) but it will prevent DNS lookup issues.
- `net.creaetConnection()` accepts a custom `handler` class instance. It's an internal API responsible for provisioning the connection to a resolved address, reading/writing socket chunks, and terminating the socket. 

## Links

- https://github.com/nodejs/node/blob/main/lib/net.js#L1169
- https://github.com/nodejs/node/blob/main/lib/net.js#L1524

## Roadmap

- [ ] Socket interceptor is sensitive to import order. If you import `./socket.impl` _after_ you import `http`, it stops working. 
- [ ] Should establish the actual socket connection instead of force-emitting `connect` and `ready` events. This will improve the underlying code's integrity and allow us to replay the connection errors (very similar to what we already do in `ClientRequestInterceptor`).
- [ ] Support SMTP and other protocols (currently getting `Unsupported fd type: UNKNOWN` from `createHandle`).
- [ ] Wrap this whole thing in the `Interceptor` (`class SocketInterceptor extends Interceptor`).