### PR TITLE
fix(ClientRequest): support falsy request headers

### DIFF
--- a/src/interceptors/ClientRequest/utils/createRequest.test.ts
+++ b/src/interceptors/ClientRequest/utils/createRequest.test.ts
@@ -123,3 +123,22 @@ it('creates a fetch Request with an empty username', async () => {
   expect(request.headers.get('Authorization')).toBe(`Basic ${btoa(':password')}`)
   expect(request.url).toBe('https://api.github.com/')
 })
+
+it('creates a fetch Request with falsy headers', async () => {
+  const clientRequest = new NodeClientRequest(
+    [
+      new URL('https://api.github.com'),
+      { headers: { 'foo': 0, 'empty': '' }}
+    ],
+    {
+      emitter,
+      logger,
+    }
+  )
+  clientRequest.write('')
+
+  const request = createRequest(clientRequest)
+
+  expect(request.headers.get('foo')).toBe('0')
+  expect(request.headers.get('empty')).toBe('')
+})

--- a/src/interceptors/ClientRequest/utils/createRequest.ts
+++ b/src/interceptors/ClientRequest/utils/createRequest.ts
@@ -10,7 +10,7 @@ export function createRequest(clientRequest: NodeClientRequest): Request {
   for (const headerName in outgoingHeaders) {
     const headerValue = outgoingHeaders[headerName]
 
-    if (!headerValue) {
+    if (typeof headerValue === 'undefined') {
       continue
     }
 


### PR DESCRIPTION
Headers may be falsy:
![image](https://github.com/mswjs/interceptors/assets/11459632/e9f746dd-ee8c-498e-8e19-3447ebad4bd5)

Apply the same logic as in [`createResponse`](https://github.com/mswjs/interceptors/blob/main/src/interceptors/ClientRequest/utils/createResponse.ts#L41)