### PR TITLE
feat: make interceptor arguments an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,12 @@ interceptor.on('request', ({ request, requestId }) => {
 
 // Listen to any responses sent to "http.ClientRequest".
 // Note that this listener is read-only and cannot affect responses.
-interceptor.on('response', ({ response, request, requestId }) => {
-  console.log('response to %s %s was:', request.method, request.url, response)
-})
+interceptor.on(
+  'response',
+  ({ response, isMockedResponse, request, requestId }) => {
+    console.log('response to %s %s was:', request.method, request.url, response)
+  }
+)
 ```
 
 All HTTP request interceptors implement the same events:
@@ -272,6 +275,21 @@ interceptor.on('request', async ({ request, requestId }) => {
   request.respondWith(new Response(null, { status: 500 }))
 })
 ```
+
+## Observing responses
+
+You can use the "response" event to transparently observe any incoming responses in your Node.js process.
+
+```js
+interceptor.on(
+  'response',
+  ({ response, isMockedResponse, request, requestId }) => {
+    // react to the incoming response...
+  }
+)
+```
+
+> Note that the `isMockedResponse` property will only be set to `true` if you resolved this request in the "request" event listener using the `request.respondWith()` method and providing a mocked `Response` instance.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ interceptor.apply()
 
 // Listen to any "http.ClientRequest" being dispatched,
 // and log its method and full URL.
-interceptor.on('request', (request, requestId) => {
+interceptor.on('request', ({ request, requestId }) => {
   console.log(request.method, request.url)
 })
 
 // Listen to any responses sent to "http.ClientRequest".
 // Note that this listener is read-only and cannot affect responses.
-interceptor.on('response', (response, request) => {
+interceptor.on('response', ({ response, request, requestId }) => {
   console.log('response to %s %s was:', request.method, request.url, response)
 })
 ```
@@ -203,7 +203,7 @@ All HTTP request interceptors emit a "request" event. In the listener to this ev
 > There are many ways to describe a request in Node.js but this library coerces different request definitions to a single specification-compliant `Request` instance to make the handling consistent.
 
 ```js
-interceptor.on('reqest', (request, requestId) => {
+interceptor.on('reqest', ({ request, requestId }) => {
   console.log(request.method, request.url)
 })
 ```
@@ -211,7 +211,7 @@ interceptor.on('reqest', (request, requestId) => {
 Since the exposed `request` instance implements the Fetch API specification, you can operate with it just as you do with the regular browser request. For example, this is how you would read the request body as JSON:
 
 ```js
-interceptor.on('request', async (request, requestId) => {
+interceptor.on('request', async ({ request, requestId }) => {
   const json = await request.clone().json()
 })
 ```
@@ -223,7 +223,7 @@ interceptor.on('request', async (request, requestId) => {
 Request representations are readonly. You can, however, mutate the intercepted request's headers in the "request" listener:
 
 ```js
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   request.headers.set('X-My-Header', 'true')
 })
 ```
@@ -237,7 +237,7 @@ Although this library can be used purely for request introspection purposes, you
 Use the `request.respondWith()` method to respond to a request with a mocked response:
 
 ```js
-interceptor.on('request', (request, requestId) => {
+interceptor.on('request', ({ request, requestId }) => {
   request.respondWith(
     new Response(
       JSON.stringify({
@@ -267,7 +267,7 @@ Requests must be responded to within the same tick as the request listener. This
 ```js
 // Respond to all requests with a 500 response
 // delayed by 500ms.
-interceptor.on('request', async (request, requestId) => {
+interceptor.on('request', async ({ request, requestId }) => {
   await sleep(500)
   request.respondWith(new Response(null, { status: 500 }))
 })
@@ -312,7 +312,7 @@ const interceptor = new BatchInterceptor({
 
 interceptor.apply()
 
-interceptor.on('request', (request, requestId) => {
+interceptor.on('request', ({ request, requestId }) => {
   // Inspect the intercepted "request".
   // Optionally, return a mocked response.
 })
@@ -360,7 +360,7 @@ const resolver = new RemoteHttpResolver({
   process: appProcess,
 })
 
-resolver.on('request', (request, requestId) => {
+resolver.on('request', ({ request, requestId }) => {
   // Optionally, return a mocked response
   // for a request that occurred in the "appProcess".
 })

--- a/src/RemoteHttpInterceptor.ts
+++ b/src/RemoteHttpInterceptor.ts
@@ -209,6 +209,7 @@ export class RemoteHttpResolver extends Interceptor<HttpRequestEventMap> {
           // not to rely on the back-and-forth signaling for the sake of the event.
           this.emitter.emit('response', {
             response: responseClone,
+            isMockedResponse: true,
             request: capturedRequest,
             requestId: requestJson.id,
           })

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -14,6 +14,7 @@ export type HttpRequestEventMap = {
   response: [
     args: {
       response: Response
+      isMockedResponse: boolean
       request: Request
       requestId: string
     }

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -5,6 +5,17 @@ export const IS_PATCHED_MODULE: unique symbol = Symbol('isPatchedModule')
 export type RequestCredentials = 'omit' | 'include' | 'same-origin'
 
 export type HttpRequestEventMap = {
-  request: [request: InteractiveRequest, requestId: string]
-  response: [response: Response, request: Request, requestId: string]
+  request: [
+    args: {
+      request: InteractiveRequest
+      requestId: string
+    }
+  ]
+  response: [
+    args: {
+      response: Response
+      request: Request
+      requestId: string
+    }
+  ]
 }

--- a/src/interceptors/ClientRequest/NodeClientRequest.test.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.test.ts
@@ -48,7 +48,7 @@ it('gracefully finishes the request when it has a mocked response', async () => 
     }
   )
 
-  emitter.on('request', (request) => {
+  emitter.on('request', ({ request }) => {
     request.respondWith(
       new Response('mocked-response', {
         status: 301,
@@ -97,7 +97,7 @@ it('responds with a mocked response when requesting an existing hostname', async
     }
   )
 
-  emitter.on('request', (request) => {
+  emitter.on('request', ({ request }) => {
     request.respondWith(new Response('mocked-response', { status: 201 }))
   })
 
@@ -198,7 +198,7 @@ it('does not emit ENOTFOUND error connecting to an inactive server given mocked 
     { emitter, logger }
   )
 
-  emitter.on('request', async (request) => {
+  emitter.on('request', async ({ request }) => {
     await sleep(250)
     request.respondWith(
       new Response(null, { status: 200, statusText: 'Works' })
@@ -231,7 +231,7 @@ it('does not emit ECONNREFUSED error connecting to an inactive server given mock
     }
   )
 
-  emitter.on('request', async (request) => {
+  emitter.on('request', async ({ request }) => {
     await sleep(250)
     request.respondWith(
       new Response(null, { status: 200, statusText: 'Works' })
@@ -295,7 +295,7 @@ it('does not send request body to the original server given mocked response', as
     }
   )
 
-  emitter.on('request', async (request) => {
+  emitter.on('request', async ({ request }) => {
     await sleep(200)
     request.respondWith(new Response('mock created!', { status: 301 }))
   })

--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -229,6 +229,7 @@ export class NodeClientRequest extends ClientRequest {
         this.logger.info('emitting the custom "response" event...')
         this.emitter.emit('response', {
           response: responseClone,
+          isMockedResponse: true,
           request: capturedRequest,
           requestId,
         })
@@ -247,6 +248,7 @@ export class NodeClientRequest extends ClientRequest {
         this.logger.info('emitting the custom "response" event...')
         this.emitter.emit('response', {
           response: createResponse(message),
+          isMockedResponse: false,
           request: capturedRequest,
           requestId,
         })

--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -155,14 +155,17 @@ export class NodeClientRequest extends ClientRequest {
       'emitting the "request" event for %d listener(s)...',
       this.emitter.listenerCount('request')
     )
-    this.emitter.emit('request', interactiveRequest, requestId)
+    this.emitter.emit('request', {
+      request: interactiveRequest,
+      requestId,
+    })
 
     // Execute the resolver Promise like a side-effect.
     // Node.js 16 forces "ClientRequest.end" to be synchronous and return "this".
     until(async () => {
       await this.emitter.untilIdle(
         'request',
-        ({ args: [, pendingRequestId] }) => {
+        ({ args: [{ requestId: pendingRequestId }] }) => {
           /**
            * @note Await only those listeners that are relevant to this request.
            * This prevents extraneous parallel request from blocking the resolution
@@ -224,7 +227,11 @@ export class NodeClientRequest extends ClientRequest {
         callback?.()
 
         this.logger.info('emitting the custom "response" event...')
-        this.emitter.emit('response', responseClone, capturedRequest, requestId)
+        this.emitter.emit('response', {
+          response: responseClone,
+          request: capturedRequest,
+          requestId,
+        })
 
         this.logger.info('request (mock) is completed')
 
@@ -238,12 +245,11 @@ export class NodeClientRequest extends ClientRequest {
         this.logger.info('original response headers:', message.headers)
 
         this.logger.info('emitting the custom "response" event...')
-        this.emitter.emit(
-          'response',
-          createResponse(message),
-          capturedRequest,
-          requestId
-        )
+        this.emitter.emit('response', {
+          response: createResponse(message),
+          request: capturedRequest,
+          requestId,
+        })
       })
 
       return this.passthrough(chunk, encoding, callback)

--- a/src/interceptors/ClientRequest/index.test.ts
+++ b/src/interceptors/ClientRequest/index.test.ts
@@ -28,12 +28,12 @@ afterAll(async () => {
 it('forbids calling "respondWith" multiple times for the same request', async () => {
   const requestUrl = httpServer.http.url('/')
 
-  interceptor.on('request', function firstRequestListener(request) {
+  interceptor.on('request', function firstRequestListener({ request }) {
     request.respondWith(new Response())
   })
 
   const secondRequestEmitted = new DeferredPromise<void>()
-  interceptor.on('request', function secondRequestListener(request) {
+  interceptor.on('request', function secondRequestListener({ request }) {
     expect(() =>
       request.respondWith(new Response(null, { status: 301 }))
     ).toThrow(

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -25,8 +25,10 @@ export class XMLHttpRequestController {
   public requestId?: string
   public onRequest?: (
     this: XMLHttpRequestController,
-    request: Request,
-    requestId: string
+    args: {
+      request: Request
+      requestId: string
+    }
   ) => Promise<void>
   public onResponse?: (
     this: XMLHttpRequestController,
@@ -153,8 +155,10 @@ export class XMLHttpRequestController {
             // Delegate request handling to the consumer.
             const fetchRequest = this.toFetchApiRequest()
             const onceRequestSettled =
-              this.onRequest?.call(this, fetchRequest, this.requestId!) ||
-              Promise.resolve()
+              this.onRequest?.call(this, {
+                request: fetchRequest,
+                requestId: this.requestId!,
+              }) || Promise.resolve()
 
             onceRequestSettled.finally(() => {
               // If the consumer didn't handle the request perform it as-is.

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -1,3 +1,4 @@
+import { invariant } from 'outvariant'
 import { headersToString } from 'headers-polyfill'
 import type { Logger } from '@open-draft/logger'
 import { concatArrayBuffer } from './utils/concatArrayBuffer'
@@ -12,7 +13,8 @@ import { isDomParserSupportedType } from './utils/isDomParserSupportedType'
 import { parseJson } from '../../utils/parseJson'
 import { uuidv4 } from '../../utils/uuid'
 import { createResponse } from './utils/createResponse'
-import { invariant } from 'outvariant'
+
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 
 /**
  * An `XMLHttpRequest` instance controller that allows us
@@ -28,9 +30,12 @@ export class XMLHttpRequestController {
   ) => Promise<void>
   public onResponse?: (
     this: XMLHttpRequestController,
-    response: Response,
-    request: Request,
-    requestId: string
+    args: {
+      response: Response
+      isMockedResponse: boolean
+      request: Request
+      requestId: string
+    }
   ) => void
 
   private method: string = 'GET'
@@ -136,12 +141,12 @@ export class XMLHttpRequestController {
                 )
 
                 // Notify the consumer about the response.
-                this.onResponse.call(
-                  this,
-                  fetchResponse,
-                  fetchRequest,
-                  this.requestId!
-                )
+                this.onResponse.call(this, {
+                  response: fetchResponse,
+                  isMockedResponse: IS_MOCKED_RESPONSE in this.request,
+                  request: fetchRequest,
+                  requestId: this.requestId!,
+                })
               }
             })
 
@@ -208,6 +213,13 @@ export class XMLHttpRequestController {
       response.status,
       response.statusText
     )
+
+    /**
+     * @note Since `XMLHttpRequestController` delegates the handling of the responses
+     * to the "load" event listener that doesn't distinguish between the mocked and original
+     * responses, mark the request that had a mocked response with a corresponding symbol.
+     */
+    define(this.request, IS_MOCKED_RESPONSE, true)
 
     define(this.request, 'status', response.status)
     define(this.request, 'statusText', response.statusText)
@@ -533,7 +545,9 @@ export class XMLHttpRequestController {
        * @see https://xhr.spec.whatwg.org/#cross-origin-credentials
        */
       credentials: this.request.withCredentials ? 'include' : 'same-origin',
-      body: ['GET', 'HEAD'].includes(this.method) ? null : this.requestBody as any,
+      body: ['GET', 'HEAD'].includes(this.method)
+        ? null
+        : (this.requestBody as any),
     })
 
     const proxyHeaders = createProxy(fetchRequest.headers, {
@@ -573,7 +587,11 @@ function toAbsoluteUrl(url: string | URL): URL {
   return new URL(url.toString(), location.href)
 }
 
-function define(target: object, property: string, value: unknown): void {
+function define(
+  target: object,
+  property: string | symbol,
+  value: unknown
+): void {
   Reflect.defineProperty(target, property, {
     // Ensure writable properties to allow redefining readonly properties.
     writable: true,

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestProxy.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestProxy.ts
@@ -55,14 +55,17 @@ export function createXMLHttpRequestProxy({
           'emitting the "request" event for %s listener(s)...',
           emitter.listenerCount('request')
         )
-        emitter.emit('request', interactiveRequest, requestId)
+        emitter.emit('request', {
+          request: interactiveRequest,
+          requestId,
+        })
 
         this.logger.info('awaiting mocked response...')
 
         const resolverResult = await until(async () => {
           await emitter.untilIdle(
             'request',
-            ({ args: [, pendingRequestId] }) => {
+            ({ args: [{ requestId: pendingRequestId }] }) => {
               return pendingRequestId === requestId
             }
           )
@@ -119,7 +122,11 @@ export function createXMLHttpRequestProxy({
           emitter.listenerCount('response')
         )
 
-        emitter.emit('response', response, request, requestId)
+        emitter.emit('response', {
+          response,
+          request,
+          requestId,
+        })
       }
 
       // Return the proxied request from the controller

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestProxy.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestProxy.ts
@@ -112,11 +112,12 @@ export function createXMLHttpRequestProxy({
         )
       }
 
-      requestController.onResponse = async function (
+      requestController.onResponse = async function ({
         response,
+        isMockedResponse,
         request,
-        requestId
-      ) {
+        requestId,
+      }) {
         this.logger.info(
           'emitting the "response" event for %s listener(s)...',
           emitter.listenerCount('response')
@@ -124,6 +125,7 @@ export function createXMLHttpRequestProxy({
 
         emitter.emit('response', {
           response,
+          isMockedResponse,
           request,
           requestId,
         })

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestProxy.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestProxy.ts
@@ -47,7 +47,7 @@ export function createXMLHttpRequestProxy({
         logger
       )
 
-      requestController.onRequest = async function (request, requestId) {
+      requestController.onRequest = async function ({ request, requestId }) {
         // Notify the consumer about a new request.
         const interactiveRequest = toInteractiveRequest(request)
 

--- a/src/interceptors/XMLHttpRequest/index.ts
+++ b/src/interceptors/XMLHttpRequest/index.ts
@@ -5,10 +5,10 @@ import { Interceptor } from '../../Interceptor'
 import { AsyncEventEmitter } from '../../utils/AsyncEventEmitter'
 import { createXMLHttpRequestProxy } from './XMLHttpRequestProxy'
 
-export type XMLHttpRequestEventListener = (
-  request: InteractiveRequest,
+export type XMLHttpRequestEventListener = (args: {
+  request: InteractiveRequest
   requestId: string
-) => Promise<void> | void
+}) => Promise<void> | void
 
 export type XMLHttpRequestEmitter = AsyncEventEmitter<HttpRequestEventMap>
 

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -39,14 +39,17 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
         'emitting the "request" event for %d listener(s)...',
         this.emitter.listenerCount('request')
       )
-      this.emitter.emit('request', interactiveRequest, requestId)
+      this.emitter.emit('request', {
+        request: interactiveRequest,
+        requestId,
+      })
 
       this.logger.info('awaiting for the mocked response...')
 
       const resolverResult = await until(async () => {
         await this.emitter.untilIdle(
           'request',
-          ({ args: [, pendingRequestId] }) => {
+          ({ args: [{ requestId: pendingRequestId }] }) => {
             return pendingRequestId === requestId
           }
         )
@@ -70,14 +73,13 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
 
       if (mockedResponse && !request.signal?.aborted) {
         this.logger.info('received mocked response:', mockedResponse)
-        const responseCloine = mockedResponse.clone()
+        const responseClone = mockedResponse.clone()
 
-        this.emitter.emit(
-          'response',
-          responseCloine,
-          interactiveRequest,
-          requestId
-        )
+        this.emitter.emit('response', {
+          response: responseClone,
+          request: interactiveRequest,
+          requestId,
+        })
 
         const response = new Response(mockedResponse.body, mockedResponse)
 
@@ -98,12 +100,11 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
         const responseClone = response.clone()
         this.logger.info('original fetch performed', responseClone)
 
-        this.emitter.emit(
-          'response',
-          responseClone,
-          interactiveRequest,
-          requestId
-        )
+        this.emitter.emit('response', {
+          response: responseClone,
+          request: interactiveRequest,
+          requestId,
+        })
 
         return response
       })

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -77,6 +77,7 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
 
         this.emitter.emit('response', {
           response: responseClone,
+          isMockedResponse: true,
           request: interactiveRequest,
           requestId,
         })
@@ -102,6 +103,7 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
 
         this.emitter.emit('response', {
           response: responseClone,
+          isMockedResponse: false,
           request: interactiveRequest,
           requestId,
         })

--- a/test/features/events/request.test.ts
+++ b/test/features/events/request.test.ts
@@ -59,7 +59,7 @@ it('ClientRequest: emits the "request" event upon the request', async () => {
 
   expect(requestListener).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = requestListener.mock.calls[0]
+  const [{ request, requestId }] = requestListener.mock.calls[0]
 
   expect(request.method).toBe('POST')
   expect(request.url).toBe(url)
@@ -87,7 +87,7 @@ it('XMLHttpRequest: emits the "request" event upon the request', async () => {
    */
   expect(requestListener).toHaveBeenCalledTimes(2)
 
-  const [request, requestId] = requestListener.mock.calls[0]
+  const [{ request, requestId }] = requestListener.mock.calls[0]
 
   expect(request.method).toBe('POST')
   expect(request.url).toBe(url)

--- a/test/features/events/response.test.ts
+++ b/test/features/events/response.test.ts
@@ -44,7 +44,7 @@ const interceptor = new BatchInterceptor({
   ],
 })
 
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   const url = new URL(request.url)
 
   if (url.pathname === '/user') {
@@ -97,7 +97,7 @@ it('ClientRequest: emits the "response" event for a mocked response', async () =
 
   expect(responseListener).toHaveBeenCalledTimes(1)
 
-  const [response, request] = responseListener.mock.calls[0]
+  const [{ response, request }] = responseListener.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(httpServer.https.url('/user'))
@@ -128,7 +128,7 @@ it('ClientRequest: emits the "response" event upon the original response', async
 
   expect(responseListener).toHaveBeenCalledTimes(1)
 
-  const [response, request] = responseListener.mock.calls[0]
+  const [{ response, request }] = responseListener.mock.calls[0]
 
   expect(request.method).toBe('POST')
   expect(request.url).toBe(httpServer.https.url('/account'))
@@ -154,8 +154,8 @@ it('XMLHttpRequest: emits the "response" event upon a mocked response', async ()
 
   expect(responseListener).toHaveBeenCalledTimes(1)
 
-  const [response, request] = responseListener.mock.calls.find(
-    ([_, request]) => {
+  const [{ response, request }] = responseListener.mock.calls.find(
+    ([{ request }]) => {
       // The first response event will be from the "OPTIONS" preflight request.
       return request.method === 'GET'
     }
@@ -195,8 +195,8 @@ it('XMLHttpRequest: emits the "response" event upon the original response', asyn
   expect(responseListener).toHaveBeenCalledTimes(1)
 
   // Lookup the correct response listener call.
-  const [response, request] = responseListener.mock.calls.find(
-    ([_, request]) => {
+  const [{ response, request }] = responseListener.mock.calls.find(
+    ([{ request }]) => {
       return request.method === 'POST'
     }
   )!
@@ -231,7 +231,7 @@ it('fetch: emits the "response" event upon a mocked response', async () => {
 
   expect(responseListener).toHaveBeenCalledTimes(1)
 
-  const [response, request] = responseListener.mock.calls[0]
+  const [{ response, request }] = responseListener.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(httpServer.https.url('/user'))
@@ -262,7 +262,7 @@ it('fetch: emits the "response" event upon the original response', async () => {
     expect(responseListener).toHaveBeenCalledTimes(1)
   })
 
-  const [response, request] = responseListener.mock.calls[0]
+  const [{ response, request }] = responseListener.mock.calls[0]
 
   expect(request.method).toBe('POST')
   expect(request.url).toBe(httpServer.https.url('/account'))

--- a/test/features/events/response.test.ts
+++ b/test/features/events/response.test.ts
@@ -97,7 +97,8 @@ it('ClientRequest: emits the "response" event for a mocked response', async () =
 
   expect(responseListener).toHaveBeenCalledTimes(1)
 
-  const [{ response, request }] = responseListener.mock.calls[0]
+  const [{ response, request, isMockedResponse }] =
+    responseListener.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(httpServer.https.url('/user'))
@@ -109,6 +110,8 @@ it('ClientRequest: emits the "response" event for a mocked response', async () =
   expect(response.statusText).toBe('OK')
   expect(response.headers.get('x-response-type')).toBe('mocked')
   expect(await response.text()).toBe('mocked-response-text')
+
+  expect(isMockedResponse).toBe(true)
 })
 
 it('ClientRequest: emits the "response" event upon the original response', async () => {
@@ -128,7 +131,8 @@ it('ClientRequest: emits the "response" event upon the original response', async
 
   expect(responseListener).toHaveBeenCalledTimes(1)
 
-  const [{ response, request }] = responseListener.mock.calls[0]
+  const [{ response, request, isMockedResponse }] =
+    responseListener.mock.calls[0]
 
   expect(request.method).toBe('POST')
   expect(request.url).toBe(httpServer.https.url('/account'))
@@ -140,6 +144,8 @@ it('ClientRequest: emits the "response" event upon the original response', async
   expect(response.statusText).toBe('OK')
   expect(response.headers.get('x-response-type')).toBe('original')
   expect(await response.text()).toBe('original-response-text')
+
+  expect(isMockedResponse).toBe(false)
 })
 
 it('XMLHttpRequest: emits the "response" event upon a mocked response', async () => {
@@ -154,12 +160,11 @@ it('XMLHttpRequest: emits the "response" event upon a mocked response', async ()
 
   expect(responseListener).toHaveBeenCalledTimes(1)
 
-  const [{ response, request }] = responseListener.mock.calls.find(
-    ([{ request }]) => {
+  const [{ response, request, isMockedResponse }] =
+    responseListener.mock.calls.find(([{ request }]) => {
       // The first response event will be from the "OPTIONS" preflight request.
       return request.method === 'GET'
-    }
-  )!
+    })!
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(httpServer.https.url('/user'))
@@ -171,6 +176,7 @@ it('XMLHttpRequest: emits the "response" event upon a mocked response', async ()
   expect(response.statusText).toBe('OK')
   expect(response.headers.get('x-response-type')).toBe('mocked')
   expect(await response.text()).toBe('mocked-response-text')
+  expect(isMockedResponse).toBe(true)
 
   // Original response.
   expect(originalRequest.responseText).toEqual('mocked-response-text')
@@ -195,11 +201,10 @@ it('XMLHttpRequest: emits the "response" event upon the original response', asyn
   expect(responseListener).toHaveBeenCalledTimes(1)
 
   // Lookup the correct response listener call.
-  const [{ response, request }] = responseListener.mock.calls.find(
-    ([{ request }]) => {
+  const [{ response, request, isMockedResponse }] =
+    responseListener.mock.calls.find(([{ request }]) => {
       return request.method === 'POST'
-    }
-  )!
+    })!
 
   expect(request).toBeDefined()
   expect(response).toBeDefined()
@@ -214,6 +219,8 @@ it('XMLHttpRequest: emits the "response" event upon the original response', asyn
   expect(response.statusText).toBe('OK')
   expect(response.headers.get('x-response-type')).toBe('original')
   expect(await response.text()).toBe('original-response-text')
+
+  expect(isMockedResponse).toBe(false)
 
   // Original response.
   expect(originalRequest.responseText).toEqual('original-response-text')
@@ -231,7 +238,8 @@ it('fetch: emits the "response" event upon a mocked response', async () => {
 
   expect(responseListener).toHaveBeenCalledTimes(1)
 
-  const [{ response, request }] = responseListener.mock.calls[0]
+  const [{ response, request, isMockedResponse }] =
+    responseListener.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(httpServer.https.url('/user'))
@@ -243,6 +251,8 @@ it('fetch: emits the "response" event upon a mocked response', async () => {
   expect(response.statusText).toBe('OK')
   expect(response.headers.get('x-response-type')).toBe('mocked')
   expect(await response.text()).toBe('mocked-response-text')
+
+  expect(isMockedResponse).toBe(true)
 })
 
 it('fetch: emits the "response" event upon the original response', async () => {
@@ -262,7 +272,8 @@ it('fetch: emits the "response" event upon the original response', async () => {
     expect(responseListener).toHaveBeenCalledTimes(1)
   })
 
-  const [{ response, request }] = responseListener.mock.calls[0]
+  const [{ response, request, isMockedResponse }] =
+    responseListener.mock.calls[0]
 
   expect(request.method).toBe('POST')
   expect(request.url).toBe(httpServer.https.url('/account'))
@@ -274,4 +285,6 @@ it('fetch: emits the "response" event upon the original response', async () => {
   expect(response.statusText).toBe('OK')
   expect(response.headers.get('x-response-type')).toBe('original')
   expect(await response.text()).toBe('original-response-text')
+
+  expect(isMockedResponse).toBe(false)
 })

--- a/test/features/presets/browser-preset.runtime.js
+++ b/test/features/presets/browser-preset.runtime.js
@@ -8,7 +8,7 @@ const interceptor = new BatchInterceptor({
 
 interceptor.apply()
 
-interceptor.on('request', async (request, requestId) => {
+interceptor.on('request', async ({ request, requestId }) => {
   window.dispatchEvent(
     new CustomEvent('resolver', {
       detail: {

--- a/test/features/presets/node-preset.test.ts
+++ b/test/features/presets/node-preset.test.ts
@@ -14,7 +14,7 @@ const requestListener = vi.fn()
 
 beforeAll(() => {
   interceptor.apply()
-  interceptor.on('request', (request) => {
+  interceptor.on('request', ({ request }) => {
     requestListener(request)
     request.respondWith(new Response('mocked'))
   })

--- a/test/features/remote/remote.test.ts
+++ b/test/features/remote/remote.test.ts
@@ -13,7 +13,7 @@ const resolver = new RemoteHttpResolver({
   process: child,
 })
 
-resolver.on('request', (request) => {
+resolver.on('request', ({ request }) => {
   request.respondWith(
     new Response(
       JSON.stringify({

--- a/test/modules/XMLHttpRequest/compliance/xhr-add-event-listener.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-add-event-listener.test.ts
@@ -7,7 +7,7 @@ import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpR
 import { createXMLHttpRequest } from '../../../helpers'
 
 const interceptor = new XMLHttpRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   if (request.url === 'https://test.mswjs.io/user') {
     request.respondWith(
       new Response(JSON.stringify({ mocked: true }), {

--- a/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.browser.runtime.js
+++ b/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.browser.runtime.js
@@ -1,7 +1,7 @@
 import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
 
 const interceptor = new XMLHttpRequestInterceptor()
-interceptor.on('request', async (request, requestId) => {
+interceptor.on('request', async ({ request, requestId }) => {
   window.dispatchEvent(
     new CustomEvent('resolver', {
       detail: {

--- a/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-event-handlers.test.ts
@@ -23,7 +23,7 @@ const httpServer = new HttpServer((app) => {
 
 beforeAll(async () => {
   interceptor.apply()
-  interceptor.on('request', (request) => {
+  interceptor.on('request', ({ request }) => {
     switch (true) {
       case request.url.endsWith('/exception'): {
         throw new Error('Network error')

--- a/test/modules/XMLHttpRequest/compliance/xhr-events-order.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-events-order.test.ts
@@ -18,7 +18,7 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new XMLHttpRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   const url = new URL(request.url)
 
   switch (url.pathname) {

--- a/test/modules/XMLHttpRequest/compliance/xhr-modify-request.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-modify-request.test.ts
@@ -39,7 +39,7 @@ afterAll(async () => {
 })
 
 it('allows modifying outgoing request headers', async () => {
-  interceptor.on('request', (request) => {
+  interceptor.on('request', ({ request }) => {
     request.headers.delete('X-Delete-Header')
     request.headers.append('X-Append-Header', '2')
     request.headers.set('X-Set-Header', 'new-value')

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-body-empty.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-body-empty.test.ts
@@ -4,7 +4,7 @@ import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpR
 import { createXMLHttpRequest } from '../../../helpers'
 
 const interceptor = new XMLHttpRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   request.respondWith(
     new Response(null, {
       status: 401,

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-body-json-invalid.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-body-json-invalid.test.ts
@@ -5,7 +5,7 @@ import { createXMLHttpRequest } from '../../../helpers'
 
 const interceptor = new XMLHttpRequestInterceptor()
 
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   const url = new URL(request.url)
 
   switch (url.pathname) {

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-body-xml.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-body-xml.test.ts
@@ -7,7 +7,7 @@ const XML_STRING = '<node key="value">Content</node>'
 
 describe('Content-Type: application/xml', () => {
   const interceptor = new XMLHttpRequestInterceptor()
-  interceptor.on('request', (request) => {
+  interceptor.on('request', ({ request }) => {
     request.respondWith(
       new Response(XML_STRING, {
         status: 200,
@@ -38,7 +38,7 @@ describe('Content-Type: application/xml', () => {
 
 describe('Content-Type: text/xml', () => {
   const interceptor = new XMLHttpRequestInterceptor()
-  interceptor.on('request', (request) => {
+  interceptor.on('request', ({ request }) => {
     request.respondWith(
       new Response(XML_STRING, {
         status: 200,

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-headers.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-headers.test.ts
@@ -19,7 +19,7 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new XMLHttpRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   const url = new URL(request.url)
 
   if (!url.searchParams.has('mock')) {

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-type.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-type.test.ts
@@ -6,7 +6,7 @@ import { toArrayBuffer } from '../../../../src/utils/bufferUtils'
 import { createXMLHttpRequest, readBlob } from '../../../helpers'
 
 const interceptor = new XMLHttpRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   request.respondWith(
     new Response(
       JSON.stringify({

--- a/test/modules/XMLHttpRequest/compliance/xhr-status.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-status.test.ts
@@ -8,7 +8,7 @@ import { createXMLHttpRequest } from '../../../helpers'
 
 const interceptor = new XMLHttpRequestInterceptor()
 
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   const url = new URL(request.url)
 
   if (url.pathname === '/cors') {

--- a/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.browser.runtime.js
+++ b/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.browser.runtime.js
@@ -1,7 +1,7 @@
 import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
 
 const interceptor = new XMLHttpRequestInterceptor()
-interceptor.on('request', async (request, requestId) => {
+interceptor.on('request', async ({ request, requestId }) => {
   window.dispatchEvent(
     new CustomEvent('resolver', {
       detail: {

--- a/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.test.ts
+++ b/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.test.ts
@@ -63,7 +63,7 @@ it('intercepts an HTTP HEAD request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('HEAD')
   expect(request.url).toBe(url)
@@ -87,7 +87,7 @@ it('intercepts an HTTP GET request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(url)
@@ -111,7 +111,7 @@ it('intercepts an HTTP POST request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('POST')
   expect(request.url).toBe(url)
@@ -135,7 +135,7 @@ it('intercepts an HTTP PUT request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('PUT')
   expect(request.url).toBe(url)
@@ -159,7 +159,7 @@ it('intercepts an HTTP DELETE request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('DELETE')
   expect(request.url).toBe(url)
@@ -183,7 +183,7 @@ it('intercepts an HTTPS HEAD request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('HEAD')
   expect(request.url).toBe(url)
@@ -207,7 +207,7 @@ it('intercepts an HTTPS GET request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(url)
@@ -231,7 +231,7 @@ it('intercepts an HTTPS POST request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('POST')
   expect(request.url).toBe(url)
@@ -255,7 +255,7 @@ it('intercepts an HTTPS PUT request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('PUT')
   expect(request.url).toBe(url)
@@ -279,7 +279,7 @@ it('intercepts an HTTPS DELETE request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('DELETE')
   expect(request.url).toBe(url)
@@ -302,7 +302,7 @@ it('sets "credentials" to "include" on isomorphic request when "withCredentials"
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request] = resolver.mock.calls[0]
+  const [{ request }] = resolver.mock.calls[0]
   expect(request.credentials).toBe('include')
 })
 
@@ -313,7 +313,7 @@ it('sets "credentials" to "omit" on isomorphic request when "withCredentials" is
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  const [request] = resolver.mock.calls[0]
+  const [{ request }] = resolver.mock.calls[0]
   expect(request.credentials).toBe('same-origin')
 })
 
@@ -325,7 +325,7 @@ it('sets "credentials" to "omit" on isomorphic request when "withCredentials" is
   })
 
   expect(resolver).toHaveBeenCalledTimes(1)
-  const [request] = resolver.mock.calls[0]
+  const [{ request }] = resolver.mock.calls[0]
   expect(request.credentials).toBe('same-origin')
 })
 

--- a/test/modules/XMLHttpRequest/response/xhr-response-patching.browser.runtime.js
+++ b/test/modules/XMLHttpRequest/response/xhr-response-patching.browser.runtime.js
@@ -2,7 +2,7 @@ import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
 
 const interceptor = new XMLHttpRequestInterceptor()
 
-interceptor.on('request', async (request, requestId) => {
+interceptor.on('request', async ({ request, requestId }) => {
   window.dispatchEvent(
     new CustomEvent('resolver', {
       detail: {

--- a/test/modules/XMLHttpRequest/response/xhr.browser.runtime.js
+++ b/test/modules/XMLHttpRequest/response/xhr.browser.runtime.js
@@ -2,7 +2,7 @@ import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
 
 const interceptor = new XMLHttpRequestInterceptor()
 
-interceptor.on('request', async (request, requestId) => {
+interceptor.on('request', async ({ request, requestId }) => {
   window.dispatchEvent(
     new CustomEvent('resolver', {
       detail: {

--- a/test/modules/XMLHttpRequest/response/xhr.test.ts
+++ b/test/modules/XMLHttpRequest/response/xhr.test.ts
@@ -29,7 +29,7 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new XMLHttpRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   const url = new URL(request.url)
 
   const shouldMock =

--- a/test/modules/fetch/fetch-exception.runtime.js
+++ b/test/modules/fetch/fetch-exception.runtime.js
@@ -2,7 +2,7 @@ import { FetchInterceptor } from '@mswjs/interceptors/fetch'
 
 const interceptor = new FetchInterceptor()
 
-interceptor.on('request', async (request) => {
+interceptor.on('request', async () => {
   throw new Error('Network error')
 })
 

--- a/test/modules/fetch/fetch-exception.test.ts
+++ b/test/modules/fetch/fetch-exception.test.ts
@@ -8,7 +8,7 @@ beforeAll(() => {
   vi.spyOn(console, 'error').mockImplementation(() => void 0)
 
   interceptor.apply()
-  interceptor.on('request', (request) => {
+  interceptor.on('request', () => {
     throw new Error('Network error')
   })
 })

--- a/test/modules/fetch/fetch-modify-request.runtime.js
+++ b/test/modules/fetch/fetch-modify-request.runtime.js
@@ -2,7 +2,7 @@ import { FetchInterceptor } from '@mswjs/interceptors/fetch'
 
 const interceptor = new FetchInterceptor()
 
-interceptor.on('request', async (request) => {
+interceptor.on('request', async ({ request }) => {
   request.headers.set('X-Appended-Header', 'modified')
 })
 

--- a/test/modules/fetch/intercept/fetch.body.runtime.js
+++ b/test/modules/fetch/intercept/fetch.body.runtime.js
@@ -1,7 +1,7 @@
 import { FetchInterceptor } from '@mswjs/interceptors/fetch'
 
 const interceptor = new FetchInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   window.requestBody = request.clone().text()
 })
 

--- a/test/modules/fetch/intercept/fetch.browser.runtime.js
+++ b/test/modules/fetch/intercept/fetch.browser.runtime.js
@@ -1,7 +1,7 @@
 import { FetchInterceptor } from '@mswjs/interceptors/fetch'
 
 const interceptor = new FetchInterceptor()
-interceptor.on('request', async (request, requestId) => {
+interceptor.on('request', async ({ request, requestId }) => {
   window.dispatchEvent(
     new CustomEvent('resolver', {
       detail: {

--- a/test/modules/fetch/intercept/fetch.request.test.ts
+++ b/test/modules/fetch/intercept/fetch.request.test.ts
@@ -48,7 +48,7 @@ it('intercepts fetch requests constructed via a "Request" instance', async () =>
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [capturedRequest, requestId] = resolver.mock.calls[0]
+  const [{ request: capturedRequest, requestId }] = resolver.mock.calls[0]
 
   expect(capturedRequest.method).toBe('POST')
   expect(capturedRequest.url).toBe(httpServer.http.url('/user'))

--- a/test/modules/fetch/intercept/fetch.test.ts
+++ b/test/modules/fetch/intercept/fetch.test.ts
@@ -49,7 +49,7 @@ it('intercepts an HTTP HEAD request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('HEAD')
   expect(request.url).toBe(httpServer.http.url('/user?id=123'))
@@ -70,7 +70,7 @@ it('intercepts an HTTP GET request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(httpServer.http.url('/user?id=123'))
@@ -93,7 +93,7 @@ it('intercepts an HTTP POST request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('POST')
   expect(request.url).toBe(httpServer.http.url('/user?id=123'))
@@ -119,7 +119,7 @@ it('intercepts an HTTP PUT request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('PUT')
   expect(request.url).toBe(httpServer.http.url('/user?id=123'))
@@ -143,7 +143,7 @@ it('intercepts an HTTP DELETE request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('DELETE')
   expect(request.url).toBe(httpServer.http.url('/user?id=123'))
@@ -168,7 +168,7 @@ it('intercepts an HTTP PATCH request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('PATCH')
   expect(request.url).toBe(httpServer.http.url('/user?id=123'))
@@ -193,7 +193,7 @@ it('intercepts an HTTPS HEAD request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('HEAD')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))
@@ -217,7 +217,7 @@ it('intercepts an HTTPS GET request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))
@@ -243,7 +243,7 @@ it('intercepts an HTTPS POST request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('POST')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))
@@ -269,7 +269,7 @@ it('intercepts an HTTPS PUT request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('PUT')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))
@@ -294,7 +294,7 @@ it('intercepts an HTTPS DELETE request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('DELETE')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))
@@ -319,7 +319,7 @@ it('intercepts an HTTPS PATCH request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('PATCH')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))

--- a/test/modules/fetch/response/fetch-response-patching.runtime.js
+++ b/test/modules/fetch/response/fetch-response-patching.runtime.js
@@ -2,7 +2,7 @@ import { FetchInterceptor } from '@mswjs/interceptors/fetch'
 
 const interceptor = new FetchInterceptor()
 
-interceptor.on('request', async (request) => {
+interceptor.on('request', async ({ request }) => {
   const url = new URL(request.url)
 
   if (url.pathname === '/mocked') {

--- a/test/modules/fetch/response/fetch.browser.runtime.js
+++ b/test/modules/fetch/response/fetch.browser.runtime.js
@@ -2,7 +2,7 @@ import { FetchInterceptor } from '@mswjs/interceptors/fetch'
 
 const interceptor = new FetchInterceptor()
 
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   const { serverHttpUrl, serverHttpsUrl } = window
 
   if ([serverHttpUrl, serverHttpsUrl].includes(request.url)) {

--- a/test/modules/fetch/response/fetch.test.ts
+++ b/test/modules/fetch/response/fetch.test.ts
@@ -13,7 +13,7 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', function testListener(request) {
+interceptor.on('request', function testListener({ request }) {
   if ([httpServer.http.url(), httpServer.https.url()].includes(request.url)) {
     request.respondWith(
       new Response(JSON.stringify({ mocked: true }), {

--- a/test/modules/http/compliance/http-modify-request.test.ts
+++ b/test/modules/http/compliance/http-modify-request.test.ts
@@ -23,7 +23,7 @@ afterAll(async () => {
 })
 
 it('allows modifying the outgoing request headers', async () => {
-  interceptor.on('request', (request) => {
+  interceptor.on('request', ({ request }) => {
     request.headers.set('X-Appended-Header', 'modified')
   })
 

--- a/test/modules/http/compliance/http-rate-limit.test.ts
+++ b/test/modules/http/compliance/http-rate-limit.test.ts
@@ -22,7 +22,7 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   const url = new URL(request.url)
 
   if (!url.searchParams.has('mock')) {

--- a/test/modules/http/compliance/http-req-callback.test.ts
+++ b/test/modules/http/compliance/http-req-callback.test.ts
@@ -13,7 +13,7 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   if ([httpServer.https.url('/get')].includes(request.url)) {
     return
   }

--- a/test/modules/http/compliance/http-req-write.test.ts
+++ b/test/modules/http/compliance/http-req-write.test.ts
@@ -15,7 +15,7 @@ const httpServer = new HttpServer((app) => {
 const interceptedRequestBody = vi.fn()
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', async (request) => {
+interceptor.on('request', async ({ request }) => {
   interceptedRequestBody(await request.clone().text())
 })
 

--- a/test/modules/http/compliance/http-res-read-multiple-times.test.ts
+++ b/test/modules/http/compliance/http-res-read-multiple-times.test.ts
@@ -69,7 +69,7 @@ it('allows reading the response body after it has been read internally', async (
   }
 
   const untilCapturedResponse = new Promise<Response>((resolve) => {
-    interceptor.on('response', (response) => resolve(response))
+    interceptor.on('response', ({ response }) => resolve(response))
   })
   const request = await makeRequest()
   const capturedResponse = await untilCapturedResponse

--- a/test/modules/http/compliance/http-res-set-encoding.test.ts
+++ b/test/modules/http/compliance/http-res-set-encoding.test.ts
@@ -11,7 +11,7 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   const url = new URL(request.url)
 
   if (!url.searchParams.has('mock')) {

--- a/test/modules/http/http-performance.test.ts
+++ b/test/modules/http/http-performance.test.ts
@@ -29,7 +29,7 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   const url = new URL(request.url)
 
   if (url.pathname.startsWith('/user')) {

--- a/test/modules/http/intercept/http.get.test.ts
+++ b/test/modules/http/intercept/http.get.test.ts
@@ -41,7 +41,7 @@ it('intercepts an http.get request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(url)
@@ -70,7 +70,7 @@ it('intercepts an http.get request given RequestOptions without a protocol', asy
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(httpServer.http.url('/user?id=123'))

--- a/test/modules/http/intercept/http.request.test.ts
+++ b/test/modules/http/intercept/http.request.test.ts
@@ -48,7 +48,7 @@ it('intercepts a HEAD request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('HEAD')
   expect(request.url).toBe(url)
@@ -76,7 +76,7 @@ it('intercepts a GET request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(url)
@@ -105,7 +105,7 @@ it('intercepts a POST request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('POST')
   expect(request.url).toBe(url)
@@ -134,7 +134,7 @@ it('intercepts a PUT request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('PUT')
   expect(request.url).toBe(url)
@@ -163,7 +163,7 @@ it('intercepts a PATCH request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('PATCH')
   expect(request.url).toBe(url)
@@ -191,7 +191,7 @@ it('intercepts a DELETE request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('DELETE')
   expect(request.url).toBe(url)
@@ -219,7 +219,7 @@ it('intercepts an http.request given RequestOptions without a protocol', async (
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(httpServer.http.url('/user?id=123'))

--- a/test/modules/http/intercept/https.get.test.ts
+++ b/test/modules/http/intercept/https.get.test.ts
@@ -41,7 +41,7 @@ it('intercepts a GET request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(url)
@@ -69,7 +69,7 @@ it('intercepts an https.get request given RequestOptions without a protocol', as
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))

--- a/test/modules/http/intercept/https.request.test.ts
+++ b/test/modules/http/intercept/https.request.test.ts
@@ -51,7 +51,7 @@ it('intercepts a HEAD request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('HEAD')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))
@@ -76,7 +76,7 @@ it('intercepts a GET request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))
@@ -102,7 +102,7 @@ it('intercepts a POST request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('POST')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))
@@ -128,7 +128,7 @@ it('intercepts a PUT request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('PUT')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))
@@ -154,7 +154,7 @@ it('intercepts a PATCH request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('PATCH')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))
@@ -179,7 +179,7 @@ it('intercepts a DELETE request', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('DELETE')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))
@@ -202,7 +202,7 @@ it('intercepts an http.request request given RequestOptions without a protocol',
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [request, requestId] = resolver.mock.calls[0]
+  const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(httpServer.https.url('/user?id=123'))

--- a/test/modules/http/regressions/http-concurrent-different-response-source.test.ts
+++ b/test/modules/http/regressions/http-concurrent-different-response-source.test.ts
@@ -12,7 +12,7 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', async (request) => {
+interceptor.on('request', async ({ request }) => {
   if (request.headers.get('x-bypass')) {
     return
   }

--- a/test/modules/http/regressions/http-concurrent-same-host.test.ts
+++ b/test/modules/http/regressions/http-concurrent-same-host.test.ts
@@ -8,7 +8,7 @@ import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientReq
 let requests: Array<Request> = []
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   requests.push(request)
   request.respondWith(new Response())
 })

--- a/test/modules/http/regressions/http-socket-timeout.ts
+++ b/test/modules/http/regressions/http-socket-timeout.ts
@@ -17,7 +17,7 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   request.respondWith(new Response('hello world', { status: 301 }))
 })
 

--- a/test/modules/http/response/http-https.test.ts
+++ b/test/modules/http/response/http-https.test.ts
@@ -15,7 +15,7 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   const url = new URL(request.url)
 
   if (url.pathname === '/non-existing') {

--- a/test/modules/http/response/http-response-patching.test.ts
+++ b/test/modules/http/response/http-response-patching.test.ts
@@ -54,7 +54,7 @@ async function getResponse(request: Request): Promise<Response | undefined> {
   }
 }
 
-interceptor.on('request', async (request) => {
+interceptor.on('request', async ({ request }) => {
   const response = await getResponse(request)
 
   if (response) {

--- a/test/modules/http/response/readable-stream.test.ts
+++ b/test/modules/http/response/readable-stream.test.ts
@@ -9,7 +9,7 @@ type ResponseChunks = Array<{ buffer: Buffer; timestamp: number }>
 const encoder = new TextEncoder()
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   const stream = new ReadableStream({
     async start(controller) {
       controller.enqueue(encoder.encode('first'))
@@ -72,6 +72,6 @@ it('supports delays when enqueuing chunks', async () => {
   // Ensure that the chunks were sent over time,
   // respecting the delay set in the mocked stream.
   const chunkTimings = responseChunks.map((chunk) => chunk.timestamp)
-  expect(chunkTimings[1] - chunkTimings[0]).toBeGreaterThanOrEqual(190)
-  expect(chunkTimings[2] - chunkTimings[1]).toBeGreaterThanOrEqual(190)
+  expect(chunkTimings[1] - chunkTimings[0]).toBeGreaterThanOrEqual(180)
+  expect(chunkTimings[2] - chunkTimings[1]).toBeGreaterThanOrEqual(180)
 })

--- a/test/third-party/axios.test.ts
+++ b/test/third-party/axios.test.ts
@@ -22,7 +22,7 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   const url = new URL(request.url)
 
   if (url.pathname === '/user') {

--- a/test/third-party/follow-redirect-http.test.ts
+++ b/test/third-party/follow-redirect-http.test.ts
@@ -69,7 +69,7 @@ it('intercepts a POST request issued by "follow-redirects"', async () => {
   expect(resolver).toHaveBeenCalledTimes(2)
 
   // Intercepted initial request.
-  const [initialRequest] = resolver.mock.calls[0]
+  const [{ request: initialRequest }] = resolver.mock.calls[0]
 
   expect(initialRequest.method).toBe('POST')
   expect(initialRequest.url).toBe(server.https.url('/resource'))
@@ -79,7 +79,7 @@ it('intercepts a POST request issued by "follow-redirects"', async () => {
   expect(await initialRequest.json()).toEqual({ todo: 'Buy the milk' })
 
   // Intercepted redirect request (issued by "follow-redirects").
-  const [redirectedRequest] = resolver.mock.calls[1]
+  const [{ request: redirectedRequest }] = resolver.mock.calls[1]
 
   expect(redirectedRequest.method).toBe('POST')
   expect(redirectedRequest.url).toBe(server.https.url('/user'))

--- a/test/third-party/got.test.ts
+++ b/test/third-party/got.test.ts
@@ -10,7 +10,7 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', (request) => {
+interceptor.on('request', ({ request }) => {
   if (request.url.toString() === httpServer.http.url('/test')) {
     request.respondWith(new Response('mocked-body'))
   }

--- a/test/third-party/supertest.test.ts
+++ b/test/third-party/supertest.test.ts
@@ -43,13 +43,13 @@ it('intercepts a GET request', async () => {
 
   // Must call the "request" listener.
   expect(requestListener).toHaveBeenCalledTimes(1)
-  const [request] = requestListener.mock.calls[0]
+  const [{ request }] = requestListener.mock.calls[0]
   expect(request.method).toBe('GET')
   expect(request.body).toBeNull()
 
   // Must call the "response" listener.
   expect(responseListener).toHaveBeenCalledTimes(1)
-  const [responseFromListener] = responseListener.mock.calls[0]
+  const [{ response: responseFromListener }] = responseListener.mock.calls[0]
   expect(responseFromListener.status).toBe(200)
   expect(responseFromListener.statusText).toBe('OK')
   expect(responseFromListener.headers.get('content-type')).toBe(
@@ -70,13 +70,13 @@ it('intercepts a POST request', async () => {
 
   // Must call the "request" listener.
   expect(requestListener).toHaveBeenCalledTimes(1)
-  const [request] = requestListener.mock.calls[0]
+  const [{ request }] = requestListener.mock.calls[0]
   expect(request.method).toBe('POST')
   expect(await request.json()).toEqual({ query: 'foo' })
 
   // Must call the "response" listener.
   expect(responseListener).toHaveBeenCalledTimes(1)
-  const [responseFromListener] = responseListener.mock.calls[0]
+  const [{ response: responseFromListener }] = responseListener.mock.calls[0]
   expect(responseFromListener.status).toBe(200)
   expect(responseFromListener.statusText).toBe('OK')
   expect(responseFromListener.headers.get('content-type')).toBe(


### PR DESCRIPTION
I want to add a new `isMockedResponse` property to the interceptor args (for the `response` event). For that, I'm considering rewriting the structure of the arguments to be an object to allow for easier argument extensions right now and in the past. This shape also aligns more nicely with the call signature of response resolvers in MSW 2.0. 

- Prerequisite for https://github.com/mswjs/msw/pull/1436

## Changes

- The args returned from the events (request/response) are an object now.
- Adds a new `isMockedResponse` property on the args object of the "response" event. This way MSW can know which responses are mocked without relying on the intermediate `x-powered-by` response header. 