### PR TITLE
fix(fetch): do not print console error on request failures

### DIFF
--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -59,7 +59,6 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
       })
 
       if (resolverResult.error) {
-        console.error(`${request.method} ${request.url} net::ERR_FAILED`)
         const error = Object.assign(new TypeError('Failed to fetch'), {
           cause: resolverResult.error,
         })

--- a/test/modules/fetch/fetch-exception.browser.test.ts
+++ b/test/modules/fetch/fetch-exception.browser.test.ts
@@ -6,13 +6,6 @@ test('treats middleware exceptions as TypeError: Failed to fetch', async ({
 }) => {
   await loadExample(require.resolve('./fetch-exception.runtime.js'))
 
-  const errors: Array<string> = []
-  page.on('console', (message) => {
-    if (message.type() === 'error') {
-      errors.push(message.text())
-    }
-  })
-
   const fetchRejectionError = await page.evaluate(() => {
     return fetch('http://localhost:3001/resource').catch(
       (error: TypeError & { cause: Error }) => {
@@ -37,5 +30,4 @@ test('treats middleware exceptions as TypeError: Failed to fetch', async ({
       message: 'Network error',
     },
   })
-  expect(errors).toEqual(['GET http://localhost:3001/resource net::ERR_FAILED'])
 })

--- a/test/modules/fetch/fetch-exception.test.ts
+++ b/test/modules/fetch/fetch-exception.test.ts
@@ -21,9 +21,6 @@ afterAll(() => {
 it('treats middleware exceptions as TypeError: Failed to fetch', async () => {
   await fetch('http://localhost:3001/resource').catch(
     (error: TypeError & { cause: Error }) => {
-      expect(console.error).toHaveBeenCalledWith(
-        'GET http://localhost:3001/resource net::ERR_FAILED'
-      )
       expect(error).toBeInstanceOf(TypeError)
       expect(error.message).toBe('Failed to fetch')
       // Internal: preserve the original middleware error.


### PR DESCRIPTION
Fixes https://github.com/mswjs/interceptors/issues/381

## Description
Currently, when a network error is simulated in a response from `msw` server, as described in the [docs](https://mswjs.io/docs/api/response/network-error), (`return res.networkError('Failed to connect')), an error message with a stack trace appears in the console, although the tests would pass.

Here is an example of how this would look like to the developer who is using `msw`:

![image](https://github.com/mswjs/interceptors/assets/6834224/8570f9ae-f555-4396-8a3e-95c55da7cf53)

An error message, despite passing tests, is distracting. This PR removes the `console.error` statement responsible for this output.

When checked locally, this change cleaned up the test log:

<img src="https://github.com/mswjs/interceptors/assets/6834224/ab9b57f4-155e-4630-93a1-31b34faacf15" width="500" />