### PR TITLE
fix(ClientRequest): support empty "username" and "password" basic auth values

### DIFF
--- a/src/interceptors/ClientRequest/utils/createRequest.test.ts
+++ b/src/interceptors/ClientRequest/utils/createRequest.test.ts
@@ -83,3 +83,43 @@ it('creates a fetch Request with an empty string body', async () => {
   expect(request.url).toBe('https://api.github.com/')
   expect(request.body).toBe(null)
 })
+
+it('creates a fetch Request with an empty username', async () => {
+  const clientRequest = new NodeClientRequest(
+    [
+      new URL('https://api.github.com'),
+      { auth: 'username:' },
+      () => {},
+    ],
+    {
+      emitter,
+      logger,
+    }
+  )
+  clientRequest.write('')
+
+  const request = createRequest(clientRequest)
+
+  expect(request.headers.get('Authorization')).toBe(`Basic ${btoa('username:')}`)
+  expect(request.url).toBe('https://api.github.com/')
+})
+
+it('creates a fetch Request with an empty password', async () => {
+  const clientRequest = new NodeClientRequest(
+    [
+      new URL('https://api.github.com'),
+      { auth: ':password' },
+      () => {},
+    ],
+    {
+      emitter,
+      logger,
+    }
+  )
+  clientRequest.write('')
+
+  const request = createRequest(clientRequest)
+
+  expect(request.headers.get('Authorization')).toBe(`Basic ${btoa(':password')}`)
+  expect(request.url).toBe('https://api.github.com/')
+})

--- a/src/interceptors/ClientRequest/utils/createRequest.test.ts
+++ b/src/interceptors/ClientRequest/utils/createRequest.test.ts
@@ -84,7 +84,7 @@ it('creates a fetch Request with an empty string body', async () => {
   expect(request.body).toBe(null)
 })
 
-it('creates a fetch Request with an empty username', async () => {
+it('creates a fetch Request with an empty password', async () => {
   const clientRequest = new NodeClientRequest(
     [
       new URL('https://api.github.com'),
@@ -104,7 +104,7 @@ it('creates a fetch Request with an empty username', async () => {
   expect(request.url).toBe('https://api.github.com/')
 })
 
-it('creates a fetch Request with an empty password', async () => {
+it('creates a fetch Request with an empty username', async () => {
   const clientRequest = new NodeClientRequest(
     [
       new URL('https://api.github.com'),

--- a/src/interceptors/ClientRequest/utils/createRequest.ts
+++ b/src/interceptors/ClientRequest/utils/createRequest.ts
@@ -26,7 +26,7 @@ export function createRequest(clientRequest: NodeClientRequest): Request {
    * @see https://github.com/mswjs/interceptors/issues/438
    */
   if (clientRequest.url.username || clientRequest.url.password) {
-    const auth = `${clientRequest.url.username}:${clientRequest.url.password}`
+    const auth = `${clientRequest.url.username || ''}:${clientRequest.url.password || ''}`
     headers.set('Authorization', `Basic ${btoa(auth)}`)
 
     // Remove the credentials from the URL since you cannot

--- a/src/interceptors/ClientRequest/utils/createRequest.ts
+++ b/src/interceptors/ClientRequest/utils/createRequest.ts
@@ -25,7 +25,7 @@ export function createRequest(clientRequest: NodeClientRequest): Request {
    * the request "Authorization" header.
    * @see https://github.com/mswjs/interceptors/issues/438
    */
-  if (clientRequest.url.username) {
+  if (clientRequest.url.username || clientRequest.url.password) {
     const auth = `${clientRequest.url.username}:${clientRequest.url.password}`
     headers.set('Authorization', `Basic ${btoa(auth)}`)
 

--- a/src/interceptors/ClientRequest/utils/createRequest.ts
+++ b/src/interceptors/ClientRequest/utils/createRequest.ts
@@ -25,7 +25,7 @@ export function createRequest(clientRequest: NodeClientRequest): Request {
    * the request "Authorization" header.
    * @see https://github.com/mswjs/interceptors/issues/438
    */
-  if (clientRequest.url.username && clientRequest.url.password) {
+  if (clientRequest.url.username) {
     const auth = `${clientRequest.url.username}:${clientRequest.url.password}`
     headers.set('Authorization', `Basic ${btoa(auth)}`)
 


### PR DESCRIPTION
According to [this test](https://github.com/nock/nock/blob/feaa66fa64d24f95937ef759cdd5a7ca07646f1c/tests/test_basic_auth.js#L34), passwords are not mandatory.

I couldn't find any specific spec for this, but I guess that if Nock has a test for it someone needed this.