### PR TITLE
feat: remove "headers-polyfill" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "@open-draft/deferred-promise": "^2.1.0",
     "@open-draft/logger": "^0.3.0",
     "@open-draft/until": "^2.0.0",
-    "headers-polyfill": "^3.1.0",
     "is-node-process": "^1.2.0",
     "outvariant": "^1.2.1",
     "strict-event-emitter": "^0.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,6 @@ specifiers:
   express-rate-limit: ^6.3.0
   follow-redirects: ^1.15.1
   got: ^11.8.3
-  headers-polyfill: ^3.1.0
   is-node-process: ^1.2.0
   jest: ^27.4.3
   node-fetch: 2.6.7
@@ -52,7 +51,6 @@ dependencies:
   '@open-draft/deferred-promise': 2.1.0
   '@open-draft/logger': 0.3.0
   '@open-draft/until': 2.1.0
-  headers-polyfill: 3.2.0
   is-node-process: 1.2.0
   outvariant: 1.4.0
   strict-event-emitter: 0.5.0
@@ -3707,10 +3705,6 @@ packages:
     dependencies:
       function-bind: 1.1.1
     dev: true
-
-  /headers-polyfill/3.2.0:
-    resolution: {integrity: sha512-NsYkbrWFQyoPBrbX5riycJ3D4aaB/3fpx1nYgDi3JTTnoeFET3BN0rq2nOB3VUmvpQrYpbKL8zRJo1Jsmmt7nA==}
-    dev: false
 
   /hexoid/1.0.0:
     resolution: {integrity: sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==}

--- a/src/RemoteHttpInterceptor.ts
+++ b/src/RemoteHttpInterceptor.ts
@@ -1,5 +1,4 @@
 import { ChildProcess } from 'child_process'
-import { Headers, HeadersObject, headersToObject } from 'headers-polyfill'
 import { HttpRequestEventMap } from './glossary'
 import { Interceptor } from './Interceptor'
 import { BatchInterceptor } from './BatchInterceptor'
@@ -11,7 +10,7 @@ export interface SerializedRequest {
   id: string
   url: string
   method: string
-  headers: HeadersObject
+  headers: Array<[string, string]>
   credentials: RequestCredentials
   body: string
 }
@@ -24,7 +23,7 @@ interface RevivedRequest extends Omit<SerializedRequest, 'url' | 'headers'> {
 export interface SerializedResponse {
   status: number
   statusText: string
-  headers: HeadersObject
+  headers: Array<[string, string]>
   body: string
 }
 
@@ -53,7 +52,7 @@ export class RemoteHttpInterceptor extends BatchInterceptor<
         id: requestId,
         method: request.method,
         url: request.url,
-        headers: headersToObject(request.headers),
+        headers: Array.from(request.headers.entries()),
         credentials: request.credentials,
         body: ['GET', 'HEAD'].includes(request.method)
           ? null
@@ -87,11 +86,11 @@ export class RemoteHttpInterceptor extends BatchInterceptor<
             const mockedResponse = new Response(responseInit.body, {
               status: responseInit.status,
               statusText: responseInit.statusText,
-              headers: new Headers(responseInit.headers),
+              headers: responseInit.headers,
             })
 
             request.respondWith(mockedResponse)
-            resolve()
+            return resolve()
           }
         }
       })
@@ -194,7 +193,7 @@ export class RemoteHttpResolver extends Interceptor<HttpRequestEventMap> {
       const serializedResponse = JSON.stringify({
         status: mockedResponse.status,
         statusText: mockedResponse.statusText,
-        headers: headersToObject(mockedResponse.headers),
+        headers: Array.from(mockedResponse.headers.entries()),
         body: responseText,
       } as SerializedResponse)
 

--- a/src/interceptors/ClientRequest/utils/createRequest.ts
+++ b/src/interceptors/ClientRequest/utils/createRequest.ts
@@ -1,4 +1,3 @@
-import { Headers } from 'headers-polyfill'
 import type { NodeClientRequest } from '../NodeClientRequest'
 
 /**

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -1,5 +1,4 @@
 import { invariant } from 'outvariant'
-import { headersToString } from 'headers-polyfill'
 import { isNodeProcess } from 'is-node-process'
 import type { Logger } from '@open-draft/logger'
 import { concatArrayBuffer } from './utils/concatArrayBuffer'
@@ -267,7 +266,13 @@ export class XMLHttpRequestController {
             return ''
           }
 
-          const allHeaders = headersToString(response.headers)
+          const headersList = Array.from(response.headers.entries())
+          const allHeaders = headersList
+            .map(([headerName, headerValue]) => {
+              return `${headerName}: ${headerValue}`
+            })
+            .join('\r\n')
+
           this.logger.info('resolved all response headers to', allHeaders)
 
           return allHeaders

--- a/src/interceptors/XMLHttpRequest/utils/createResponse.ts
+++ b/src/interceptors/XMLHttpRequest/utils/createResponse.ts
@@ -1,12 +1,34 @@
-import { stringToHeaders } from 'headers-polyfill'
-
+/**
+ * Creates a Fetch API `Response` instance from the given
+ * `XMLHttpRequest` instance and a response body.
+ */
 export function createResponse(
   request: XMLHttpRequest,
-  responseBody: BodyInit | null
+  body: BodyInit | null
 ): Response {
-  return new Response(responseBody, {
+  return new Response(body, {
     status: request.status,
     statusText: request.statusText,
-    headers: stringToHeaders(request.getAllResponseHeaders()),
+    headers: createHeadersFromXMLHttpReqestHeaders(
+      request.getAllResponseHeaders()
+    ),
   })
+}
+
+function createHeadersFromXMLHttpReqestHeaders(headersString: string): Headers {
+  const headers = new Headers()
+
+  const lines = headersString.split(/[\r\n]+/)
+  for (const line of lines) {
+    if (line.trim() === '') {
+      continue
+    }
+
+    const [name, ...parts] = line.split(': ')
+    const value = parts.join(': ')
+
+    headers.append(name, value)
+  }
+
+  return headers
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,7 +1,6 @@
 import https from 'https'
 import http, { ClientRequest, IncomingMessage, RequestOptions } from 'http'
 import nodeFetch, { Response, RequestInfo, RequestInit } from 'node-fetch'
-import { objectToHeaders } from 'headers-polyfill'
 import { Page } from '@playwright/test'
 import { getRequestOptionsByUrl } from '../src/utils/getRequestOptionsByUrl'
 import { getIncomingMessageBody } from '../src/interceptors/ClientRequest/utils/getIncomingMessageBody'
@@ -218,7 +217,7 @@ export async function extractRequestFromPage(page: Page): Promise<Request> {
 
   const request = new Request(requestJson.url, {
     method: requestJson.method,
-    headers: objectToHeaders(requestJson.headers),
+    headers: new Headers(requestJson.headers),
     credentials: requestJson.credentials,
     body: ['GET', 'HEAD'].includes(requestJson.method)
       ? null

--- a/test/modules/fetch/response/fetch.browser.test.ts
+++ b/test/modules/fetch/response/fetch.browser.test.ts
@@ -1,6 +1,5 @@
 import { HttpServer } from '@open-draft/test-server/http'
 import { Page } from '@playwright/test'
-import { listToHeaders } from 'headers-polyfill'
 import { test, expect } from '../../../playwright.extend'
 import { useCors } from '../../../helpers'
 import { FetchInterceptor } from '../../../../src/interceptors/fetch'
@@ -68,7 +67,7 @@ test('responds to an HTTP request handled in the resolver', async ({
       }))
     })
   }, httpServer.http.url('/'))
-  const headers = listToHeaders(response.headers)
+  const headers = new Headers(response.headers)
 
   expect(response.url).toBe(httpServer.http.url('/'))
   expect(response.type).toBe('default')
@@ -100,7 +99,7 @@ test('bypasses an HTTP request not handled in the resolver', async ({
       }
     })
   }, httpServer.http.url('/get'))
-  const headers = listToHeaders(response.headers)
+  const headers = new Headers(response.headers)
 
   expect(response.url).toBe(httpServer.http.url('/get'))
   expect(response.type).toBe('cors')
@@ -133,7 +132,7 @@ test('responds to an HTTPS request handled in the resolver', async ({
       }))
     })
   }, httpServer.https.url('/'))
-  const headers = listToHeaders(response.headers)
+  const headers = new Headers(response.headers)
 
   expect(response.url).toBe(httpServer.https.url('/'))
   expect(response.type).toBe('default')
@@ -165,7 +164,7 @@ test('bypasses an HTTPS request not handled in the resolver', async ({
       }
     })
   }, httpServer.https.url('/get'))
-  const headers = listToHeaders(response.headers)
+  const headers = new Headers(response.headers)
 
   expect(response.url).toBe(httpServer.https.url('/get'))
   expect(response.type).toBe('cors')


### PR DESCRIPTION
- Closes #406 

We can fully rely on the Fetch API `Headers` instead of using the `headers-polyfill` library.

We can substitute some of the utility functions of that library by `Array.from(headers.entries())`, and I've added a custom utility that converts `XMLHttpRequest.getAlLResponseHeaders()` string to a `Headers` instance (that one wasn't included in the polyfill library anyway). 