### PR TITLE
feat: support "Response.error()" for mocking network errors

### DIFF
--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -212,9 +212,26 @@ export class NodeClientRequest extends ClientRequest {
       const mockedResponse = resolverResult.data
 
       if (mockedResponse) {
+        this.logger.info('received mocked response:', mockedResponse)
+
+        // Handle mocked "Response.error" network error responses.
+        if (mockedResponse.type === 'error') {
+          this.logger.info(
+            'received network error response, aborting request...'
+          )
+
+          /**
+           * There is no standardized error format for network errors
+           * in Node.js. Instead, emit a generic TypeError.
+           */
+          this.emit('error', new TypeError('Network error'))
+          this.terminate()
+
+          return this
+        }
+
         const responseClone = mockedResponse.clone()
 
-        this.logger.info('received mocked response:', mockedResponse)
         this.responseSource = 'mock'
 
         this.respondWith(mockedResponse)

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestProxy.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestProxy.ts
@@ -104,6 +104,15 @@ export function createXMLHttpRequestProxy({
             mockedResponse.statusText
           )
 
+          if (mockedResponse.type === 'error') {
+            this.logger.info(
+              'received a network error response, rejecting the request promise...'
+            )
+
+            requestController.errorWith(new TypeError('Network error'))
+            return
+          }
+
           return requestController.respondWith(mockedResponse)
         }
 

--- a/test/modules/XMLHttpRequest/response/xhr-response-error.browser.runtime.js
+++ b/test/modules/XMLHttpRequest/response/xhr-response-error.browser.runtime.js
@@ -1,0 +1,9 @@
+import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
+
+const interceptor = new XMLHttpRequestInterceptor()
+
+interceptor.on('request', ({ request }) => {
+  request.respondWith(Response.error())
+})
+
+interceptor.apply()

--- a/test/modules/XMLHttpRequest/response/xhr-response-error.browser.test.ts
+++ b/test/modules/XMLHttpRequest/response/xhr-response-error.browser.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '../../../playwright.extend'
+
+test('treats "Response.error()" as request error', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(require.resolve('./xhr-response-error.browser.runtime.js'))
+
+  const requestAfterError = await page.evaluate(() => {
+    const request = new XMLHttpRequest()
+    request.open('GET', 'http://localhost/resource')
+
+    return new Promise<{
+      status: number
+      statusText: string
+      response: unknown
+    }>((resolve) => {
+      request.addEventListener('error', () => {
+        resolve({
+          status: request.status,
+          statusText: request.statusText,
+          response: request.response,
+        })
+      })
+
+      request.send()
+    })
+  })
+
+  expect(requestAfterError.status).toBe(0)
+  expect(requestAfterError.statusText).toBe('')
+  expect(requestAfterError.response).toBe('')
+})

--- a/test/modules/XMLHttpRequest/response/xhr-response-error.test.ts
+++ b/test/modules/XMLHttpRequest/response/xhr-response-error.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
+import { createXMLHttpRequest } from '../../../helpers'
+
+const interceptor = new XMLHttpRequestInterceptor()
+interceptor.on('request', ({ request }) => {
+  request.respondWith(Response.error())
+})
+
+beforeAll(async () => {
+  interceptor.apply()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+})
+
+it('treats "Response.error()" as request error', async () => {
+  const requestErrorListener = vi.fn()
+
+  const request = await createXMLHttpRequest((request) => {
+    request.open('GET', 'http://localhost:3001/resource')
+    request.addEventListener('error', requestErrorListener)
+    request.send()
+  })
+
+  // Request must reflect the request error state.
+  expect(request.readyState).toBe(request.DONE)
+  expect(request.status).toBe(0)
+  expect(request.statusText).toBe('')
+  expect(request.response).toBe('')
+
+  // Network error must propagate to the "error" request event.
+  expect(requestErrorListener).toHaveBeenCalledTimes(1)
+})

--- a/test/modules/fetch/compliance/abort-conrtoller.test.ts
+++ b/test/modules/fetch/compliance/abort-conrtoller.test.ts
@@ -96,7 +96,6 @@ it('forwards custom abort reason to the request if aborted before it starts', as
   controller.abort(new Error('Custom abort reason'))
 
   const abortError = await requestAborted
-  console.log({ abortError })
 
   expect(abortError.name).toBe('Error')
   expect(abortError.code).toBeUndefined()

--- a/test/modules/fetch/compliance/fetch-response-error.test.ts
+++ b/test/modules/fetch/compliance/fetch-response-error.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+import { vi, it, expect, beforeAll, afterAll } from 'vitest'
+import { FetchInterceptor } from '../../../../src/interceptors/fetch'
+
+const interceptor = new FetchInterceptor()
+
+interceptor.on('request', ({ request }) => {
+  /**
+   * Responding with "Response.error()" is equivalent to
+   * network error occurring during the request processing.
+   * This must reject the request promise.
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Response/error_static
+   */
+  request.respondWith(Response.error())
+})
+
+beforeAll(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => void 0)
+  interceptor.apply()
+})
+
+afterAll(() => {
+  vi.restoreAllMocks()
+  interceptor.dispose()
+})
+
+it('treats "Response.error()" as a network error', async () => {
+  const error = await fetch('http://localhost:3001/resource').then<
+    null,
+    TypeError & { cause: unknown }
+  >(
+    () => null,
+    (error) => error
+  )
+
+  expect(error).toBeInstanceOf(TypeError)
+  expect(error!.message).toBe('Failed to fetch')
+  // Internal: preserve the original Response error.
+  expect(error!.cause).toEqual(Response.error())
+})

--- a/test/modules/fetch/fetch-exception.test.ts
+++ b/test/modules/fetch/fetch-exception.test.ts
@@ -19,12 +19,16 @@ afterAll(() => {
 })
 
 it('treats middleware exceptions as TypeError: Failed to fetch', async () => {
-  await fetch('http://localhost:3001/resource').catch(
-    (error: TypeError & { cause: Error }) => {
-      expect(error).toBeInstanceOf(TypeError)
-      expect(error.message).toBe('Failed to fetch')
-      // Internal: preserve the original middleware error.
-      expect(error.cause).toEqual(new Error('Network error'))
-    }
+  const error = await fetch('http://localhost:3001/resource').then<
+    null,
+    TypeError & { cause: unknown }
+  >(
+    () => null,
+    (error) => error
   )
+
+  expect(error).toBeInstanceOf(TypeError)
+  expect(error!.message).toBe('Failed to fetch')
+  // Internal: preserve the original middleware error.
+  expect(error!.cause).toEqual(new Error('Network error'))
 })

--- a/test/modules/http/response/http-response-error.test.ts
+++ b/test/modules/http/response/http-response-error.test.ts
@@ -1,0 +1,32 @@
+import { it, expect, beforeAll, afterAll } from 'vitest'
+import http from 'http'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+import { DeferredPromise } from '@open-draft/deferred-promise'
+
+const interceptor = new ClientRequestInterceptor()
+
+interceptor.on('request', ({ request }) => {
+  request.respondWith(Response.error())
+})
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+})
+
+it('treats "Response.error()" as a request error', async () => {
+  const requestErrorPromise = new DeferredPromise<Error>()
+
+  const request = http.get('http://localhost:3001/resource')
+
+  // In ClientRequest, network errors are forwarded as
+  // request errors.
+  request.on('error', requestErrorPromise.resolve)
+  const requestError = await requestErrorPromise
+
+  expect(requestError).toBeInstanceOf(TypeError)
+  expect(requestError.message).toBe('Network error')
+})


### PR DESCRIPTION
- Closes #413 
- Prerequisite for https://github.com/mswjs/msw/pull/1730