### PR TITLE
fix(xhr): allow setters for non-existing properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@types/node": "^16.11.26",
     "@types/node-fetch": "2.5.12",
     "@types/supertest": "^2.0.11",
-    "axios": "^0.24.0",
+    "axios": "^1.6.0",
     "body-parser": "^1.19.0",
     "commitizen": "^4.2.4",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "express-rate-limit": "^6.3.0",
     "follow-redirects": "^1.15.1",
     "got": "^11.8.3",
+    "happy-dom": "^12.10.3",
     "jest": "^27.4.3",
     "node-fetch": "2.6.7",
     "rimraf": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ specifiers:
   '@types/node': ^16.11.26
   '@types/node-fetch': 2.5.12
   '@types/supertest': ^2.0.11
-  axios: ^0.24.0
+  axios: ^1.6.0
   body-parser: ^1.19.0
   commitizen: ^4.2.4
   cors: ^2.8.5
@@ -69,7 +69,7 @@ devDependencies:
   '@types/node': 16.18.46
   '@types/node-fetch': 2.5.12
   '@types/supertest': 2.0.12
-  axios: 0.24.0
+  axios: 1.6.0
   body-parser: 1.20.2
   commitizen: 4.3.0
   cors: 2.8.5
@@ -2110,10 +2110,12 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /axios/0.24.0:
-    resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
+  /axios/1.6.0:
+    resolution: {integrity: sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==}
     dependencies:
       follow-redirects: 1.15.2
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
     dev: true
@@ -5379,6 +5381,10 @@ packages:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+    dev: true
+
+  /proxy-from-env/1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
     dev: true
 
   /psl/1.9.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ specifiers:
   express-rate-limit: ^6.3.0
   follow-redirects: ^1.15.1
   got: ^11.8.3
+  happy-dom: ^12.10.3
   is-node-process: ^1.2.0
   jest: ^27.4.3
   node-fetch: 2.6.7
@@ -79,6 +80,7 @@ devDependencies:
   express-rate-limit: 6.9.0_express@4.18.2
   follow-redirects: 1.15.2
   got: 11.8.6
+  happy-dom: 12.10.3
   jest: 27.5.1
   node-fetch: 2.6.7
   rimraf: 3.0.2
@@ -88,7 +90,7 @@ devDependencies:
   ts-jest: 27.1.5_n4jzo3ixy42kfaqevs43wjx5ui
   tsup: 6.7.0_typescript@4.9.5
   typescript: 4.9.5
-  vitest: 0.28.5
+  vitest: 0.28.5_happy-dom@12.10.3
   wait-for-expect: 3.0.2
   web-encoding: 1.1.5
   webpack-http-server: 0.5.0
@@ -2764,6 +2766,10 @@ packages:
       which: 2.0.2
     dev: true
 
+  /css.escape/1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+    dev: true
+
   /cssom/0.3.8:
     resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
     dev: true
@@ -3048,6 +3054,11 @@ packages:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+    dev: true
+
+  /entities/4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
     dev: true
 
   /error-ex/1.3.2:
@@ -3669,6 +3680,17 @@ packages:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: true
 
+  /happy-dom/12.10.3:
+    resolution: {integrity: sha512-JzUXOh0wdNGY54oKng5hliuBkq/+aT1V3YpTM+lrN/GoLQTANZsMaIvmHiHe612rauHvPJnDZkZ+5GZR++1Abg==}
+    dependencies:
+      css.escape: 1.5.1
+      entities: 4.5.0
+      iconv-lite: 0.6.3
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+    dev: true
+
   /hard-rejection/2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
@@ -3793,6 +3815,13 @@ packages:
 
   /iconv-lite/0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: true
+
+  /iconv-lite/0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
@@ -6689,7 +6718,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest/0.28.5:
+  /vitest/0.28.5_happy-dom@12.10.3:
     resolution: {integrity: sha512-pyCQ+wcAOX7mKMcBNkzDwEHRGqQvHUl0XnoHR+3Pb1hytAHISgSxv9h0gUiSiYtISXUU3rMrKiKzFYDrI6ZIHA==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
@@ -6723,6 +6752,7 @@ packages:
       cac: 6.7.14
       chai: 4.3.8
       debug: 4.3.4
+      happy-dom: 12.10.3
       local-pkg: 0.4.3
       pathe: 1.1.1
       picocolors: 1.0.0
@@ -6809,6 +6839,11 @@ packages:
     engines: {node: '>=10.4'}
     dev: true
 
+  /webidl-conversions/7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+    dev: true
+
   /webpack-http-server/0.5.0:
     resolution: {integrity: sha512-kyewxAnzmDuZxe09fn/Bb0PeEnaDxHChYKFVsMy4oeBUs9Cyv2j1uEgzQJ7ljPFexLU8ongUS4i4O+e22CeBZQ==}
     dependencies:
@@ -6878,8 +6913,20 @@ packages:
       iconv-lite: 0.4.24
     dev: true
 
+  /whatwg-encoding/2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: true
+
   /whatwg-mimetype/2.3.0:
     resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
+    dev: true
+
+  /whatwg-mimetype/3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
     dev: true
 
   /whatwg-url/5.0.0:

--- a/src/utils/createProxy.ts
+++ b/src/utils/createProxy.ts
@@ -44,21 +44,21 @@ function optionsToProxyHandler<T extends Record<string, any>>(
     }
   }
 
-  handler.set = function (target, propertyName, nextValue, receiver) {
+  handler.set = function (target, propertyName, nextValue) {
     const next = () => {
-      const propertySource = findPropertySource(target, propertyName)
-      if (propertySource === null) return false
-
+      const propertySource = findPropertySource(target, propertyName) || target
       const ownDescriptors = Reflect.getOwnPropertyDescriptor(
         propertySource,
         propertyName
       )
 
+      // Respect any custom setters present for this property.
       if (typeof ownDescriptors?.set !== 'undefined') {
         ownDescriptors.set.apply(target, [nextValue])
         return true
       }
 
+      // Otherwise, set the property on the source.
       return Reflect.defineProperty(propertySource, propertyName, {
         writable: true,
         enumerable: true,

--- a/test/modules/XMLHttpRequest/regressions/xhr-axios-xhr-adapter.test.ts
+++ b/test/modules/XMLHttpRequest/regressions/xhr-axios-xhr-adapter.test.ts
@@ -1,5 +1,6 @@
 /**
- * @vitest-environment jsdom
+ * @vitest-environment happy-dom
+ * @note This issue is only reproducible in "happy-dom".
  * @see https://github.com/mswjs/msw/issues/1816
  */
 import { beforeAll, afterAll, it, expect } from 'vitest'

--- a/test/modules/XMLHttpRequest/regressions/xhr-axios-xhr-adapter.test.ts
+++ b/test/modules/XMLHttpRequest/regressions/xhr-axios-xhr-adapter.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @vitest-environment jsdom
+ * @see https://github.com/mswjs/msw/issues/1816
+ */
+import { beforeAll, afterAll, it, expect } from 'vitest'
+import axios from 'axios'
+import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
+
+const request = axios.create({
+  baseURL: 'http://localhost',
+  adapter: 'xhr',
+})
+
+const interceptor = new XMLHttpRequestInterceptor()
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+})
+
+it('performs a request with the "xhr" axios adapter', async () => {
+  interceptor.once('request', ({ request }) => {
+    request.respondWith(new Response('Hello world'))
+  })
+
+  const res = await request('/resource')
+  expect(res.status).toBe(200)
+  expect(res.data).toBe('Hello world')
+})


### PR DESCRIPTION
- Fixes https://github.com/mswjs/msw/issues/1816

## Investigation

This issue is caused by the Axios XHR adapter in Happy DOM only. Axios does:

```js
request.timeout = config.timeout
```

Where `request` is already a proxy established by Interceptors. It looks up the `setProperty` trap on the proxy and since `timeout` doesn't have a special case, it defaults to `invoke()`. 

Calling `invoke()` to set `timeout` on XMLHttpRequest proxy _returns false_ because property `timeout` does not exist on `target`:

https://github.com/mswjs/interceptors/blob/1f04d100bad190a393a5855fc6cc3a54f6117dfb/src/utils/findPropertySource.ts#L9-L11

The `timeout` property is not mandatory on XMLHttpRequest, so it's missing from the immediate XHR instance as well as its prototype. We return false from the setter and that causes the following error:

```
TypeError: 'set' on proxy: trap returned falsish for property 'timeout'
```

## Solution

I think us forbidding setters on unknown properties is a mistake. To fix this, I'm adding a fallback to `propertySource` to be the immediate `target` itself is `findPropertySource` returned `null`. 