### PR TITLE
chore: set "moduleResolution" to "NodeNext"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "sourceMap": true,
     "outDir": "lib",
     "declaration": true,
-    "moduleResolution": "node",
+    "moduleResolution": "NodeNext",
     "removeComments": false,
     "esModuleInterop": true,
     "downlevelIteration": true,


### PR DESCRIPTION
Module resolution must be set to `NodeNext` if using `NodeNext` as the `module`. 