### PR TITLE
chore(release): use node v18.14.x for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.8.0
+          node-version: 18.14
           always-auth: true
           registry-url: https://registry.npmjs.org
 


### PR DESCRIPTION
Addresses [failing release pipeline](https://github.com/mswjs/interceptors/actions/runs/6444001793) due to Node version-specific `Headers` tests. 