### PR TITLE
fix(ClientRequest): support "http.request()" and "http.get()" without any arguments

### DIFF
--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
@@ -23,6 +23,8 @@ const logger = new Logger('http normalizeClientRequestArgs')
 export type HttpRequestCallback = (response: IncomingMessage) => void
 
 export type ClientRequestArgs =
+  // Request without any arguments is also possible.
+  | []
   | [string | URL | LegacyURL, HttpRequestCallback?]
   | [string | URL | LegacyURL, RequestOptions, HttpRequestCallback?]
   | [RequestOptions, HttpRequestCallback?]
@@ -108,6 +110,14 @@ export function normalizeClientRequestArgs(
 
   logger.info('arguments', args)
   logger.info('using default protocol:', defaultProtocol)
+
+  // Support "http.request()" calls without any arguments.
+  // That call results in a "GET http://localhost" request.
+  if (args.length === 0) {
+    const url = new URL('http://localhost')
+    const options = resolveRequestOptions(args, url)
+    return [url, options]
+  }
 
   // Convert a url string into a URL instance
   // and derive request options from it.

--- a/test/modules/http/compliance/http-request-without-options.test.ts
+++ b/test/modules/http/compliance/http-request-without-options.test.ts
@@ -1,0 +1,102 @@
+import { vi, it, expect, beforeAll, afterAll } from 'vitest'
+import http from 'http'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+import { waitForClientRequest } from '../../../helpers'
+
+const interceptor = new ClientRequestInterceptor()
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+})
+
+it('supports "http.request()" without any options', async () => {
+  const responseListener = vi.fn()
+  const errorListener = vi.fn()
+
+  const request = http
+    // @ts-ignore It's possible to make a request without any options.
+    // This will result in a "GET http://localhost" request in Node.js.
+    .request()
+  request.end()
+  request.on('response', responseListener)
+  request.on('error', errorListener)
+
+  expect(errorListener).not.toHaveBeenCalled()
+  expect(responseListener).not.toHaveBeenCalled()
+  expect(request.path).toBe('/')
+  expect(request.method).toBe('GET')
+  expect(request.protocol).toBe('http:')
+  expect(request.host).toBe('localhost')
+})
+
+it('responds with a mocked response for "http.request()" without any options', async () => {
+  interceptor.once('request', ({ request }) => {
+    if (request.url === 'http://localhost/') {
+      request.respondWith(new Response('Mocked'))
+    }
+  })
+
+  const request = http
+    // @ts-ignore It's possible to make a request without any options.
+    // This will result in a "GET http://localhost" request in Node.js.
+    .request()
+  request.end()
+
+  const errorListener = vi.fn()
+  request.on('error', errorListener)
+
+  const { res, text } = await waitForClientRequest(request)
+
+  expect(errorListener).not.toHaveBeenCalled()
+
+  expect(res.statusCode).toBe(200)
+  expect(await text()).toBe('Mocked')
+})
+
+it('supports "http.get()" without any argumenst', async () => {
+  const responseListener = vi.fn()
+  const errorListener = vi.fn()
+
+  const request = http
+    // @ts-ignore It's possible to make a request without any options.
+    // This will result in a "GET http://localhost" request in Node.js.
+    .get()
+  request.end()
+  request.on('response', responseListener)
+  request.on('error', errorListener)
+
+  expect(errorListener).not.toHaveBeenCalled()
+  expect(responseListener).not.toHaveBeenCalled()
+  expect(request.path).toBe('/')
+  expect(request.method).toBe('GET')
+  expect(request.protocol).toBe('http:')
+  expect(request.host).toBe('localhost')
+})
+
+it('responds with a mocked response for "http.get()" without any options', async () => {
+  interceptor.once('request', ({ request }) => {
+    if (request.url === 'http://localhost/') {
+      request.respondWith(new Response('Mocked'))
+    }
+  })
+
+  const request = http
+    // @ts-ignore It's possible to make a request without any options.
+    // This will result in a "GET http://localhost" request in Node.js.
+    .get()
+  request.end()
+
+  const errorListener = vi.fn()
+  request.on('error', errorListener)
+
+  const { res, text } = await waitForClientRequest(request)
+
+  expect(errorListener).not.toHaveBeenCalled()
+
+  expect(res.statusCode).toBe(200)
+  expect(await text()).toBe('Mocked')
+})


### PR DESCRIPTION
- Fixes #461