### PR TITLE
fix(Interceptor): set interceptor state on the current event loop cycle

### DIFF
--- a/src/Interceptor.test.ts
+++ b/src/Interceptor.test.ts
@@ -52,21 +52,15 @@ describe('readyState', () => {
     interceptor.apply()
 
     expect(interceptor.readyState).toBe(InterceptorReadyState.INACTIVE)
-
-    await nextTickAsync(() => {
-      expect(interceptor.readyState).toBe(InterceptorReadyState.INACTIVE)
-    })
   })
 
   it('perfroms state transition when the interceptor is applying', async () => {
     const interceptor = new Interceptor(symbol)
     interceptor.apply()
 
-    expect(interceptor.readyState).toBe(InterceptorReadyState.APPLYING)
-
-    await nextTickAsync(() => {
-      expect(interceptor.readyState).toBe(InterceptorReadyState.APPLIED)
-    })
+    // The interceptor's state transitions to APPLIED immediately.
+    // The only exception is if something throws during the setup.
+    expect(interceptor.readyState).toBe(InterceptorReadyState.APPLIED)
   })
 
   it('perfroms state transition when disposing of the interceptor', async () => {
@@ -74,11 +68,9 @@ describe('readyState', () => {
     interceptor.apply()
     interceptor.dispose()
 
-    expect(interceptor.readyState).toBe(InterceptorReadyState.DISPOSING)
-
-    await nextTickAsync(() => {
-      expect(interceptor.readyState).toBe(InterceptorReadyState.DISPOSED)
-    })
+    // The interceptor's state transitions to DISPOSED immediately.
+    // The only exception is if something throws during the teardown.
+    expect(interceptor.readyState).toBe(InterceptorReadyState.DISPOSED)
   })
 })
 

--- a/src/Interceptor.ts
+++ b/src/Interceptor.ts
@@ -1,7 +1,6 @@
 import { Logger } from '@open-draft/logger'
 import { Listener } from 'strict-event-emitter'
 import { AsyncEventEmitter } from './utils/AsyncEventEmitter'
-import { nextTick } from './utils/nextTick'
 
 export type InterceptorEventMap = Record<string, any>
 export type InterceptorSubscription = () => void
@@ -115,9 +114,7 @@ export class Interceptor<Events extends InterceptorEventMap> {
         })
       }
 
-      nextTick(() => {
-        this.readyState = InterceptorReadyState.APPLIED
-      })
+      this.readyState = InterceptorReadyState.APPLIED
 
       return
     }
@@ -130,9 +127,7 @@ export class Interceptor<Events extends InterceptorEventMap> {
     // Store the newly applied interceptor instance globally.
     this.setInstance()
 
-    nextTick(() => {
-      this.readyState = InterceptorReadyState.APPLIED
-    })
+    this.readyState = InterceptorReadyState.APPLIED
   }
 
   /**
@@ -204,9 +199,7 @@ export class Interceptor<Events extends InterceptorEventMap> {
     this.emitter.deactivate()
     logger.info('destroyed the listener!')
 
-    nextTick(() => {
-      this.readyState = InterceptorReadyState.DISPOSED
-    })
+    this.readyState = InterceptorReadyState.DISPOSED
   }
 
   private getInstance(): this | undefined {

--- a/test/modules/http/compliance/http-req-write.test.ts
+++ b/test/modules/http/compliance/http-req-write.test.ts
@@ -73,8 +73,6 @@ it('writes JSON request body', async () => {
   const { res, text } = await waitForClientRequest(req)
   const expectedBody = `{"key":"value"}`
 
-  console.log(res.statusCode, res.statusMessage)
-
   expect(interceptedRequestBody).toHaveBeenCalledWith(expectedBody)
   expect(getInternalRequestBody(req).toString()).toEqual(expectedBody)
   expect(await text()).toEqual(expectedBody)


### PR DESCRIPTION
- `APPLIED` and `DISPOSED` interceptor state is now transitioned to _immediately_ (in the current event loop). 

I find it confusing that the interceptor is still showing `APPLYING` state when it's already applied. The patching logic affects the runtime as soon as it's invoked, so there is little reason to defer the interceptor's state transition to the next tick. If anything, it only results in confusing logs. 

This isn't a breaking change because nobody should rely on the internal ready state of the interceptors. 