### PR TITLE
fix: pin "headers-polyfill" to 3.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@types/debug": "^4.1.7",
     "@xmldom/xmldom": "^0.8.3",
     "debug": "^4.3.3",
-    "headers-polyfill": "^3.1.0",
+    "headers-polyfill": "3.2.5",
     "outvariant": "^1.2.1",
     "strict-event-emitter": "^0.2.4",
     "web-encoding": "^1.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3201,15 +3201,15 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+headers-polyfill@3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-3.2.5.tgz#6e67d392c9d113d37448fe45014e0afdd168faed"
+  integrity sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==
+
 headers-polyfill@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-3.0.3.tgz#222bd9a6b5a1f610ad563473efb0d34a13eb7ebc"
   integrity sha512-Ak5m549Y+5vBtWNnIUcyARJjF0tQpINuy3+vOqG8tK/qjF0itYhAPgrzJc0zsZJh7AX8PalzICMPuWIqHpZlEA==
-
-headers-polyfill@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-3.1.0.tgz#22135c594feb4d5efd56e5c7f587552b9feac0e7"
-  integrity sha512-AVwgTAzeGpF7kwUCMc9HbAoCKFcHGEfmWkaI8g0jprrkh9VPRaofIsfV7Lw8UuR9pi4Rk7IIjJce8l0C+jSJNA==
 
 homedir-polyfill@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
- Fixes incorrect minor release of a breaking change in https://github.com/mswjs/headers-polyfill/releases/tag/v3.3.0