### PR TITLE
fix(XMLHttpRequest): prevent invalid listener name access

### DIFF
--- a/src/Interceptor.ts
+++ b/src/Interceptor.ts
@@ -149,7 +149,7 @@ export class Interceptor<Events extends InterceptorEventMap> {
       return this
     }
 
-    logger.info('adding "%s" event listener:', event, listener?.name)
+    logger.info('adding "%s" event listener:', event, listener)
 
     this.emitter.on(event, listener)
     return this

--- a/src/Interceptor.ts
+++ b/src/Interceptor.ts
@@ -149,7 +149,7 @@ export class Interceptor<Events extends InterceptorEventMap> {
       return this
     }
 
-    logger.info('adding "%s" event listener:', event, listener.name)
+    logger.info('adding "%s" event listener:', event, listener?.name)
 
     this.emitter.on(event, listener)
     return this

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -103,7 +103,7 @@ export class XMLHttpRequestController {
             ]
 
             this.registerEvent(eventName, listener)
-            this.logger.info('addEventListener', eventName, listener?.name)
+            this.logger.info('addEventListener', eventName, listener)
 
             return invoke()
           }
@@ -206,7 +206,7 @@ export class XMLHttpRequestController {
     const nextEvents = prevEvents.concat(listener)
     this.events.set(eventName, nextEvents)
 
-    this.logger.info('registered event "%s"', eventName, listener?.name)
+    this.logger.info('registered event "%s"', eventName, listener)
   }
 
   /**

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -103,7 +103,7 @@ export class XMLHttpRequestController {
             ]
 
             this.registerEvent(eventName, listener)
-            this.logger.info('addEventListener', eventName, listener.name)
+            this.logger.info('addEventListener', eventName, listener?.name)
 
             return invoke()
           }
@@ -206,7 +206,7 @@ export class XMLHttpRequestController {
     const nextEvents = prevEvents.concat(listener)
     this.events.set(eventName, nextEvents)
 
-    this.logger.info('registered event "%s"', eventName, listener.name)
+    this.logger.info('registered event "%s"', eventName, listener?.name)
   }
 
   /**

--- a/test/modules/XMLHttpRequest/compliance/xhr-event-callback-null.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-event-callback-null.test.ts
@@ -2,7 +2,7 @@
  * @note https://xhr.spec.whatwg.org/#event-handlers
  */
 // @vitest-environment jsdom
-import { vi, it, expect, beforeAll, afterAll } from 'vitest'
+import { it, expect, beforeAll, afterAll } from 'vitest'
 import { HttpServer } from '@open-draft/test-server/http'
 import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
 import { createXMLHttpRequest } from '../../../helpers'

--- a/test/modules/XMLHttpRequest/compliance/xhr-event-callback-null.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-event-callback-null.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @note https://xhr.spec.whatwg.org/#event-handlers
+ */
+// @vitest-environment jsdom
+import { vi, it, expect, beforeAll, afterAll } from 'vitest'
+import { HttpServer } from '@open-draft/test-server/http'
+import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
+import { createXMLHttpRequest } from '../../../helpers'
+
+const interceptor = new XMLHttpRequestInterceptor()
+
+const httpServer = new HttpServer((app) => {
+  app.get('/resource', (req, res) => {
+    res.send('hello')
+  })
+  app.get('/error', (req, res) => {
+    res.status(500).send('Internal Server Error')
+  })
+  app.get('/exception', (req, res) => {
+    throw new Error('Server error')
+  })
+})
+
+beforeAll(async () => {
+  interceptor.apply()
+  interceptor.on('request', ({ request }) => {
+    switch (true) {
+      case request.url.endsWith('/exception'): {
+        throw new Error('Network error')
+      }
+
+      case request.url.endsWith('/error'): {
+        return request.respondWith(
+          new Response('Internal Server Error', { status: 500 })
+        )
+      }
+
+      default:
+        return request.respondWith(new Response('hello'))
+    }
+  })
+
+  await httpServer.listen()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+  await httpServer.close()
+})
+
+it.each<[name: string, getUrl: () => string]>([
+  ['passthrough', () => httpServer.https.url('/resource')],
+  ['mocked', () => 'http://localhost/resource'],
+])(
+  `does not fail when unsetting event handlers for a successful %s response`,
+  async (_, getUrl) => {
+    const url = getUrl()
+
+    const request = await createXMLHttpRequest((request) => {
+      request.open('GET', url)
+
+      request.onreadystatechange = null
+      request.onloadstart = null
+      request.onprogress = null
+      request.onload = null
+      request.onloadend = null
+      request.ontimeout = null
+
+      request.send()
+    })
+
+    expect(request.readyState).toBe(4)
+    expect(request.status).toBe(200)
+    expect(request.responseText).toBe('hello')
+  }
+)
+
+it.each<[name: string, getUrl: () => string]>([
+  ['passthrough', () => httpServer.https.url('/error')],
+  ['mocked', () => 'http://localhost/error'],
+])(
+  `does not fail when unsetting event handlers for a %s error response`,
+  async (_, getUrl) => {
+    const url = getUrl()
+
+    const request = await createXMLHttpRequest((request) => {
+      request.open('GET', url)
+
+      request.onreadystatechange = null
+      request.onloadstart = null
+      request.onprogress = null
+      request.onload = null
+      request.onloadend = null
+      request.ontimeout = null
+
+      request.send()
+    })
+
+    expect(request.readyState).toBe(4)
+    expect(request.status).toBe(500)
+    expect(request.responseText).toBe('Internal Server Error')
+  }
+)
+
+it.each<[name: string, getUrl: () => string]>([
+  ['passthrough', () => httpServer.https.url('/exception')],
+  ['mocked', () => 'http://localhost/exception'],
+])(
+  `does not fail when unsetting event handlers for a %s request error`,
+  async (_, getUrl) => {
+    const url = getUrl()
+
+    const request = await createXMLHttpRequest((request) => {
+      request.open('GET', url)
+
+      request.onreadystatechange = null
+      request.onloadstart = null
+      request.onprogress = null
+      request.onload = null
+      request.onloadend = null
+      request.ontimeout = null
+
+      request.send()
+    })
+
+    expect(request.readyState).toBe(4)
+    expect(request.status).toBe(0)
+    expect(request.responseText).toBe('')
+  }
+)


### PR DESCRIPTION
When a XMLHttpRequest event handler is reset by setting it to `null`, an error will be thrown, that @mswjs/interceptors cannot access the property `name` on `null`. Here is an example of that error:

```ts
const req = new XMLHttpRequest()
req.onload = function() { console.log(`Responded with status %i`, this.status) }
req.ontimeout = null
req.open("GET", "http://localhost:7003/test/status/200")
req.send()
```

This PR prevents the error by not accessing the `name` property if the listener is `undefined | null`;

Do you think it needs tests, or is it fine as-is?