### PR TITLE
fix(xhr): ignore body for GET/HEAD requests

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -533,7 +533,7 @@ export class XMLHttpRequestController {
        * @see https://xhr.spec.whatwg.org/#cross-origin-credentials
        */
       credentials: this.request.withCredentials ? 'include' : 'same-origin',
-      body: this.requestBody as any,
+      body: ['GET', 'HEAD'].includes(this.method) ? null : this.requestBody as any,
     })
 
     const proxyHeaders = createProxy(fetchRequest.headers, {

--- a/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.browser.test.ts
+++ b/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.browser.test.ts
@@ -134,3 +134,35 @@ test('sets "credentials" to "same-origin" on isomorphic request when "withCreden
 
   expect(request.credentials).toBe('same-origin')
 })
+
+test('ignores the body for HEAD requests', async ({ loadExample, callXMLHttpRequest}) => {
+  await loadExample(require.resolve('./XMLHttpRequest.browser.runtime.js'))
+
+  const url = httpServer.http.url('/user')
+  const call = callXMLHttpRequest({
+    method: 'HEAD',
+    url,
+    body: "test"
+  });
+
+  await expect(call).resolves.not.toThrowError()
+
+  const [request] = await call
+  expect(request.body).toBe(null)
+})
+
+test('ignores the body for GET requests', async ({ loadExample, callXMLHttpRequest}) => {
+  await loadExample(require.resolve('./XMLHttpRequest.browser.runtime.js'))
+
+  const url = httpServer.http.url('/user')
+  const call = callXMLHttpRequest({
+    method: 'GET',
+    url,
+    body: "test"
+  });
+
+  await expect(call).resolves.not.toThrowError()
+
+  const [request] = await call
+  expect(request.body).toBe(null)
+})


### PR DESCRIPTION
__TL;DR:__
- Ignore request body during transformation of `XMLHttpRequest` to `Request` when method is `HEAD` or `GET`
- Adds tests for both cases

---

__Longer description:__

`HEAD` and `GET` requests are not allowed to have request bodies.
The Request constructor throws an error if you try to construct a request with a body and one of these request methods.

```ts
new Request(location.href, { method: "GET", body: "test" });
// => TypeError: HEAD or GET Request cannot have a body
```

Because `fetch` is using `Request` under the hood, constructing a fetch fails in the same way

```ts
fetch(location.href, { method: "GET", body: "test" });
// => TypeError: HEAD or GET Request cannot have a body
```

`XMLHttpRequest` handles this scenario by not throwing an error, but ignoring the request body.
You can add a body to the request, but it won’t fail, but silently ignore the request body instead.

```ts
const req = new XMLHttpRequest();
req.addEventListener("load", console.log);
req.open("GET", <some-url>);
req.send("test");
// => OK
```

The request that will be sent, will not include the request body (Tested in FF, Chrome and Safari with a Deno server as the receiving end).

This becomes a problem when `@mswjs/interceptors` is used, because it transforms an `XMLHttpRequest` to a `Request`.
The request body of the `XMLHttpRequest` will be ignored when sending it to the server, but it will be there when the transformation happens, resulting in a `TypeError: HEAD or GET Request cannot have a body`-error.

This PR ignores the request body during the transformation to `Request`, when the method is set to `GET` or `HEAD`, resulting in the same behavior that you would get without request interception.