### PR TITLE
fix(ClientRequest): support the "auth" option

### DIFF
--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -69,8 +69,6 @@ export class NodeClientRequest extends ClientRequest {
     })
 
     this.url = url
-    this.url.username = ''
-    this.url.password = ''
     this.emitter = options.emitter
 
     // Set request buffer to null by default so that GET/HEAD requests

--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -69,6 +69,8 @@ export class NodeClientRequest extends ClientRequest {
     })
 
     this.url = url
+    this.url.username = ''
+    this.url.password = ''
     this.emitter = options.emitter
 
     // Set request buffer to null by default so that GET/HEAD requests

--- a/src/interceptors/ClientRequest/utils/createRequest.ts
+++ b/src/interceptors/ClientRequest/utils/createRequest.ts
@@ -20,6 +20,21 @@ export function createRequest(clientRequest: NodeClientRequest): Request {
     }
   }
 
+  /**
+   * Translate the authentication from the request URL to
+   * the request "Authorization" header.
+   * @see https://github.com/mswjs/interceptors/issues/438
+   */
+  if (clientRequest.url.username && clientRequest.url.password) {
+    const auth = `${clientRequest.url.username}:${clientRequest.url.password}`
+    headers.set('Authorization', `Basic ${btoa(auth)}`)
+
+    // Remove the credentials from the URL since you cannot
+    // construct a Request instance with such a URL.
+    clientRequest.url.username = ''
+    clientRequest.url.password = ''
+  }
+
   const method = clientRequest.method || 'GET'
 
   return new Request(clientRequest.url, {

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -86,7 +86,14 @@ function getHostByRequestOptions(options: ResolvedRequestOptions): string {
   return host || DEFAULT_HOST
 }
 
-function getAuthByRequestOptions(options: ResolvedRequestOptions) {
+interface RequestAuth {
+  username: string
+  password: string
+}
+
+function getAuthByRequestOptions(
+  options: ResolvedRequestOptions
+): RequestAuth | undefined {
   if (options.auth) {
     const [username, password] = options.auth.split(':')
     return { username, password }
@@ -159,7 +166,10 @@ export function getUrlByRequestOptions(options: ResolvedRequestOptions): URL {
     : ''
   logger.info('auth string:', authString)
 
-  const url = new URL(`${protocol}//${authString}${hostname}${path}`)
+  const url = new URL(`${protocol}//${hostname}${path}`)
+  url.username = credentials?.username || ''
+  url.password = credentials?.password || ''
+
   logger.info('created url:', url)
 
   return url

--- a/test/modules/http/intercept/http.request.test.ts
+++ b/test/modules/http/intercept/http.request.test.ts
@@ -229,3 +229,29 @@ it('intercepts an http.request given RequestOptions without a protocol', async (
 
   expect(requestId).toMatch(UUID_REGEXP)
 })
+
+it.only('intercepts an http.request given auth', async () => {
+  // Create a request with `RequestOptions` without an explicit "protocol".
+  // Since request is done via `http.get`, the "http:" protocol must be inferred.
+  const req = http.request({
+    host: httpServer.http.address.host,
+    port: httpServer.http.address.port,
+    path: '/user?id=123',
+    auth: 'username:password',
+  })
+  req.end()
+  await waitForClientRequest(req)
+
+  expect(resolver).toHaveBeenCalledTimes(1)
+
+  const [{ request, requestId }] = resolver.mock.calls[0]
+
+  expect(request.method).toBe('GET')
+  expect(request.url).toBe(httpServer.http.url('/user?id=123'))
+  expect(request.credentials).toBe('same-origin')
+  expect(request.body).toBe(null)
+  expect(request.respondWith).toBeInstanceOf(Function)
+
+  expect(requestId).toMatch(UUID_REGEXP)
+})
+

--- a/test/modules/http/intercept/http.request.test.ts
+++ b/test/modules/http/intercept/http.request.test.ts
@@ -1,7 +1,7 @@
 import { vi, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
 import http from 'http'
-import { RequestHandler } from 'express-serve-static-core'
 import { HttpServer } from '@open-draft/test-server/http'
+import type { RequestHandler } from 'express'
 import { UUID_REGEXP, waitForClientRequest } from '../../../helpers'
 import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
 import { HttpRequestEventMap } from '../../../../src'
@@ -230,8 +230,8 @@ it('intercepts an http.request given RequestOptions without a protocol', async (
   expect(requestId).toMatch(UUID_REGEXP)
 })
 
-it('intercepts an http.request given auth', async () => {
-  const auth = 'username:password'
+it('intercepts an http.request with custom "auth" option', async () => {
+  const auth = 'john:secret123'
   const req = http.request({
     host: httpServer.http.address.host,
     port: httpServer.http.address.port,
@@ -242,15 +242,36 @@ it('intercepts an http.request given auth', async () => {
 
   expect(resolver).toHaveBeenCalledTimes(1)
 
-  const [{ request, requestId }] = resolver.mock.calls[0]
+  const [{ request }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
   expect(request.url).toBe(httpServer.http.url('/'))
-  expect(request.headers.get('authorization')).toEqual('Basic ' + Buffer.from(auth).toString('base64'))
+  expect(request.headers.get('authorization')).toBe(`Basic ${btoa(auth)}`)
   expect(request.credentials).toBe('same-origin')
   expect(request.body).toBe(null)
-  expect(request.respondWith).toBeInstanceOf(Function)
-
-  expect(requestId).toMatch(UUID_REGEXP)
 })
 
+it('intercepts an http.request with a URL with "username" and "password"', async () => {
+  const username = 'john'
+  const password = 'secret123'
+  const req = http.request(
+    // The request URL can include the basic auth directly.
+    new URL(
+      `http://${username}:${password}@${httpServer.http.address.host}:${httpServer.http.address.port}/`
+    )
+  )
+  req.end()
+  await waitForClientRequest(req)
+
+  expect(resolver).toHaveBeenCalledTimes(1)
+
+  const [{ request }] = resolver.mock.calls[0]
+
+  expect(request.method).toBe('GET')
+  expect(request.url).toBe(httpServer.http.url('/'))
+  expect(request.headers.get('authorization')).toBe(
+    `Basic ${btoa(`${username}:${password}`)}`
+  )
+  expect(request.credentials).toBe('same-origin')
+  expect(request.body).toBe(null)
+})

--- a/test/modules/http/intercept/http.request.test.ts
+++ b/test/modules/http/intercept/http.request.test.ts
@@ -230,14 +230,12 @@ it('intercepts an http.request given RequestOptions without a protocol', async (
   expect(requestId).toMatch(UUID_REGEXP)
 })
 
-it.only('intercepts an http.request given auth', async () => {
-  // Create a request with `RequestOptions` without an explicit "protocol".
-  // Since request is done via `http.get`, the "http:" protocol must be inferred.
+it('intercepts an http.request given auth', async () => {
+  const auth = 'username:password'
   const req = http.request({
     host: httpServer.http.address.host,
     port: httpServer.http.address.port,
-    path: '/user?id=123',
-    auth: 'username:password',
+    auth,
   })
   req.end()
   await waitForClientRequest(req)
@@ -247,7 +245,8 @@ it.only('intercepts an http.request given auth', async () => {
   const [{ request, requestId }] = resolver.mock.calls[0]
 
   expect(request.method).toBe('GET')
-  expect(request.url).toBe(httpServer.http.url('/user?id=123'))
+  expect(request.url).toBe(httpServer.http.url('/'))
+  expect(request.headers.get('authorization')).toEqual('Basic ' + Buffer.from(auth).toString('base64'))
   expect(request.credentials).toBe('same-origin')
   expect(request.body).toBe(null)
   expect(request.respondWith).toBeInstanceOf(Function)


### PR DESCRIPTION
Options: https://nodejs.org/api/http.html#httprequesturl-options-callback

@kettanaito 
* Not sure if this is where the test should be
* Also, I'm not sure if this is what you mean by "Do not propagate username and password onto the [NodeClientRequest.url](https://github.com/mswjs/interceptors/blob/b8bce893d7e9642a9836ad29a0903562dde7fbca/src/interceptors/ClientRequest/NodeClientRequest.ts#L71)", I just override the username/password. Please let me know if you have something else in mind.

closes #438