### PR TITLE
chore: set "Access-Control-Allow-Credentials" when testing xhr credentials

### DIFF
--- a/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.test.ts
+++ b/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.test.ts
@@ -16,7 +16,12 @@ declare namespace window {
 }
 
 const httpServer = new HttpServer((app) => {
-  app.use(useCors)
+  app.use(useCors, (req, res, next) => {
+    res.set({
+      'Access-Control-Allow-Credentials': 'true',
+    })
+    return next()
+  })
 
   const handleUserRequest: RequestHandler = (_req, res) => {
     res.status(200).send('user-body').end()


### PR DESCRIPTION
I've noticed release job failures due to one integration test writing to `stderr` (not actually exiting): https://github.com/mswjs/interceptors/actions/runs/6018488102. 

This configures that test to correctly allow `credentials: "include" `in JSDOM through the right response header. 