### PR TITLE
fix: add "once", "off", and "removeAllListeners" to the Interceptor class

### DIFF
--- a/src/BatchInterceptor.test.ts
+++ b/src/BatchInterceptor.test.ts
@@ -112,3 +112,135 @@ it('disposes of child interceptors', async () => {
   expect(primaryDisposeSpy).toHaveBeenCalledTimes(1)
   expect(secondaryDisposeSpy).toHaveBeenCalledTimes(1)
 })
+
+it('forwards listeners added via "on()"', () => {
+  class FirstInterceptor extends Interceptor<any> {
+    constructor() {
+      super(Symbol('first'))
+    }
+  }
+  class SecondaryInterceptor extends Interceptor<any> {
+    constructor() {
+      super(Symbol('second'))
+    }
+  }
+
+  const firstInterceptor = new FirstInterceptor()
+  const secondInterceptor = new SecondaryInterceptor()
+
+  const interceptor = new BatchInterceptor({
+    name: 'batch',
+    interceptors: [firstInterceptor, secondInterceptor],
+  })
+
+  const listener = vi.fn()
+  interceptor.on('foo', listener)
+
+  expect(firstInterceptor['emitter'].listenerCount('foo')).toBe(1)
+  expect(secondInterceptor['emitter'].listenerCount('foo')).toBe(1)
+  expect(interceptor['emitter'].listenerCount('foo')).toBe(0)
+})
+
+it('forwards listeners removal via "off()"', () => {
+  class FirstInterceptor extends Interceptor<any> {
+    constructor() {
+      super(Symbol('first'))
+    }
+  }
+  class SecondaryInterceptor extends Interceptor<any> {
+    constructor() {
+      super(Symbol('second'))
+    }
+  }
+
+  const firstInterceptor = new FirstInterceptor()
+  const secondInterceptor = new SecondaryInterceptor()
+
+  const interceptor = new BatchInterceptor({
+    name: 'batch',
+    interceptors: [firstInterceptor, secondInterceptor],
+  })
+
+  const listener = vi.fn()
+  interceptor.on('foo', listener)
+  interceptor.off('foo', listener)
+
+  expect(firstInterceptor['emitter'].listenerCount('foo')).toBe(0)
+  expect(secondInterceptor['emitter'].listenerCount('foo')).toBe(0)
+})
+
+it('forwards removal of all listeners by name via ".removeAllListeners()"', () => {
+  class FirstInterceptor extends Interceptor<any> {
+    constructor() {
+      super(Symbol('first'))
+    }
+  }
+  class SecondaryInterceptor extends Interceptor<any> {
+    constructor() {
+      super(Symbol('second'))
+    }
+  }
+
+  const firstInterceptor = new FirstInterceptor()
+  const secondInterceptor = new SecondaryInterceptor()
+
+  const interceptor = new BatchInterceptor({
+    name: 'batch',
+    interceptors: [firstInterceptor, secondInterceptor],
+  })
+
+  const listener = vi.fn()
+  interceptor.on('foo', listener)
+  interceptor.on('foo', listener)
+  interceptor.on('bar', listener)
+
+  expect(firstInterceptor['emitter'].listenerCount('foo')).toBe(2)
+  expect(secondInterceptor['emitter'].listenerCount('foo')).toBe(2)
+  expect(firstInterceptor['emitter'].listenerCount('bar')).toBe(1)
+  expect(secondInterceptor['emitter'].listenerCount('bar')).toBe(1)
+
+  interceptor.removeAllListeners('foo')
+
+  expect(firstInterceptor['emitter'].listenerCount('foo')).toBe(0)
+  expect(secondInterceptor['emitter'].listenerCount('foo')).toBe(0)
+  expect(firstInterceptor['emitter'].listenerCount('bar')).toBe(1)
+  expect(secondInterceptor['emitter'].listenerCount('bar')).toBe(1)
+})
+
+it('forwards removal of all listeners via ".removeAllListeners()"', () => {
+  class FirstInterceptor extends Interceptor<any> {
+    constructor() {
+      super(Symbol('first'))
+    }
+  }
+  class SecondaryInterceptor extends Interceptor<any> {
+    constructor() {
+      super(Symbol('second'))
+    }
+  }
+
+  const firstInterceptor = new FirstInterceptor()
+  const secondInterceptor = new SecondaryInterceptor()
+
+  const interceptor = new BatchInterceptor({
+    name: 'batch',
+    interceptors: [firstInterceptor, secondInterceptor],
+  })
+
+  const listener = vi.fn()
+  interceptor.on('foo', listener)
+  interceptor.on('foo', listener)
+  interceptor.on('bar', listener)
+
+  expect(firstInterceptor['emitter'].listenerCount('foo')).toBe(2)
+  expect(secondInterceptor['emitter'].listenerCount('foo')).toBe(2)
+  expect(firstInterceptor['emitter'].listenerCount('bar')).toBe(1)
+  expect(secondInterceptor['emitter'].listenerCount('bar')).toBe(1)
+
+  interceptor.removeAllListeners()
+
+  expect(firstInterceptor['emitter'].listenerCount('foo')).toBe(0)
+  expect(secondInterceptor['emitter'].listenerCount('foo')).toBe(0)
+  expect(firstInterceptor['emitter'].listenerCount('bar')).toBe(0)
+  expect(secondInterceptor['emitter'].listenerCount('bar')).toBe(0)
+})

--- a/src/BatchInterceptor.ts
+++ b/src/BatchInterceptor.ts
@@ -82,4 +82,14 @@ export class BatchInterceptor<
 
     return this
   }
+
+  public removeAllListeners<EventName extends ExtractEventNames<Events>>(
+    event?: EventName | undefined
+  ): this {
+    for (const interceptors of this.interceptors) {
+      interceptors.removeAllListeners(event)
+    }
+
+    return this
+  }
 }

--- a/src/BatchInterceptor.ts
+++ b/src/BatchInterceptor.ts
@@ -51,11 +51,35 @@ export class BatchInterceptor<
   public on<EventName extends ExtractEventNames<Events>>(
     event: EventName,
     listener: Listener<Events[EventName]>
-  ) {
+  ): this {
     // Instead of adding a listener to the batch interceptor,
     // propagate the listener to each of the individual interceptors.
-    this.interceptors.forEach((interceptor) => {
+    for (const interceptor of this.interceptors) {
       interceptor.on(event, listener)
-    })
+    }
+
+    return this
+  }
+
+  public once<EventName extends ExtractEventNames<Events>>(
+    event: EventName,
+    listener: Listener<Events[EventName]>
+  ): this {
+    for (const interceptor of this.interceptors) {
+      interceptor.once(event, listener)
+    }
+
+    return this
+  }
+
+  public off<EventName extends ExtractEventNames<Events>>(
+    event: EventName,
+    listener: Listener<Events[EventName]>
+  ): this {
+    for (const interceptor of this.interceptors) {
+      interceptor.off(event, listener)
+    }
+
+    return this
   }
 }

--- a/src/Interceptor.test.ts
+++ b/src/Interceptor.test.ts
@@ -18,6 +18,31 @@ it('does not set a maximum listeners limit', () => {
   expect(interceptor['emitter'].getMaxListeners()).toBe(0)
 })
 
+describe('on()', () => {
+  it('adds a new listener using "on()"', () => {
+    const interceptor = new Interceptor(symbol)
+    expect(interceptor['emitter'].listenerCount('event')).toBe(0)
+
+    const listener = vi.fn()
+    interceptor.on('event', listener)
+    expect(interceptor['emitter'].listenerCount('event')).toBe(1)
+  })
+})
+
+describe('off()', () => {
+  it('removes a listener using "off()"', () => {
+    const interceptor = new Interceptor(symbol)
+    expect(interceptor['emitter'].listenerCount('event')).toBe(0)
+
+    const listener = vi.fn()
+    interceptor.on('event', listener)
+    expect(interceptor['emitter'].listenerCount('event')).toBe(1)
+
+    interceptor.off('event', listener)
+    expect(interceptor['emitter'].listenerCount('event')).toBe(0)
+  })
+})
+
 describe('persistence', () => {
   it('stores global reference to the applied interceptor', () => {
     const interceptor = new Interceptor(symbol)

--- a/src/Interceptor.ts
+++ b/src/Interceptor.ts
@@ -112,6 +112,8 @@ export class Interceptor<Events extends InterceptorEventMap> {
           runningInstance.emitter.removeListener(event, listener)
           logger.info('removed proxied "%s" listener!', event)
         })
+
+        return this
       }
 
       this.readyState = InterceptorReadyState.APPLIED
@@ -143,7 +145,7 @@ export class Interceptor<Events extends InterceptorEventMap> {
   public on<EventName extends ExtractEventNames<Events>>(
     eventName: EventName,
     listener: Listener<Events[EventName]>
-  ): void {
+  ): this {
     const logger = this.logger.extend('on')
 
     if (
@@ -151,12 +153,39 @@ export class Interceptor<Events extends InterceptorEventMap> {
       this.readyState === InterceptorReadyState.DISPOSED
     ) {
       logger.info('cannot listen to events, already disposed!')
-      return
+      return this
     }
 
     logger.info('adding "%s" event listener:', eventName, listener.name)
 
     this.emitter.on(eventName, listener)
+    return this
+  }
+
+  public once<EventName extends ExtractEventNames<Events>>(
+    eventName: EventName,
+    listener: Listener<Events[EventName]>
+  ): this {
+    const logger = this.logger.extend('once')
+    logger.info(
+      'adding a one-time "%s" event listener:',
+      eventName,
+      listener.name
+    )
+
+    this.emitter.once(eventName, listener)
+    return this
+  }
+
+  public off<EventName extends ExtractEventNames<Events>>(
+    eventName: EventName,
+    listener: Listener<Events[EventName]>
+  ): this {
+    const logger = this.logger.extend('off')
+    logger.info('removing "%s" event listener:', eventName, listener.name)
+
+    this.emitter.off(eventName, listener)
+    return this
   }
 
   /**

--- a/src/Interceptor.ts
+++ b/src/Interceptor.ts
@@ -143,7 +143,7 @@ export class Interceptor<Events extends InterceptorEventMap> {
    * Listen to the interceptor's public events.
    */
   public on<EventName extends ExtractEventNames<Events>>(
-    eventName: EventName,
+    event: EventName,
     listener: Listener<Events[EventName]>
   ): this {
     const logger = this.logger.extend('on')
@@ -156,35 +156,38 @@ export class Interceptor<Events extends InterceptorEventMap> {
       return this
     }
 
-    logger.info('adding "%s" event listener:', eventName, listener.name)
+    logger.info('adding "%s" event listener:', event, listener.name)
 
-    this.emitter.on(eventName, listener)
+    this.emitter.on(event, listener)
     return this
   }
 
   public once<EventName extends ExtractEventNames<Events>>(
-    eventName: EventName,
+    event: EventName,
     listener: Listener<Events[EventName]>
   ): this {
     const logger = this.logger.extend('once')
-    logger.info(
-      'adding a one-time "%s" event listener:',
-      eventName,
-      listener.name
-    )
+    logger.info('adding a one-time "%s" event listener:', event, listener.name)
 
-    this.emitter.once(eventName, listener)
+    this.emitter.once(event, listener)
     return this
   }
 
   public off<EventName extends ExtractEventNames<Events>>(
-    eventName: EventName,
+    event: EventName,
     listener: Listener<Events[EventName]>
   ): this {
     const logger = this.logger.extend('off')
-    logger.info('removing "%s" event listener:', eventName, listener.name)
+    logger.info('removing "%s" event listener:', event, listener.name)
 
-    this.emitter.off(eventName, listener)
+    this.emitter.off(event, listener)
+    return this
+  }
+
+  public removeAllListeners<EventName extends ExtractEventNames<Events>>(
+    event?: EventName
+  ): this {
+    this.emitter.removeAllListeners(event)
     return this
   }
 


### PR DESCRIPTION
- Adds `once` and `off` methods on the `Interceptor` class (and the derived classes, like `BatchInterceptor`) to attach one-time listener and to remove listener, respectively. 