### PR TITLE
fix(ClientRequest): preserve headers casing on mocked responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18.8.0]
+        node: [18.14.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/src/interceptors/ClientRequest/NodeClientRequest.test.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.test.ts
@@ -315,36 +315,3 @@ it('does not send request body to the original server given mocked response', as
   const text = await getIncomingMessageBody(response)
   expect(text).toBe('mock created!')
 })
-
-it('preserves the original mocked response headers casing in "rawHeaders"', async () => {
-  const emitter = new Emitter<HttpRequestEventMap>()
-  const request = new NodeClientRequest(
-    normalizeClientRequestArgs('http:', 'http://any.thing'),
-    {
-      emitter,
-      logger,
-    }
-  )
-
-  emitter.on('request', ({ request }) => {
-    request.respondWith(
-      new Response(null, {
-        headers: {
-          'X-CustoM-HeadeR': 'Yes',
-        },
-      })
-    )
-  })
-
-  request.end()
-
-  const responseReceived = new DeferredPromise<IncomingMessage>()
-
-  request.on('response', async (response) => {
-    responseReceived.resolve(response)
-  })
-  const response = await responseReceived
-
-  expect(response.rawHeaders).toStrictEqual(['X-CustoM-HeadeR', 'Yes'])
-  expect(response.headers).toStrictEqual({ 'x-custom-header': 'Yes' })
-})

--- a/src/interceptors/ClientRequest/NodeClientRequest.test.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.test.ts
@@ -316,7 +316,7 @@ it('does not send request body to the original server given mocked response', as
   expect(text).toBe('mock created!')
 })
 
-it.only('does not lowercase the rawHeaders', async () => {
+it('does not lowercase the rawHeaders', async () => {
   const emitter = new Emitter<HttpRequestEventMap>()
   const request = new NodeClientRequest(
     normalizeClientRequestArgs('http:', 'http://any.thing'),

--- a/src/interceptors/ClientRequest/NodeClientRequest.test.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.test.ts
@@ -316,7 +316,7 @@ it('does not send request body to the original server given mocked response', as
   expect(text).toBe('mock created!')
 })
 
-it('does not lowercase the rawHeaders', async () => {
+it('preserves the original mocked response headers casing in "rawHeaders"', async () => {
   const emitter = new Emitter<HttpRequestEventMap>()
   const request = new NodeClientRequest(
     normalizeClientRequestArgs('http:', 'http://any.thing'),
@@ -330,7 +330,7 @@ it('does not lowercase the rawHeaders', async () => {
     request.respondWith(
       new Response(null, {
         headers: {
-          'X-Custom-Header': 'Yes',
+          'X-CustoM-HeadeR': 'Yes',
         },
       })
     )
@@ -345,6 +345,6 @@ it('does not lowercase the rawHeaders', async () => {
   })
   const response = await responseReceived
 
-  expect(response.rawHeaders).toStrictEqual([ 'X-Custom-Header', 'Yes' ])
+  expect(response.rawHeaders).toStrictEqual(['X-CustoM-HeadeR', 'Yes'])
   expect(response.headers).toStrictEqual({ 'x-custom-header': 'Yes' })
 })

--- a/src/interceptors/ClientRequest/NodeClientRequest.test.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.test.ts
@@ -316,7 +316,7 @@ it('does not send request body to the original server given mocked response', as
   expect(text).toBe('mock created!')
 })
 
-it.only('sets the correct rawHeaders', async () => {
+it.only('does not lowercase the rawHeaders', async () => {
   const emitter = new Emitter<HttpRequestEventMap>()
   const request = new NodeClientRequest(
     normalizeClientRequestArgs('http:', 'http://any.thing'),

--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -19,6 +19,7 @@ import { createRequest } from './utils/createRequest'
 import { toInteractiveRequest } from '../../utils/toInteractiveRequest'
 import { uuidv4 } from '../../utils/uuid'
 import { emitAsync } from '../../utils/emitAsync'
+import { getRawFetchHeaders } from '../../utils/getRawFetchHeaders'
 
 export type Protocol = 'http' | 'https'
 
@@ -448,10 +449,14 @@ export class NodeClientRequest extends ClientRequest {
     this.response.statusCode = status
     this.response.statusMessage = statusText
 
-    if (headers) {
+    // Try extracting the raw headers from the headers instance.
+    // If not possible, fallback to the headers instance as-is.
+    const rawHeaders = getRawFetchHeaders(headers) || headers
+
+    if (rawHeaders) {
       this.response.headers = {}
 
-      headers.forEach((headerValue, headerName) => {
+      rawHeaders.forEach((headerValue, headerName) => {
         /**
          * @note Make sure that multi-value headers are appended correctly.
          */

--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -20,10 +20,6 @@ import { toInteractiveRequest } from '../../utils/toInteractiveRequest'
 import { uuidv4 } from '../../utils/uuid'
 import { emitAsync } from '../../utils/emitAsync'
 
-const kHeadersList = Object.getOwnPropertySymbols(new Headers()).find(
-    (s) => s.description === "headers list"
-);
-
 export type Protocol = 'http' | 'https'
 
 export interface NodeClientOptions {
@@ -455,7 +451,7 @@ export class NodeClientRequest extends ClientRequest {
     if (headers) {
       this.response.headers = {}
 
-      Object.entries(headers[kHeadersList].entries).forEach(([headerName, headerValue]) => {
+      headers.forEach((headerValue, headerName) => {
         /**
          * @note Make sure that multi-value headers are appended correctly.
          */

--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -20,6 +20,10 @@ import { toInteractiveRequest } from '../../utils/toInteractiveRequest'
 import { uuidv4 } from '../../utils/uuid'
 import { emitAsync } from '../../utils/emitAsync'
 
+const kHeadersList = Object.getOwnPropertySymbols(new Headers()).find(
+    (s) => s.description === "headers list"
+);
+
 export type Protocol = 'http' | 'https'
 
 export interface NodeClientOptions {
@@ -451,7 +455,7 @@ export class NodeClientRequest extends ClientRequest {
     if (headers) {
       this.response.headers = {}
 
-      headers.forEach((headerValue, headerName) => {
+      Object.entries(headers[kHeadersList].entries).forEach(([headerName, headerValue]) => {
         /**
          * @note Make sure that multi-value headers are appended correctly.
          */

--- a/src/utils/getRawFetchHeaders.test.ts
+++ b/src/utils/getRawFetchHeaders.test.ts
@@ -9,6 +9,17 @@ it('returns an empty Map given an empty Headers instance', () => {
   expect(getRawFetchHeaders(new Headers())).toEqual(new Map())
 })
 
+it('returns undefined for headers map on older Node.js versions', () => {
+  // Emulate the Headers symbol structure on older
+  // versions of Node.js (e.g. 18.8.0).
+  const headers = {
+    [Symbol('headers list')]: {
+      [Symbol('headers map')]: new Map([['header-name', 'header-value']]),
+    },
+  }
+  expect(getRawFetchHeaders(headers as unknown as Headers)).toBeUndefined()
+})
+
 it('returns raw headers from the given Headers instance', () => {
   expect(
     getRawFetchHeaders(

--- a/src/utils/getRawFetchHeaders.test.ts
+++ b/src/utils/getRawFetchHeaders.test.ts
@@ -1,0 +1,28 @@
+import { it, expect } from 'vitest'
+import { getRawFetchHeaders } from './getRawFetchHeaders'
+
+it('returns undefined given a non-Headers object', () => {
+  expect(getRawFetchHeaders({} as Headers)).toBeUndefined()
+})
+
+it('returns an empty Map given an empty Headers instance', () => {
+  expect(getRawFetchHeaders(new Headers())).toEqual(new Map())
+})
+
+it('returns raw headers from the given Headers instance', () => {
+  expect(
+    getRawFetchHeaders(
+      new Headers([
+        ['lowercase-header', 'one'],
+        ['UPPERCASE-HEADER', 'TWO'],
+        ['MiXeD-cAsE-hEaDeR', 'ThReE'],
+      ])
+    )
+  ).toEqual(
+    new Map([
+      ['lowercase-header', 'one'],
+      ['UPPERCASE-HEADER', 'TWO'],
+      ['MiXeD-cAsE-hEaDeR', 'ThReE'],
+    ])
+  )
+})

--- a/src/utils/getRawFetchHeaders.test.ts
+++ b/src/utils/getRawFetchHeaders.test.ts
@@ -37,3 +37,14 @@ it('returns raw headers from the given Headers instance', () => {
     ])
   )
 })
+
+it('returns raw headers for a header with multiple values', () => {
+  expect(
+    getRawFetchHeaders(
+      new Headers([
+        ['Set-CookiE', 'a=b'],
+        ['Set-CookiE', 'c=d'],
+      ])
+    )
+  ).toEqual(new Map([['Set-CookiE', 'a=b, c=d']]))
+})

--- a/src/utils/getRawFetchHeaders.ts
+++ b/src/utils/getRawFetchHeaders.ts
@@ -16,6 +16,9 @@ export function getRawFetchHeaders(
 ): RawHeadersMap | undefined {
   const headersList = getValueBySymbol<object>('headers list', headers)
 
+  console.log('\n\n----')
+  console.log({ headersList })
+
   if (!headersList) {
     return
   }
@@ -23,6 +26,8 @@ export function getRawFetchHeaders(
   const headersMap = getValueBySymbol<
     Map<string, { name: string; value: string }>
   >('headers map', headersList)
+
+  console.log({ headersList })
 
   if (!headersMap) {
     return
@@ -33,6 +38,8 @@ export function getRawFetchHeaders(
   headersMap?.forEach(({ name, value }) => {
     rawHeaders.set(name, value)
   })
+
+  console.log({ rawHeaders })
 
   return rawHeaders
 }

--- a/src/utils/getRawFetchHeaders.ts
+++ b/src/utils/getRawFetchHeaders.ts
@@ -1,0 +1,38 @@
+import { getValueBySymbol } from './getValueBySymbol'
+
+type RawHeadersMap = Map<string, string>
+
+/**
+ * Returns raw headers from the given `Headers` instance.
+ * @example
+ * const headers = new Headers([
+ *   ['X-HeadeR-NamE', 'Value']
+ * ])
+ * getRawFetchHeaders(headers)
+ * // { 'X-HeadeR-NamE': 'Value' }
+ */
+export function getRawFetchHeaders(
+  headers: Headers
+): RawHeadersMap | undefined {
+  const headersList = getValueBySymbol<object>('headers list', headers)
+
+  if (!headersList) {
+    return
+  }
+
+  const headersMap = getValueBySymbol<
+    Map<string, { name: string; value: string }>
+  >('headers map', headersList)
+
+  if (!headersMap) {
+    return
+  }
+
+  const rawHeaders: RawHeadersMap = new Map()
+
+  headersMap?.forEach(({ name, value }) => {
+    rawHeaders.set(name, value)
+  })
+
+  return rawHeaders
+}

--- a/src/utils/getValueBySymbol.test.ts
+++ b/src/utils/getValueBySymbol.test.ts
@@ -1,0 +1,14 @@
+import { it, expect } from 'vitest'
+import { getValueBySymbol } from './getValueBySymbol'
+
+it('returns undefined given a non-existing symbol', () => {
+  expect(getValueBySymbol('non-existing', {})).toBeUndefined()
+})
+
+it('returns value behind the given symbol', () => {
+  const symbol = Symbol('kInternal')
+
+  expect(getValueBySymbol('kInternal', { [symbol]: null })).toBe(null)
+  expect(getValueBySymbol('kInternal', { [symbol]: true })).toBe(true)
+  expect(getValueBySymbol('kInternal', { [symbol]: 'value' })).toBe('value')
+})

--- a/src/utils/getValueBySymbol.ts
+++ b/src/utils/getValueBySymbol.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns the value behind the symbol with the given name.
+ */
+export function getValueBySymbol<T>(
+  symbolName: string,
+  source: object
+): T | undefined {
+  const ownSymbols = Object.getOwnPropertySymbols(source)
+
+  const symbol = ownSymbols.find((symbol) => {
+    return symbol.description === symbolName
+  })
+
+  if (symbol) {
+    return Reflect.get(source, symbol)
+  }
+
+  return
+}

--- a/test/modules/http/compliance/http-res-raw-headers.test.ts
+++ b/test/modules/http/compliance/http-res-raw-headers.test.ts
@@ -1,0 +1,32 @@
+import { it, expect, beforeAll, afterAll } from 'vitest'
+import http from 'http'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+import { waitForClientRequest } from '../../../helpers'
+
+const interceptor = new ClientRequestInterceptor()
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+})
+
+it('preserves the original mocked response headers casing in "rawHeaders"', async () => {
+  interceptor.once('request', ({ request }) => {
+    request.respondWith(
+      new Response(null, {
+        headers: {
+          'X-CustoM-HeadeR': 'Yes',
+        },
+      })
+    )
+  })
+
+  const request = http.get('http://any.thing')
+  const { res } = await waitForClientRequest(request)
+
+  expect(res.rawHeaders).toStrictEqual(['X-CustoM-HeadeR', 'Yes'])
+  expect(res.headers).toStrictEqual({ 'x-custom-header': 'Yes' })
+})


### PR DESCRIPTION
There are a few typing issues, but I would like to hear what you think about this solution first.
Do you know how can we find the Symbol more elegantly? I'm not very familiar with Symbols and `Symbol.for('headers list')` returns `undefined`

closes #448 

----

Some thoughts:

1. While this solution probably will work for good, it relies on an "unofficial" behavior of Node.
2. Perhaps we could add a function that allows users to set the 'rawHeaders', although it may be a bit clumsy.
3. We can also solve it from Nock's side by sending a tempered version of the `Response` object which does not return lowercase headers. but IMO the solution should be in this lib.