### PR TITLE
fix(xhr): fix onloadend not being called

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -67,9 +67,9 @@ export class XMLHttpRequestController {
              * called in node though, which is why we never call `invoke` for `onloadend`
              * to ensure a similar behavior in node and the browser.
              */
-            if (propertyName !== "onloadend") {
-              return invoke()
-            }
+            return propertyName === "onloadend"
+              ? true
+              : invoke();
           }
 
           default: {

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -48,7 +48,6 @@ export class XMLHttpRequestController {
     this.request = createProxy(initialRequest, {
       setProperty: ([propertyName, nextValue], invoke) => {
         switch (propertyName) {
-          case 'onloadend':
           case 'ontimeout': {
             const eventName = propertyName.slice(
               2
@@ -61,15 +60,7 @@ export class XMLHttpRequestController {
              */
             this.request.addEventListener(eventName, nextValue as any)
 
-            /**
-             * @note Calling invoke for the `onloadend` event does not have an effect
-             * in browsers. The `onloadend` handler will never be called. It will be
-             * called in node though, which is why we never call `invoke` for `onloadend`
-             * to ensure a similar behavior in node and the browser.
-             */
-            return propertyName === "onloadend"
-              ? true
-              : invoke();
+            return invoke()
           }
 
           default: {
@@ -542,7 +533,9 @@ export class XMLHttpRequestController {
        * @see https://xhr.spec.whatwg.org/#cross-origin-credentials
        */
       credentials: this.request.withCredentials ? 'include' : 'same-origin',
-      body: ['GET', 'HEAD'].includes(this.method) ? null : this.requestBody as any,
+      body: ['GET', 'HEAD'].includes(this.method)
+        ? null
+        : (this.requestBody as any),
     })
 
     const proxyHeaders = createProxy(fetchRequest.headers, {

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -61,7 +61,15 @@ export class XMLHttpRequestController {
              */
             this.request.addEventListener(eventName, nextValue as any)
 
-            return invoke()
+            /**
+             * @note Calling invoke for the `onloadend` event does not have an effect
+             * in browsers. The `onloadend` handler will never be called. It will be
+             * called in node though, which is why we never call `invoke` for `onloadend`
+             * to ensure a similar behavior in node and the browser.
+             */
+            if (propertyName !== "onloadend") {
+              return invoke()
+            }
           }
 
           default: {

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -48,6 +48,7 @@ export class XMLHttpRequestController {
     this.request = createProxy(initialRequest, {
       setProperty: ([propertyName, nextValue], invoke) => {
         switch (propertyName) {
+          case 'onloadend':
           case 'ontimeout': {
             const eventName = propertyName.slice(
               2

--- a/src/utils/createProxy.test.ts
+++ b/src/utils/createProxy.test.ts
@@ -147,3 +147,16 @@ it('spies on method calls', () => {
     expect.any(Function)
   )
 })
+
+it('proxies properties on the prototype level', () => {
+  const method = vi.fn()
+  const prototype = { method }
+
+  const proxy = createProxy(Object.create(prototype), {})
+  const proxyMethod = vi.fn()
+  proxy.method = proxyMethod
+
+  prototype.method()
+  expect(method).toHaveBeenCalledTimes(0)
+  expect(proxyMethod).toHaveBeenCalledTimes(1)
+})

--- a/src/utils/createProxy.ts
+++ b/src/utils/createProxy.ts
@@ -1,3 +1,5 @@
+import { findPropertySource } from './findPropertySource'
+
 export interface ProxyOptions<Target extends Record<string, any>> {
   constructorCall?(args: Array<unknown>, next: NextFunction<Target>): Target
 
@@ -44,8 +46,11 @@ function optionsToProxyHandler<T extends Record<string, any>>(
 
   handler.set = function (target, propertyName, nextValue, receiver) {
     const next = () => {
+      const propertySource = findPropertySource(target, propertyName)
+      if (propertySource === null) return false
+
       const ownDescriptors = Reflect.getOwnPropertyDescriptor(
-        target,
+        propertySource,
         propertyName
       )
 
@@ -54,7 +59,7 @@ function optionsToProxyHandler<T extends Record<string, any>>(
         return true
       }
 
-      return Reflect.defineProperty(target, propertyName, {
+      return Reflect.defineProperty(propertySource, propertyName, {
         writable: true,
         enumerable: true,
         configurable: true,

--- a/src/utils/findPropertySource.test.ts
+++ b/src/utils/findPropertySource.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { findPropertySource } from './findPropertySource'
+
+describe('findPropertySource', () => {
+  it('does return the source for objects without prototypes', () => {
+    const obj = Object.create(null)
+    obj.test = undefined
+    const source = findPropertySource(obj, 'test')
+    expect(source).toBe(obj)
+  })
+
+  it('does return the source for objects with prototypes', () => {
+    const prototype = Object.create(null)
+    prototype.test = undefined
+
+    const obj = Object.create(prototype)
+
+    const source = findPropertySource(obj, 'test')
+    expect(source).toBe(prototype)
+  })
+
+  it('does return null if the prototype chain does not contain the property', () => {
+    const prototype = Object.create(null)
+    const obj = Object.create(prototype)
+
+    const source = findPropertySource(obj, 'test')
+    expect(source).toBeNull()
+  })
+})

--- a/src/utils/findPropertySource.ts
+++ b/src/utils/findPropertySource.ts
@@ -1,0 +1,12 @@
+export function findPropertySource(
+  target: object,
+  propertyName: string | symbol
+): object | null {
+  if (propertyName in target === false) return null
+
+  const hasProperty = Object.prototype.hasOwnProperty.call(target, propertyName)
+  if (hasProperty) return target
+
+  const prototype = Reflect.getPrototypeOf(target)
+  return prototype ? findPropertySource(prototype, propertyName) : null
+}

--- a/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.browser.runtime.js
+++ b/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.browser.runtime.js
@@ -1,0 +1,19 @@
+import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
+
+const interceptor = new XMLHttpRequestInterceptor()
+interceptor.on('request', async (request, requestId) => {
+  window.dispatchEvent(
+    new CustomEvent('resolver', {
+      detail: {
+        id: requestId,
+        method: request.method,
+        url: request.url,
+        headers: Object.fromEntries(request.headers.entries()),
+        credentials: request.credentials,
+        body: await request.text(),
+      },
+    })
+  )
+})
+
+interceptor.apply()

--- a/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.browser.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.browser.test.ts
@@ -17,7 +17,7 @@ test.afterAll(async () => {
   await httpServer.close()
 })
 
-test.only('onloadend handler is called', async ({ page, loadExample }) => {
+test('onloadend handler is called', async ({ page, loadExample }) => {
   await loadExample(require.resolve('./xhr-event-handlers.browser.runtime.js'))
 
   const { request, calls } = await page.evaluate(async (url) => {

--- a/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.browser.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.browser.test.ts
@@ -1,0 +1,55 @@
+import { HttpServer } from '@open-draft/test-server/http'
+import { test, expect } from '../../../playwright.extend'
+import { useCors } from '../../../helpers'
+
+const httpServer = new HttpServer((app) => {
+  app.use(useCors)
+  app.get('/resource', (req, res) => {
+    res.status(200).send('hello')
+  })
+})
+
+test.beforeAll(async () => {
+  await httpServer.listen()
+})
+
+test.afterAll(async () => {
+  await httpServer.close()
+})
+
+test.only('onloadend handler is called', async ({ page, loadExample }) => {
+  await loadExample(require.resolve('./xhr-event-handlers.browser.runtime.js'))
+
+  const { request, calls } = await page.evaluate(async (url) => {
+    const calls = {
+      loadEndHandler: 0,
+      loadEndListener: 0,
+    }
+
+    const xhr = new XMLHttpRequest()
+    xhr.open('GET', url)
+    xhr.onloadend = () => calls.loadEndHandler++
+    xhr.addEventListener('loadend', () => calls.loadEndListener++)
+
+    await Promise.all([
+      new Promise((resolve) => {
+        const resolveDelayed = () => setTimeout(resolve, 1000)
+        xhr.addEventListener('error', resolveDelayed)
+        xhr.addEventListener('load', resolveDelayed)
+      }),
+      xhr.send(null),
+    ])
+
+    return {
+      request: xhr,
+      calls,
+    }
+  }, httpServer.http.url('/resource'))
+
+  expect(request.readyState).toBe(4)
+  expect(request.status).toBe(200)
+  expect(request.responseText).toBe('hello')
+
+  expect(calls.loadEndHandler).toBe(1)
+  expect(calls.loadEndListener).toBe(1)
+})


### PR DESCRIPTION
The `onloadend` event handler is not being called if we do not send mocked response from a request interceptor:

```ts
import { XMLHttpRequestInterceptor } from "@mswjs/interceptors/XMLHttpRequest";
import { BatchInterceptor } from "@mswjs/interceptors";

const interceptor = new BatchInterceptor({
  name: "my-interceptor",
  interceptors: [new XMLHttpRequestInterceptor()],
});

interceptor.on("request", (req) => {
  console.log("new request", req);
})

interceptor.apply();

function handleResponse(event: any) {
  console.log(`[Response] Type: ${event.type}`);
  console.log(`[Response] Content: ${xhr.responseText}`);
}

const xhr = new XMLHttpRequest();
xhr.open("GET", <some-url>);

// This works as expected
xhr.addEventListener("loadend", handleResponse);

// This will never be called
xhr.onloadend = handleResponse;

xhr.send(null);
```

This is caused by `onloadend` not being located on `XMLHttpRequest`, but on `XMLHttpRequestEventTarget` which is part of its prototype chain (`XMLHttpRequest` <- `XMLHttpRequestPrototype` <- `XMLHttpRequestEventTargetPrototype`).

Because of that the property descriptor for `onloadend` is not found and we patch it on the `XMLHttpRequest`. When the browser calls the setter for `onloadend`, it does that on `XMLHttpRequestEventTarget`, which is why our proxy does not get notified.

This PR fixes the issue by walking the prototype chain, until it finds the property it is looking for. Redefining the property or looking for a property descriptor is done on the same level where the property is defined.

The vitest tests in `xhr-event-handlers.test.ts` do not complain about the issue, I am sure in which environment they are running, but it is an issue in browsers. I have added a playwright test because of that.

---

As a sidenote: While looking for a fix, I found https://github.com/mswjs/interceptors/blob/v0.22.15/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts#L51-L64, which looks like it could be caused by a similar issue. I have removed the highlighted part and ran the tests. They run without errors, so if there is a test covering that part it might be fixed.