### PR TITLE
fix(ClientRequest): suppress the "EHOSTUNREACH" connection error

### DIFF
--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -39,6 +39,7 @@ export class NodeClientRequest extends ClientRequest {
     'ECONNRESET',
     'EAI_AGAIN',
     'ENETUNREACH',
+    'EHOSTUNREACH',
   ]
 
   private response: IncomingMessage


### PR DESCRIPTION
- Related to #454 

When testing on Node.js 18.14.2, I get a different error from the `ENETUNREACH` test case:

```
[Error: connect EHOSTUNREACH 2607:f0d0:1002:51::4:80 - Local (:::59828)]
```

This may be related to different versions of Node.js. I'm adding the `EHOSTUNREACH` error to the list of suppressed errors as well. 