### PR TITLE
fix(ClientRequest): respect "options.path" over "url.pathname"

### DIFF
--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.test.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.test.ts
@@ -212,21 +212,23 @@ it('handles [URL, RequestOptions, callback] input', () => {
   expect(callback?.name).toEqual('cb')
 })
 
-it('handles [URL, RequestOptions] where options override the URL', () => {
-  const firstResult = normalizeClientRequestArgs(
+it('handles [URL, RequestOptions] where options have custom "hostname"', () => {
+  const [url, options] = normalizeClientRequestArgs(
     'http:',
     new URL('http://example.com/path-from-url'),
     {
       hostname: 'host-from-options.com',
     }
   )
-  expect(firstResult[0].href).toBe('http://host-from-options.com/path-from-url')
-  expect(firstResult[1]).toMatchObject({
+  expect(url.href).toBe('http://host-from-options.com/path-from-url')
+  expect(options).toMatchObject({
     host: 'host-from-options.com',
     path: '/path-from-url',
   })
+})
 
-  const secondResult = normalizeClientRequestArgs(
+it('handles [URL, RequestOptions] where options contain "host" and "path" and "port"', () => {
+  const [url, options] = normalizeClientRequestArgs(
     'http:',
     new URL('http://example.com/path-from-url?a=b&c=d'),
     {
@@ -236,13 +238,26 @@ it('handles [URL, RequestOptions] where options override the URL', () => {
     }
   )
   // Must remove the query string since it's not specified in "options.path"
-  expect(secondResult[0].href).toBe(
-    'http://host-from-options.com:1234/path-from-options'
-  )
-  expect(secondResult[1]).toMatchObject({
+  expect(url.href).toBe('http://host-from-options.com:1234/path-from-options')
+  expect(options).toMatchObject({
     host: 'host-from-options.com:1234',
     path: '/path-from-options',
     port: 1234,
+  })
+})
+
+it('handles [URL, RequestOptions] where options contain "path" with query string', () => {
+  const [url, options] = normalizeClientRequestArgs(
+    'http:',
+    new URL('http://example.com/path-from-url?a=b&c=d'),
+    {
+      path: '/path-from-options?foo=bar&baz=xyz',
+    }
+  )
+  expect(url.href).toBe('http://example.com/path-from-options?foo=bar&baz=xyz')
+  expect(options).toMatchObject({
+    host: 'example.com',
+    path: '/path-from-options?foo=bar&baz=xyz',
   })
 })
 

--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.test.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.test.ts
@@ -371,3 +371,50 @@ it('merges URL-based RequestOptions with the custom RequestOptions', () => {
   expect(options.hostname).toEqual(url.hostname)
   expect(options.path).toEqual(url.pathname)
 })
+
+it('respects custom "options.path" over URL path', () => {
+  const [url, options] = normalizeClientRequestArgs(
+    'http:',
+    new URL('http://example.com/path-from-url'),
+    {
+      path: '/path-from-options',
+    }
+  )
+
+  expect(url.href).toBe('http://example.com/path-from-options')
+  expect(options.protocol).toBe('http:')
+  expect(options.host).toBe('example.com')
+  expect(options.hostname).toBe('example.com')
+  expect(options.path).toBe('/path-from-options')
+})
+
+it('respects custom "options.path" over URL path with query string', () => {
+  const [url, options] = normalizeClientRequestArgs(
+    'http:',
+    new URL('http://example.com/path-from-url?a=b&c=d'),
+    {
+      path: '/path-from-options',
+    }
+  )
+
+  // Must replace the path but preserve the query string.
+  expect(url.href).toBe('http://example.com/path-from-options?a=b&c=d')
+  expect(options.protocol).toBe('http:')
+  expect(options.host).toBe('example.com')
+  expect(options.hostname).toBe('example.com')
+  expect(options.path).toBe('/path-from-options')
+})
+
+it('preserves URL query string', () => {
+  const [url, options] = normalizeClientRequestArgs(
+    'http:',
+    new URL('http://example.com/resource?a=b&c=d')
+  )
+
+  expect(url.href).toBe('http://example.com/resource?a=b&c=d')
+  expect(options.protocol).toBe('http:')
+  expect(options.host).toBe('example.com')
+  expect(options.hostname).toBe('example.com')
+  // Query string is a part of the options path.
+  expect(options.path).toBe('/resource?a=b&c=d')
+})

--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
@@ -114,7 +114,12 @@ export function normalizeClientRequestArgs(
     options = resolveRequestOptions(args, url)
     logger.info('derived request options:', options)
 
-    url.pathname = options.path || ''
+    if (options.path) {
+      logger.info('found explicit "path" option ("%s"), overriding URL pathname ("%s")', options.path, url.pathname)
+
+      url.pathname = options.path
+    }
+
     logger.info('first argument is a URL:', url)
 
     callback = resolveCallback(args)

--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
@@ -110,17 +110,29 @@ export function normalizeClientRequestArgs(
   // and derive request options from it.
   else if (args[0] instanceof URL) {
     url = args[0]
+    logger.info('first argument is a URL:', url)
+
+    // Check if the second provided argument is RequestOptions.
+    // If it is, check if "options.path" was set and rewrite it
+    // on the input URL.
+    // Do this before resolving options from the URL below
+    // to prevent query string from being duplicated in the path.
+    if (typeof args[1] !== 'undefined' && isObject<RequestOptions>(args[1])) {
+      const explicitOptions = args[1]
+
+      if (explicitOptions.path != null) {
+        logger.info(
+          'found explicit "path" option ("%s"), overriding URL pathname ("%s")',
+          explicitOptions.path,
+          url.pathname
+        )
+
+        url.pathname = explicitOptions.path
+      }
+    }
 
     options = resolveRequestOptions(args, url)
     logger.info('derived request options:', options)
-
-    if (options.path) {
-      logger.info('found explicit "path" option ("%s"), overriding URL pathname ("%s")', options.path, url.pathname)
-
-      url.pathname = options.path
-    }
-
-    logger.info('first argument is a URL:', url)
 
     callback = resolveCallback(args)
   }

--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
@@ -110,10 +110,12 @@ export function normalizeClientRequestArgs(
   // and derive request options from it.
   else if (args[0] instanceof URL) {
     url = args[0]
-    logger.info('first argument is a URL:', url)
 
     options = resolveRequestOptions(args, url)
     logger.info('derived request options:', options)
+
+    url.pathname = options.path || ''
+    logger.info('first argument is a URL:', url)
 
     callback = resolveCallback(args)
   }

--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
@@ -74,10 +74,9 @@ function overrideUrlByRequestOptions(url: URL, options: RequestOptions): URL {
   url.port = options.port ? options.port.toString() : url.port
 
   if (options.path) {
-    url.pathname = options.path
-
-    const parsedPartialUrl = parseUrl(options.path)
-    url.search = parsedPartialUrl.search || ''
+    const parsedOptionsPath = parseUrl(options.path, false)
+    url.pathname = parsedOptionsPath.pathname || ''
+    url.search = parsedOptionsPath.search || ''
   }
 
   return url
@@ -138,19 +137,7 @@ export function normalizeClientRequestArgs(
     // Do this before resolving options from the URL below
     // to prevent query string from being duplicated in the path.
     if (typeof args[1] !== 'undefined' && isObject<RequestOptions>(args[1])) {
-      const explicitOptions = args[1]
-
       url = overrideUrlByRequestOptions(url, args[1])
-
-      if (explicitOptions.path != null) {
-        logger.info(
-          'found explicit "path" option ("%s"), overriding URL pathname ("%s")',
-          explicitOptions.path,
-          url.pathname
-        )
-
-        url.pathname = explicitOptions.path
-      }
     }
 
     options = resolveRequestOptions(args, url)

--- a/src/utils/isObject.ts
+++ b/src/utils/isObject.ts
@@ -1,6 +1,6 @@
 /**
  * Determines if a given value is an instance of object.
  */
-export function isObject(value: any): boolean {
+export function isObject<T>(value: any): value is T {
   return Object.prototype.toString.call(value) === '[object Object]'
 }

--- a/test/modules/http/intercept/http.request.test.ts
+++ b/test/modules/http/intercept/http.request.test.ts
@@ -230,36 +230,12 @@ it('intercepts an http.request given RequestOptions without a protocol', async (
   expect(requestId).toMatch(UUID_REGEXP)
 })
 
-it('intercepts an http.request with three argument form: URL, options, and callback', async () => {
-  const callback = vi.fn()
-  const req = http.request(
-    new URL(httpServer.http.url('/')),
-    { path: '/user?id=123' },
-    callback,
-  )
-  req.end()
-  await waitForClientRequest(req)
-
-  expect(resolver).toHaveBeenCalledTimes(1)
-
-  const [{ request, requestId }] = resolver.mock.calls[0]
-
-  expect(request.method).toBe('GET')
-  expect(request.url).toBe(httpServer.http.url('/user%3Fid=123'))
-  expect(request.credentials).toBe('same-origin')
-  expect(request.body).toBe(null)
-  expect(request.respondWith).toBeInstanceOf(Function)
-  expect(callback).toHaveBeenCalledTimes(1)
-
-  expect(requestId).toMatch(UUID_REGEXP)
-})
-
 it('intercepts an http.request path in url and options', async () => {
   const callback = vi.fn()
   const req = http.request(
     new URL(httpServer.http.url('/one')),
     { path: '/two' },
-    callback,
+    callback
   )
   req.end()
   await waitForClientRequest(req)

--- a/test/modules/http/intercept/http.request.test.ts
+++ b/test/modules/http/intercept/http.request.test.ts
@@ -254,6 +254,30 @@ it('intercepts an http.request with three argument form: URL, options, and callb
   expect(requestId).toMatch(UUID_REGEXP)
 })
 
+it('intercepts an http.request path in url and options', async () => {
+  const callback = vi.fn()
+  const req = http.request(
+    new URL(httpServer.http.url('/one')),
+    { path: '/two' },
+    callback,
+  )
+  req.end()
+  await waitForClientRequest(req)
+
+  expect(resolver).toHaveBeenCalledTimes(1)
+
+  const [{ request, requestId }] = resolver.mock.calls[0]
+
+  expect(request.method).toBe('GET')
+  expect(request.url).toBe(httpServer.http.url('/two'))
+  expect(request.credentials).toBe('same-origin')
+  expect(request.body).toBe(null)
+  expect(request.respondWith).toBeInstanceOf(Function)
+  expect(callback).toHaveBeenCalledTimes(1)
+
+  expect(requestId).toMatch(UUID_REGEXP)
+})
+
 it('intercepts an http.request with custom "auth" option', async () => {
   const auth = 'john:secret123'
   const req = http.request({

--- a/test/modules/http/intercept/http.request.test.ts
+++ b/test/modules/http/intercept/http.request.test.ts
@@ -229,3 +229,27 @@ it('intercepts an http.request given RequestOptions without a protocol', async (
 
   expect(requestId).toMatch(UUID_REGEXP)
 })
+
+it('intercepts an http.request with three argument form: URL, options, and callback', async () => {
+  const callback = vi.fn()
+  const req = http.request(
+    new URL(httpServer.http.url('/')),
+    { path: '/user?id=123' },
+    callback,
+  )
+  req.end()
+  await waitForClientRequest(req)
+
+  expect(resolver).toHaveBeenCalledTimes(1)
+
+  const [{ request, requestId }] = resolver.mock.calls[0]
+
+  expect(request.method).toBe('GET')
+  expect(request.url).toBe(httpServer.http.url('/user%3Fid=123'))
+  expect(request.credentials).toBe('same-origin')
+  expect(request.body).toBe(null)
+  expect(request.respondWith).toBeInstanceOf(Function)
+  expect(callback).toHaveBeenCalledTimes(1)
+
+  expect(requestId).toMatch(UUID_REGEXP)
+})


### PR DESCRIPTION
Currently, we ignore the path from the second argument.

@kettanaito 
When I do: 
```js
url.pathname = "/user?id=123"
```
It's automatically encodes it. Are we ok with this? see the `exepct` request.url line