### PR TITLE
Abort all requests the interceptor is disposed

### DIFF
--- a/src/interceptors/ClientRequest/NodeClientRequest.test.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.test.ts
@@ -27,7 +27,6 @@ const httpServer = new HttpServer((app) => {
 })
 
 const logger = new Logger('test')
-const registerSignal = () => {}
 
 beforeAll(async () => {
   await httpServer.listen()
@@ -46,7 +45,6 @@ it('gracefully finishes the request when it has a mocked response', async () => 
     {
       emitter,
       logger,
-      registerSignal
     }
   )
 
@@ -96,7 +94,6 @@ it('responds with a mocked response when requesting an existing hostname', async
     {
       emitter,
       logger,
-      registerSignal
     }
   )
 
@@ -127,7 +124,6 @@ it('performs the request as-is given resolver returned no mocked response', asyn
     {
       emitter,
       logger,
-      registerSignal
     }
   )
 
@@ -154,7 +150,7 @@ it('emits the ENOTFOUND error connecting to a non-existing hostname given no moc
   const emitter = new AsyncEventEmitter<HttpRequestEventMap>()
   const request = new NodeClientRequest(
     normalizeClientRequestArgs('http:', 'http://non-existing-url.com'),
-    { emitter, logger, registerSignal }
+    { emitter, logger }
   )
   request.end()
 
@@ -175,7 +171,6 @@ it('emits the ECONNREFUSED error connecting to an inactive server given no mocke
     {
       emitter,
       logger,
-      registerSignal
     }
   )
 
@@ -200,7 +195,7 @@ it('does not emit ENOTFOUND error connecting to an inactive server given mocked 
   const handleError = vi.fn()
   const request = new NodeClientRequest(
     normalizeClientRequestArgs('http:', 'http://non-existing-url.com'),
-    { emitter, logger, registerSignal }
+    { emitter, logger }
   )
 
   emitter.on('request', async ({ request }) => {
@@ -233,7 +228,6 @@ it('does not emit ECONNREFUSED error connecting to an inactive server given mock
     {
       emitter,
       logger,
-      registerSignal
     }
   )
 
@@ -270,7 +264,6 @@ it('sends the request body to the server given no mocked response', async () => 
     {
       emitter,
       logger,
-      registerSignal
     }
   )
 
@@ -299,7 +292,6 @@ it('does not send request body to the original server given mocked response', as
     {
       emitter,
       logger,
-      registerSignal
     }
   )
 
@@ -334,7 +326,6 @@ it('abort the request when the interceptor is disposed', async () => {
     {
       emitter,
       logger,
-      registerSignal
     }
   )
 

--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -24,6 +24,7 @@ export type Protocol = 'http' | 'https'
 export interface NodeClientOptions {
   emitter: ClientRequestEmitter
   logger: Logger
+  registerSignal: (signal: AbortSignal) => void
 }
 
 export class NodeClientRequest extends ClientRequest {

--- a/src/interceptors/ClientRequest/http.get.ts
+++ b/src/interceptors/ClientRequest/http.get.ts
@@ -15,6 +15,16 @@ export function get(protocol: Protocol, options: NodeClientOptions) {
       `${protocol}:`,
       ...args
     )
+
+    const [, requestOptions] = clientRequestArgs;
+
+    if (!requestOptions.signal) {
+      const abortController = new AbortController();
+      requestOptions.signal = abortController.signal;
+    }
+
+    options.registerSignal(requestOptions.signal);
+
     const request = new NodeClientRequest(clientRequestArgs, options)
 
     /**

--- a/src/interceptors/ClientRequest/http.get.ts
+++ b/src/interceptors/ClientRequest/http.get.ts
@@ -16,15 +16,6 @@ export function get(protocol: Protocol, options: NodeClientOptions) {
       ...args
     )
 
-    const [, requestOptions] = clientRequestArgs;
-
-    if (!requestOptions.signal) {
-      const abortController = new AbortController();
-      requestOptions.signal = abortController.signal;
-    }
-
-    options.registerSignal(requestOptions.signal);
-
     const request = new NodeClientRequest(clientRequestArgs, options)
 
     /**

--- a/src/interceptors/ClientRequest/http.request.ts
+++ b/src/interceptors/ClientRequest/http.request.ts
@@ -21,14 +21,6 @@ export function request(protocol: Protocol, options: NodeClientOptions) {
       ...args
     )
 
-    const [, requestOptions] = clientRequestArgs;
-
-    if (!requestOptions.signal) {
-      const abortController = new AbortController();
-      requestOptions.signal = abortController.signal;
-    }
-
-    options.registerSignal(requestOptions.signal);
     return new NodeClientRequest(clientRequestArgs, options)
   }
 }

--- a/src/interceptors/ClientRequest/http.request.ts
+++ b/src/interceptors/ClientRequest/http.request.ts
@@ -20,6 +20,15 @@ export function request(protocol: Protocol, options: NodeClientOptions) {
       `${protocol}:`,
       ...args
     )
+
+    const [, requestOptions] = clientRequestArgs;
+
+    if (!requestOptions.signal) {
+      const abortController = new AbortController();
+      requestOptions.signal = abortController.signal;
+    }
+
+    options.registerSignal(requestOptions.signal);
     return new NodeClientRequest(clientRequestArgs, options)
   }
 }

--- a/src/interceptors/ClientRequest/index.ts
+++ b/src/interceptors/ClientRequest/index.ts
@@ -48,7 +48,6 @@ export class ClientRequestInterceptor extends Interceptor<HttpRequestEventMap> {
       const options: NodeClientOptions = {
         emitter: this.emitter,
         logger: this.logger,
-        registerSignal: (signal) => controllerManager.registerSignal(signal),
       }
 
       // @ts-ignore

--- a/src/interceptors/ClientRequest/index.ts
+++ b/src/interceptors/ClientRequest/index.ts
@@ -2,6 +2,7 @@ import http from 'http'
 import https from 'https'
 import { HttpRequestEventMap } from '../../glossary'
 import { Interceptor } from '../../Interceptor'
+import { AbortControllerManager } from '../../utils/AbortControllerManager'
 import { AsyncEventEmitter } from '../../utils/AsyncEventEmitter'
 import { get } from './http.get'
 import { request } from './http.request'
@@ -21,7 +22,6 @@ export class ClientRequestInterceptor extends Interceptor<HttpRequestEventMap> {
 
   constructor() {
     super(ClientRequestInterceptor.interceptorSymbol)
-
     this.modules = new Map()
     this.modules.set('http', http)
     this.modules.set('https', https)
@@ -29,6 +29,11 @@ export class ClientRequestInterceptor extends Interceptor<HttpRequestEventMap> {
 
   protected setup(): void {
     const logger = this.logger.extend('setup')
+
+    const controllerManager = new AbortControllerManager()
+    this.subscriptions.push(() => controllerManager.dispose())
+
+    controllerManager.decorate()
 
     for (const [protocol, requestModule] of this.modules) {
       const { request: pureRequest, get: pureGet } = requestModule
@@ -43,6 +48,7 @@ export class ClientRequestInterceptor extends Interceptor<HttpRequestEventMap> {
       const options: NodeClientOptions = {
         emitter: this.emitter,
         logger: this.logger,
+        registerSignal: (signal) => controllerManager.registerSignal(signal),
       }
 
       // @ts-ignore

--- a/src/interceptors/fetch/index.test.ts
+++ b/src/interceptors/fetch/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
-import http from 'http'
 import { HttpServer } from '@open-draft/test-server/http'
 import { DeferredPromise } from '@open-draft/deferred-promise'
-import { ClientRequestInterceptor } from '.'
+import { FetchInterceptor } from './index'
 
-describe('ClientRequestInterceptor', () => {
+describe('FetchInterceptor', () => {
+  const noop = () => {}
   const httpServer = new HttpServer((app) => {
     app.get('/', (_req, res) => {
       res.status(200).send('/')
@@ -14,7 +14,7 @@ describe('ClientRequestInterceptor', () => {
     })
   })
 
-  const interceptor = new ClientRequestInterceptor()
+  const interceptor = new FetchInterceptor()
 
   beforeAll(async () => {
     await httpServer.listen()
@@ -32,37 +32,6 @@ describe('ClientRequestInterceptor', () => {
     interceptor.dispose()
   })
 
-  it('forbids calling "respondWith" multiple times for the same request', async () => {
-    const requestUrl = httpServer.http.url('/')
-
-    interceptor.on('request', function firstRequestListener({ request }) {
-      request.respondWith(new Response())
-    })
-
-    const secondRequestEmitted = new DeferredPromise<void>()
-    interceptor.on('request', function secondRequestListener({ request }) {
-      expect(() =>
-        request.respondWith(new Response(null, { status: 301 }))
-      ).toThrow(
-        `Failed to respond to "GET ${requestUrl}" request: the "request" event has already been responded to.`
-      )
-
-      secondRequestEmitted.resolve()
-    })
-
-    const request = http.get(requestUrl)
-    await secondRequestEmitted
-
-    const responseReceived = new DeferredPromise<http.IncomingMessage>()
-    request.on('response', (response) => {
-      responseReceived.resolve(response)
-    })
-
-    const response = await responseReceived
-    expect(response.statusCode).toBe(200)
-    expect(response.statusMessage).toBe('')
-  })
-
   it('add an AbortSignal to the request if missing', async () => {
     const requestUrl = httpServer.http.url('/')
 
@@ -72,7 +41,7 @@ describe('ClientRequestInterceptor', () => {
       requestEmitted.resolve()
     })
 
-    http.get(requestUrl)
+    fetch(requestUrl).catch(noop)
     await requestEmitted
   })
 
@@ -91,15 +60,13 @@ describe('ClientRequestInterceptor', () => {
       requestEmitted.resolve()
     })
 
-    const request = http.get(requestUrl, { signal: controller.signal })
-    await requestEmitted
-
     const requestAborted = new DeferredPromise<void>()
-    request.on('error', (err) => {
+    fetch(requestUrl, { signal: controller.signal }).catch((err) => {
       expect(err.name).toEqual('AbortError')
       requestAborted.resolve()
     })
 
+    await requestEmitted
     controller.abort()
     await requestAborted
   })
@@ -113,14 +80,15 @@ describe('ClientRequestInterceptor', () => {
     })
 
     const controller = new AbortController()
-    const requestWithoutUserController = http.get(requestUrl)
-    const requestWithUserController = http.get(requestUrl, { signal: controller.signal })
+    const requestWithoutUserController = fetch(requestUrl)
+    const requestWithUserController = fetch(requestUrl, { signal: controller.signal })
 
     const requests = [requestWithoutUserController, requestWithUserController]
 
-    const requestsAborted = requests.map(request => {
+    const requestsAborted = requests.map((request) => {
       const requestAborted = new DeferredPromise<void>()
-      request.on('error', (err) => {
+
+      request.catch((err) => {
         expect(err.name).toEqual('AbortError')
         requestAborted.resolve()
       })
@@ -136,19 +104,44 @@ describe('ClientRequestInterceptor', () => {
   it('abort upcoming requests when disposed', async () => {
     const requestUrl = httpServer.http.url('/')
 
-    interceptor.on('request', function requestListener() {
-      expect.fail('the request should never be sent, yet intercepted')
-    })
+    const stream = {
+      open: true
+    }
 
-    const controller = new AbortController()
-    const requestWithoutUserController = http.request(requestUrl)
-    const requestWithUserController = http.request(requestUrl, { signal: controller.signal })
+    function createBodyStream() {
+      return new ReadableStream({
+        pull: function(controller) {
+          if (!stream.open) {
+            controller.close()
+            return
+          }
+          console.log('pull called!')
+          controller.enqueue('Some data...')
+        }
+      })
+    }
+
+    const abortController = new AbortController()
+    const requestWithoutUserController = fetch(requestUrl, {
+      method: 'POST',
+      // @ts-ignore
+      duplex: 'half',
+      body: createBodyStream(),
+    })
+    const requestWithUserController = fetch(requestUrl, {
+      method: 'POST',
+      // @ts-ignore
+      duplex: 'half',
+      body: createBodyStream(),
+      signal: abortController.signal
+    })
 
     const requests = [requestWithoutUserController, requestWithUserController]
 
-    const requestsAborted = requests.map(request => {
+    const requestsAborted = requests.map((request) => {
       const requestAborted = new DeferredPromise<void>()
-      request.on('error', (err) => {
+
+      request.catch((err) => {
         expect(err.name).toEqual('AbortError')
         requestAborted.resolve()
       })
@@ -157,7 +150,8 @@ describe('ClientRequestInterceptor', () => {
     })
 
     interceptor.dispose()
-    requests.forEach(request => request.end())
+    stream.open = false
+    // requests.forEach(request => request.end())
 
     await Promise.all(requestsAborted)
   })

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -41,7 +41,10 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
         augmentedInit.signal = abortController.signal;
       }
 
-      controllerManager.registerSignal(augmentedInit.signal);
+      const { signal } = augmentedInit
+      invariant(signal, "Missing AbortSignal")
+
+      controllerManager.registerSignal(signal);
 
       const requestId = uuidv4()
       const request = new Request(input, augmentedInit)
@@ -75,6 +78,8 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
 
         return mockedResponse
       })
+
+      queueMicrotask(() => controllerManager.forgetSignal(signal))
 
       if (resolverResult.error) {
         const error = Object.assign(new TypeError('Failed to fetch'), {

--- a/src/utils/AbortControllerManager.test.ts
+++ b/src/utils/AbortControllerManager.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { AbortControllerManager } from './AbortControllerManager'
+
+describe('AbortControllerManager', () => {
+  const manager = new AbortControllerManager()
+
+  afterEach(() => {
+    if (manager) {
+      manager.dispose()
+    }
+  })
+
+  test('global AbortController is not decorated if patch is not applied yet', () => {
+    const pureAbortController = AbortController
+
+    expect(AbortController).toBe(pureAbortController)
+    expect(manager.isDecorated()).toBeFalsy()
+  })
+
+  test('global AbortController is decorated if patch is applied', () => {
+    const pureAbortController = AbortController
+    manager.decorate()
+
+    expect(AbortController).not.toBe(pureAbortController)
+    expect(manager.isDecorated()).toBeTruthy()
+  })
+
+  test('new AbortControllers are referenced if patch is applied', () => {
+    manager.decorate()
+
+    const controller = new AbortController()
+
+    expect(manager.isReferenced(controller)).toBeTruthy()
+    expect(manager.isRegistered(controller)).toBeFalsy()
+  })
+
+  test('registering a AbortSignal add the controller into the request map', () => {
+    manager.decorate()
+
+    const controller = new AbortController()
+    manager.registerSignal(controller.signal)
+
+    expect(manager.isRegistered(controller)).toBeTruthy()
+  })
+
+  test('global AbortController is restored if restoreAbortController is called', () => {
+    manager.decorate()
+
+    const controller = new AbortController()
+
+    manager.restore()
+
+    const controller2 = new AbortController()
+
+    expect(manager.isReferenced(controller)).toBeTruthy()
+    expect(manager.isReferenced(controller2)).toBeFalsy()
+  })
+
+  test('restoring AbortController do not clear the maps', () => {
+    manager.decorate()
+
+    const controller = new AbortController()
+
+    manager.registerSignal(controller.signal)
+    manager.restore()
+
+    expect(manager.isReferenced(controller)).toBeTruthy()
+    expect(manager.isRegistered(controller)).toBeTruthy()
+  })
+
+  test('calling dispose restore the AbortController and clear the maps', () => {
+    manager.decorate()
+
+    const controller = new AbortController()
+    manager.registerSignal(controller.signal)
+
+    expect(manager.isReferenced(controller)).toBeTruthy()
+    expect(manager.isRegistered(controller)).toBeTruthy()
+
+    manager.dispose()
+
+    expect(manager.isReferenced(controller)).toBeFalsy()
+    expect(manager.isRegistered(controller)).toBeFalsy()
+
+    const controller2 = new AbortController()
+
+    expect(manager.isReferenced(controller2)).toBeFalsy()
+  })
+
+  test('creating a new instance of the manager returns the existing one', () => {
+    const manager2 = new AbortControllerManager()
+    expect(manager).toBe(manager2)
+  })
+
+  test('calling abortAll abort all registered controllers', () => {
+    manager.decorate()
+
+    const controller = new AbortController()
+    const controller2 = new AbortController()
+    const controller3 = new AbortController()
+
+    manager.registerSignal(controller.signal)
+    manager.registerSignal(controller2.signal)
+
+    manager.abortAll()
+
+    expect(controller.signal.aborted).toBeTruthy()
+    expect(controller2.signal.aborted).toBeTruthy()
+    expect(controller3.signal.aborted).toBeFalsy()
+  })
+
+  test('calling dispose abort all registered controllers', () => {
+    manager.decorate()
+
+    const controller = new AbortController()
+    const controller2 = new AbortController()
+    const controller3 = new AbortController()
+
+    manager.registerSignal(controller.signal)
+    manager.registerSignal(controller2.signal)
+
+    manager.dispose()
+
+    expect(controller.signal.aborted).toBeTruthy()
+    expect(controller2.signal.aborted).toBeTruthy()
+    expect(controller3.signal.aborted).toBeFalsy()
+  })
+})

--- a/src/utils/AbortControllerManager.test.ts
+++ b/src/utils/AbortControllerManager.test.ts
@@ -68,7 +68,7 @@ describe('AbortControllerManager', () => {
     expect(manager.isRegistered(controller)).toBeTruthy()
   })
 
-  test('calling dispose restore the AbortController and clear the maps', () => {
+  test('calling dispose() restore the AbortController and clear the maps', () => {
     manager.decorate()
 
     const controller = new AbortController()
@@ -92,7 +92,7 @@ describe('AbortControllerManager', () => {
     expect(manager).toBe(manager2)
   })
 
-  test('calling abortAll abort all registered controllers', () => {
+  test('calling abortAll() abort all registered controllers', () => {
     manager.decorate()
 
     const controller = new AbortController()
@@ -109,7 +109,7 @@ describe('AbortControllerManager', () => {
     expect(controller3.signal.aborted).toBeFalsy()
   })
 
-  test('calling dispose abort all registered controllers', () => {
+  test('calling dispose() abort all registered controllers', () => {
     manager.decorate()
 
     const controller = new AbortController()
@@ -124,5 +124,22 @@ describe('AbortControllerManager', () => {
     expect(controller.signal.aborted).toBeTruthy()
     expect(controller2.signal.aborted).toBeTruthy()
     expect(controller3.signal.aborted).toBeFalsy()
+  })
+
+
+  test('calling forget() removes the controller from the references map and registration map', () => {
+    manager.decorate()
+
+    const controller = new AbortController()
+
+    manager.registerSignal(controller.signal)
+
+    expect(manager.isReferenced(controller)).toBeTruthy()
+    expect(manager.isRegistered(controller)).toBeTruthy()
+
+    manager.forgetSignal(controller.signal)
+
+    expect(manager.isReferenced(controller)).toBeFalsy()
+    expect(manager.isRegistered(controller)).toBeFalsy()
   })
 })

--- a/src/utils/AbortControllerManager.ts
+++ b/src/utils/AbortControllerManager.ts
@@ -1,0 +1,158 @@
+import { Logger } from '@open-draft/logger'
+
+export const instanceSymbolAbortControllerManager: unique symbol = Symbol('AbortControllerManager');
+export const decoratorSymbol: unique symbol = Symbol('DecoratedAbortController');
+
+export class AbortControllerManager {
+  private logger: Logger
+  private pureAbortController: typeof AbortController | undefined
+  private referencedAbortControllers= new WeakMap<AbortSignal, WeakRef<AbortController>>();
+  private registeredAbortControllers = new Map<AbortSignal, AbortController>();
+
+  constructor() {
+    this.logger = new Logger('AbortControllerManager');
+
+    const runningInstance = this.getRunningInstance()
+
+    if (runningInstance) {
+      this.logger.debug("returning the existing instance");
+      return runningInstance
+    }
+
+    this.pureAbortController = AbortController
+
+    Object.defineProperty(globalThis, instanceSymbolAbortControllerManager, {
+      enumerable: true,
+      configurable: true,
+      value: this,
+    })
+  }
+
+  private getRunningInstance(): AbortControllerManager | undefined {
+    // @ts-ignore
+    return globalThis[instanceSymbolAbortControllerManager]
+  }
+
+  private getReferencedAbortControllers() {
+    return this.referencedAbortControllers
+  }
+
+  private getPureAbortController(): typeof AbortController {
+    return this.pureAbortController ?? globalThis.AbortController
+  }
+
+  decorate(): boolean {
+    if (this.isDecorated()) {
+      this.logger.debug('already decorated')
+      return false
+    }
+
+    const pureAbortController = this.getPureAbortController()
+    const logger = this.logger
+    const getGlobalAbortControllers = () => this.getReferencedAbortControllers()
+
+    const decorator = class CustomAbortController {
+      constructor() {
+        const abortController = new pureAbortController()
+        getGlobalAbortControllers().set(abortController.signal, new WeakRef(abortController))
+        logger.debug('AbortController registered')
+        return abortController
+      }
+    }
+
+    Object.defineProperty(decorator, decoratorSymbol, {
+      enumerable: true,
+      configurable: true,
+      value: true,
+    })
+
+    Object.defineProperty(globalThis, 'AbortController', {
+      enumerable: true,
+      configurable: true,
+      value: decorator,
+    })
+
+    this.logger.info('native "AbortController" patched!')
+    return true
+  }
+
+  restore(): boolean {
+    if (!this.isDecorated()) {
+      this.logger.info('nothing to restore.')
+      return false
+    }
+
+    Object.defineProperty(globalThis, 'AbortController', {
+      enumerable: true,
+      configurable: true,
+      value: this.getPureAbortController(),
+    })
+
+    this.logger.info('native "AbortController" restored!')
+    return true
+  }
+
+  registerSignal(signal: AbortSignal): boolean {
+    const controllerWeakRef = this.referencedAbortControllers.get(signal)
+
+    /**
+     * If the controller is not found, it means one of two things :
+     * 1) it has been created before the interceptor setup
+     * 2) it has been garbage collected
+     *
+     * Case (1) means this controller is outside of the scope of MSW,
+     * therefore it is not the responsibility of the interceptor to handle its behavior during shutdown.
+     *
+     * Case (2) means the last ref to AbortController.signal has been dropped before the request was sent.
+     * This indicates that the test might be flaky and the user may benefit from a warning by
+     * the test runner about open handles.
+     * For this reason it is correct to not handle its behavior during shutdown.
+     */
+    if (controllerWeakRef === undefined) {
+      this.logger.debug('AbortController not found in the global map')
+      return false
+    }
+
+    const controller = controllerWeakRef.deref()
+
+    if (controller === undefined) {
+      this.logger.debug('AbortController has been garbage collected before it could be registered')
+      return false
+    }
+
+    this.registeredAbortControllers.set(signal, controller)
+    return true
+  }
+
+  isDecorated() {
+    // @ts-ignore
+    return globalThis.AbortController[decoratorSymbol] === true
+  }
+
+  isReferenced(controller: AbortController) {
+    return this.referencedAbortControllers.has(controller.signal);
+  }
+
+  isRegistered(controller: AbortController) {
+    return this.registeredAbortControllers.has(controller.signal);
+  }
+
+  abortAll(): number {
+    let i = 0
+    this.registeredAbortControllers.forEach(c => {
+      if (c.signal.aborted) return
+      i++
+      c.abort()
+    })
+
+    return i;
+  }
+
+  dispose() {
+    this.logger.debug('dispose')
+    this.restore()
+    this.abortAll()
+    this.referencedAbortControllers = new WeakMap()
+    this.registeredAbortControllers.clear()
+  }
+}

--- a/src/utils/AbortControllerManager.ts
+++ b/src/utils/AbortControllerManager.ts
@@ -103,7 +103,7 @@ export class AbortControllerManager {
      * Case (1) means this controller is outside of the scope of MSW,
      * therefore it is not the responsibility of the interceptor to handle its behavior during shutdown.
      *
-     * Case (2) means the last ref to AbortController.signal has been dropped before the request was sent.
+     * Case (2) means the last ref to AbortController.signal has been dropped before the request was intercepted.
      * This indicates that the test might be flaky and the user may benefit from a warning by
      * the test runner about open handles.
      * For this reason it is correct to not handle its behavior during shutdown.
@@ -122,6 +122,11 @@ export class AbortControllerManager {
 
     this.registeredAbortControllers.set(signal, controller)
     return true
+  }
+
+  forgetSignal(signal: AbortSignal) {
+    this.referencedAbortControllers.delete(signal);
+    this.registeredAbortControllers.delete(signal);
   }
 
   isDecorated() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,12 @@
     "removeComments": false,
     "esModuleInterop": true,
     "downlevelIteration": true,
-    "lib": ["dom", "dom.iterable", "ES2018.AsyncGenerator"]
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "ES2018.AsyncGenerator",
+      "es2021.weakref"
+    ]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "**/*.test.*"]


### PR DESCRIPTION
This PR aims to solve issue https://github.com/mswjs/msw/issues/778.

I took the following approach : 

- Decorate the global AbortController class
- Hold weak references to all controllers created
- Once a request is intercepted, hold a strong reference to its controller
- Once a request ends, free the strong reference
- On dispose, abort the requests using their controllers 

Since this only affects Node.js, I implemented the logic into `FetchInterceptor` and `ClientRequestInterceptor`