### PR TITLE
fix(ClientRequest): suppress "ENETUNREACH" socket error

### DIFF
--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -37,6 +37,7 @@ export class NodeClientRequest extends ClientRequest {
     'ECONNREFUSED',
     'ECONNRESET',
     'EAI_AGAIN',
+    'ENETUNREACH',
   ]
 
   private response: IncomingMessage


### PR DESCRIPTION
I didn't add a test because we already tested this logic in the following:
1. emits the ENOTFOUND error connecting to a non-existing hostname given no mocked response
2. emits the ECONNREFUSED error connecting to an inactive server given no mocked response

closes #451