### PR TITLE
feat: intercept WebSocket in the browser

### DIFF
--- a/WebSocket/package.json
+++ b/WebSocket/package.json
@@ -1,0 +1,5 @@
+{
+  "browser": "../lib/browser/interceptors/WebSocket/index.js",
+  "module": "../lib/browser/interceptors/WebSocket/index.mjs",
+  "types": "../lib/browser/interceptors/WebSocket/index.d.ts"
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,15 @@
       "import": "./lib/node/interceptors/fetch/index.mjs",
       "default": "./lib/node/interceptors/fetch/index.js"
     },
+    "./WebSocket": {
+      "node": null,
+      "browser": {
+        "types": "./lib/browser/interceptors/WebSocket/index.d.ts",
+        "require": "./lib/browser/interceptors/WebSocket/index.js",
+        "import": "./lib/browser/interceptors/WebSocket/index.mjs",
+        "default": "./lib/browser/interceptors/WebSocket/index.js"
+      }
+    },
     "./RemoteHttpInterceptor": {
       "browser": null,
       "types": "./lib/node/RemoteHttpInterceptor.d.ts",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   "devDependencies": {
     "@commitlint/cli": "^16.0.2",
     "@commitlint/config-conventional": "^16.0.0",
-    "@open-draft/test-server": "^0.5.1",
+    "@open-draft/test-server": "^0.6.1",
     "@ossjs/release": "^0.7.2",
     "@playwright/test": "^1.37.1",
     "@types/cors": "^2.8.12",
@@ -120,6 +120,7 @@
     "@types/node": "^16.11.26",
     "@types/node-fetch": "2.5.12",
     "@types/supertest": "^2.0.11",
+    "@types/ws": "^8.5.9",
     "axios": "^1.6.0",
     "body-parser": "^1.19.0",
     "commitizen": "^4.2.4",
@@ -144,7 +145,9 @@
     "vitest-environment-miniflare": "^2.14.1",
     "wait-for-expect": "^3.0.2",
     "web-encoding": "^1.1.5",
-    "webpack-http-server": "^0.5.0"
+    "webpack": "5.88.2",
+    "webpack-http-server": "^0.5.0",
+    "ws": "^8.14.2"
   },
   "dependencies": {
     "@open-draft/deferred-promise": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ specifiers:
   '@commitlint/config-conventional': ^16.0.0
   '@open-draft/deferred-promise': ^2.2.0
   '@open-draft/logger': ^0.3.0
-  '@open-draft/test-server': ^0.5.1
+  '@open-draft/test-server': ^0.6.1
   '@open-draft/until': ^2.0.0
   '@ossjs/release': ^0.7.2
   '@playwright/test': ^1.37.1
@@ -20,6 +20,7 @@ specifiers:
   '@types/node': ^16.11.26
   '@types/node-fetch': 2.5.12
   '@types/supertest': ^2.0.11
+  '@types/ws': ^8.5.9
   axios: ^1.6.0
   body-parser: ^1.19.0
   commitizen: ^4.2.4
@@ -47,7 +48,9 @@ specifiers:
   vitest-environment-miniflare: ^2.14.1
   wait-for-expect: ^3.0.2
   web-encoding: ^1.1.5
+  webpack: 5.88.2
   webpack-http-server: ^0.5.0
+  ws: ^8.14.2
 
 dependencies:
   '@open-draft/deferred-promise': 2.2.0
@@ -60,7 +63,7 @@ dependencies:
 devDependencies:
   '@commitlint/cli': 16.3.0
   '@commitlint/config-conventional': 16.2.4
-  '@open-draft/test-server': 0.5.1
+  '@open-draft/test-server': 0.6.1
   '@ossjs/release': 0.7.2
   '@playwright/test': 1.37.1
   '@types/cors': 2.8.13
@@ -71,6 +74,7 @@ devDependencies:
   '@types/node': 16.18.46
   '@types/node-fetch': 2.5.12
   '@types/supertest': 2.0.12
+  '@types/ws': 8.5.9
   axios: 1.6.0
   body-parser: 1.20.2
   commitizen: 4.3.0
@@ -95,7 +99,9 @@ devDependencies:
   vitest-environment-miniflare: 2.14.1_vitest@0.28.5
   wait-for-expect: 3.0.2
   web-encoding: 1.1.5
+  webpack: 5.88.2
   webpack-http-server: 0.5.0
+  ws: 8.14.2
 
 packages:
 
@@ -1462,7 +1468,7 @@ packages:
       '@miniflare/core': 2.14.1
       '@miniflare/shared': 2.14.1
       undici: 5.20.0
-      ws: 8.11.0
+      ws: 8.14.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -1499,16 +1505,17 @@ packages:
       outvariant: 1.4.0
     dev: false
 
-  /@open-draft/test-server/0.5.1:
-    resolution: {integrity: sha512-RYyjRVfddPMmVWePP49OQ/zmJL5D0kr+/LsLILYftC067LDPdZwUm75s9h+2+gqyVHU8qcWiWPXwYouDHUmVNw==}
+  /@open-draft/test-server/0.6.1:
+    resolution: {integrity: sha512-/eOet/0rJ14Jt5dUb6uY+Iqsr0LRAgdssrmwxruzJSkS3QCLSpIodG/7jKJmfZvBqAOhrpGyiKrqefKFuaKtpw==}
     dependencies:
       '@types/body-parser': 1.19.2
       '@types/cors': 2.8.13
       '@types/express': 4.17.17
+      '@types/ws': 8.5.9
       cors: 2.8.5
       express: 4.18.2
       outvariant: 1.4.0
-      socket.io: 4.7.2
+      ws: 8.14.2
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -1574,10 +1581,6 @@ packages:
     resolution: {integrity: sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==}
     dependencies:
       '@sinonjs/commons': 1.8.6
-    dev: true
-
-  /@socket.io/component-emitter/3.1.0:
-    resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
     dev: true
 
   /@szmarczak/http-timer/4.0.6:
@@ -1679,10 +1682,6 @@ packages:
     resolution: {integrity: sha512-aoUKfRQYvGMH+spFpOTX9jO4nZoz9/BKp4hlHPxL3Cj2r2Xj+jEcwlXtFIyZr5uL8bh1nbWynDEYaAota+XqPg==}
     dependencies:
       '@types/node': 20.4.7
-    dev: true
-
-  /@types/cookie/0.4.1:
-    resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
     dev: true
 
   /@types/cookiejar/2.1.2:
@@ -1898,6 +1897,12 @@ packages:
     resolution: {integrity: sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==}
     dependencies:
       '@types/superagent': 4.1.18
+    dev: true
+
+  /@types/ws/8.5.9:
+    resolution: {integrity: sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==}
+    dependencies:
+      '@types/node': 20.4.7
     dev: true
 
   /@types/yargs-parser/21.0.0:
@@ -2379,11 +2384,6 @@ packages:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: true
 
-  /base64id/2.0.0:
-    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
-    engines: {node: ^4.5.0 || >= 5.9}
-    dev: true
-
   /binary-extensions/2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
@@ -2854,11 +2854,6 @@ packages:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
     dev: true
 
-  /cookie/0.4.2:
-    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
-    engines: {node: '>= 0.6'}
-    dev: true
-
   /cookie/0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
@@ -3215,31 +3210,6 @@ packages:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
-    dev: true
-
-  /engine.io-parser/5.2.1:
-    resolution: {integrity: sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==}
-    engines: {node: '>=10.0.0'}
-    dev: true
-
-  /engine.io/6.5.2:
-    resolution: {integrity: sha512-IXsMcGpw/xRfjra46sVZVHiSWo/nJ/3g1337q9KNXtS6YRzbW5yIzTCb9DjhrBe7r3GZQR0I4+nq+4ODk5g/cA==}
-    engines: {node: '>=10.2.0'}
-    dependencies:
-      '@types/cookie': 0.4.1
-      '@types/cors': 2.8.13
-      '@types/node': 20.4.7
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cookie: 0.4.2
-      cors: 2.8.5
-      debug: 4.3.4
-      engine.io-parser: 5.2.1
-      ws: 8.11.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: true
 
   /enhanced-resolve/5.15.0:
@@ -6131,42 +6101,6 @@ packages:
       is-fullwidth-code-point: 4.0.0
     dev: true
 
-  /socket.io-adapter/2.5.2:
-    resolution: {integrity: sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==}
-    dependencies:
-      ws: 8.11.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: true
-
-  /socket.io-parser/4.2.4:
-    resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      '@socket.io/component-emitter': 3.1.0
-      debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /socket.io/4.7.2:
-    resolution: {integrity: sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==}
-    engines: {node: '>=10.2.0'}
-    dependencies:
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cors: 2.8.5
-      debug: 4.3.4
-      engine.io: 6.5.2
-      socket.io-adapter: 2.5.2
-      socket.io-parser: 4.2.4
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /sonic-boom/2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
     dependencies:
@@ -7342,12 +7276,12 @@ packages:
         optional: true
     dev: true
 
-  /ws/8.11.0:
-    resolution: {integrity: sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==}
+  /ws/8.14.2:
+    resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true

--- a/src/interceptors/WebSocket/WebSocketController.ts
+++ b/src/interceptors/WebSocket/WebSocketController.ts
@@ -1,102 +1,347 @@
-import { createProxy } from '../../utils/createProxy'
-import { Connection, kOnOutgoingMessage } from './connections/Connection'
+import { invariant } from 'outvariant'
+import { Emitter } from 'strict-event-emitter'
+import { kHandshakeState, kOnOutgoingMessage } from './connections/Connection'
 import { WebSocketConnection } from './connections/WebSocketConnection'
-import { extendEvent } from './utils/extendEvent'
 import type { WebSocketData } from './transports/Transport'
+import { extendEvent } from './utils/extendEvent'
+import { emitAsync } from '../../utils/emitAsync'
+import type { WebSocketInterceptorEventMap } from '.'
+import { NextFunction, createProxy } from '../../utils/createProxy'
+
+interface WebSocketControllerOptions {
+  url: URL | string
+  protocols?: string | Array<string>
+  emitter: Emitter<WebSocketInterceptorEventMap>
+  WebSocketClass: typeof WebSocket
+}
 
 export class WebSocketController {
-  public ws: WebSocket
-  public connection: Connection
+  public ws: WebSocket | WebSocketOverride
+  public connection: WebSocketConnection
 
-  constructor(originalWebSocket: WebSocket) {
-    this.connection = new WebSocketConnection(originalWebSocket)
+  constructor(protected options: WebSocketControllerOptions) {
+    // By default, construct a WebSocket override class to prevent
+    // the connection errors that cannot be try/catch'ed.
+    // If the user decides to mock this connection,
+    // they will continue interacting with the override instance
+    // that implements the WebSocket browser class faithfully.
+    this.ws = new WebSocketOverride(options.url, options.protocols)
 
-    this.ws = createProxy(originalWebSocket, {
-      methodCall: ([methodName, args], next) => {
-        switch (methodName) {
-          case 'send': {
-            return this.send(args[0] as WebSocketData)
-          }
+    // Connection is the bridge between whatever internals are
+    // happening in the interceptor and the user, who operates
+    // on the connection to send/listen to the client-side events.
+    this.connection = new WebSocketConnection(this.ws)
 
-          case 'addEventListener': {
-            const [event, listener] = args as [
-              string,
-              EventListenerOrEventListenerObject
-            ]
-
-            // Suppress the original "error" and "close" events
-            // from propagating to the user-attached listeners.
-            // The user will be in charge of those events via
-            // the connection received in the handler.
-            if (['error', 'close'].includes(event)) {
-              /**
-               * @fixme Somehow still call these listeners
-               * if the connection was closed in the handler. The same for errors.
-               */
-              return
-            }
-
-            return next()
-          }
-
-          default: {
-            return next()
-          }
+    // Wait for all the "connection" listeners to be called before continuing.
+    emitAsync(options.emitter, 'connection', this.connection).then(() => {
+      // By this time, the consumer has already decided whether to mock
+      // this connection or not, so either continue using the override class
+      // or re-construct the WebSocket connection using the original arguments.
+      if (this.connection[kHandshakeState] === 'bypass') {
+        if ('unwrap' in this.ws) {
+          this.ws = this.ws.unwrap(options.WebSocketClass)
         }
-      },
+      }
 
-      setProperty: ([propertyName, nextValue], next) => {
-        switch (propertyName) {
-          case 'onopen':
-          case 'onmessage':
-          case 'onclose':
-          case 'onerror': {
-            const eventName = propertyName.replace(/^on/, '')
-            this.ws.addEventListener(
-              eventName,
-              nextValue as EventListenerOrEventListenerObject
-            )
-            return true
-          }
-
-          default: {
-            return next()
-          }
-        }
-      },
+      /**
+       * @todo Proxy whichever WebSocket target is right.
+       * This will spy on the send/receive events and tunnel them
+       * through the "connection" before forwarding them to the socket instance.
+       */
+      this.ws = createWebSocketProxy(this.ws, {
+        onSend: (data, next) => {
+          this.connection[kOnOutgoingMessage](data)
+        },
+        onReceived: (data, next) => {
+          throw new Error('Incoming messages not implemented')
+        },
+      })
     })
 
-    Reflect.set(this.ws, 'readyState', WebSocket.CONNECTING)
+    /**
+     * @todo Is this proxy really necessary?
+     */
+    // this.ws = createProxy(this.ws, {
+    //   methodCall: ([methodName, args], next) => {
+    //     switch (methodName) {
+    //       case 'send': {
+    //         return this.send(args[0] as WebSocketData)
+    //       }
 
-    this.ws.addEventListener(
-      'close',
-      () => {
-        // Forward the "close" events initialted outside
-        // of the connection (e.g. by the client).
-        this.connection.close()
-      },
-      {
-        once: true,
-      }
-    )
+    //       case 'addEventListener': {
+    //         const [event, listener] = args as [
+    //           string,
+    //           EventListenerOrEventListenerObject
+    //         ]
+
+    //         // Suppress the original "error" and "close" events
+    //         // from propagating to the user-attached listeners.
+    //         // The user will be in charge of those events via
+    //         // the connection received in the handler.
+    //         if (['error', 'close'].includes(event)) {
+    //           /**
+    //            * @fixme Somehow still call these listeners
+    //            * if the connection was closed in the handler. The same for errors.
+    //            */
+    //           return
+    //         }
+
+    //         return next()
+    //       }
+
+    //       default: {
+    //         return next()
+    //       }
+    //     }
+    //   },
+
+    //   setProperty: ([propertyName, nextValue], next) => {
+    //     switch (propertyName) {
+    //       case 'onopen':
+    //       case 'onmessage':
+    //       case 'onclose':
+    //       case 'onerror': {
+    //         const eventName = propertyName.replace(/^on/, '')
+    //         this.ws.addEventListener(
+    //           eventName,
+    //           nextValue as EventListenerOrEventListenerObject
+    //         )
+    //         return true
+    //       }
+
+    //       default: {
+    //         return next()
+    //       }
+    //     }
+    //   },
+    // })
   }
 
-  private send(data: WebSocketData): void {
-    if (
-      this.ws.readyState === WebSocket.CLOSING ||
-      this.ws.readyState === WebSocket.CLOSED
-    ) {
+  // private send(data: WebSocketData): void {
+  //   if (
+  //     this.ws.readyState === WebSocket.CLOSING ||
+  //     this.ws.readyState === WebSocket.CLOSED
+  //   ) {
+  //     /**
+  //      * @todo Calculate the buffer amount.
+  //      */
+  //     Reflect.set(this.ws, 'bufferAmount', this.ws.bufferedAmount + 0)
+  //     return
+  //   }
+
+  //   queueMicrotask(() => {
+  //     // Notify the "connection" object so the user could
+  //     // react to the outgoing (client) data in the handler.
+  //     this.connection[kOnOutgoingMessage](data)
+  //   })
+  // }
+}
+
+function createWebSocketProxy(
+  ws: WebSocket,
+  options: {
+    onSend: (data: WebSocketData, next: NextFunction<void>) => void
+    onReceived: (data: WebSocketData, next: NextFunction<void>) => void
+  }
+): WebSocket {
+  const proxy = createProxy(ws, {
+    methodCall([methodName, args], next) {
+      switch (methodName) {
+        case 'send': {
+          options.onSend(args[0], next)
+          break
+        }
+
+        case 'dispatchEvent': {
+          const [event] = args
+
+          if (event instanceof MessageEvent && event.type === 'message') {
+            options.onReceived(event.data, next)
+            return
+          }
+
+          return next()
+        }
+
+        default: {
+          return next()
+        }
+      }
+    },
+  })
+
+  return proxy
+}
+
+class WebSocketOverride extends EventTarget implements WebSocket {
+  static readonly CONNECTING = WebSocket.CONNECTING
+  static readonly OPEN = WebSocket.OPEN
+  static readonly CLOSING = WebSocket.CLOSING
+  static readonly CLOSED = WebSocket.CLOSED
+  readonly CONNECTING = WebSocket.CONNECTING
+  readonly OPEN = WebSocket.OPEN
+  readonly CLOSING = WebSocket.CLOSING
+  readonly CLOSED = WebSocket.CLOSED
+
+  public url: string
+  public protocol: string
+  public extensions: string
+  public bufferedAmount: number
+  public binaryType: BinaryType
+  public readyState: number
+
+  private _url: string | URL
+  private _protocols?: string | Array<string>
+  private _events: Map<string, Set<EventListenerOrEventListenerObject>>
+  private _onopen: ((this: WebSocket, event: Event) => void) | null = null
+  private _onmessage: ((this: WebSocket, event: MessageEvent) => void) | null =
+    null
+  private _onclose: ((this: WebSocket, event: CloseEvent) => void) | null = null
+  private _onerror: ((this: WebSocket, event: Event) => void) | null = null
+
+  constructor(url: URL | string, protocols?: string | Array<string>) {
+    super()
+
+    this._url = url
+    this._protocols = protocols
+    this._events = new Map()
+
+    this.url = url.toString()
+    this.protocol = protocols ? protocols[0] : 'ws'
+    this.extensions = ''
+    this.bufferedAmount = 0
+    this.binaryType = 'arraybuffer'
+
+    this.readyState = this.CONNECTING
+  }
+
+  public unwrap(WebSocketClass: typeof WebSocket): WebSocket {
+    const ws = new WebSocketClass(this._url, this._protocols)
+
+    // Forward any event listeners added to the override
+    // to the original WebSocket instance.
+    this._events.forEach((listeners, event) => {
+      listeners.forEach((listener) => {
+        ws.addEventListener(event, listener)
+      })
+    })
+
+    return ws
+  }
+
+  public send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
+    if (this.readyState === this.CONNECTING) {
+      this.close()
+      throw new Error('InvalidStateError')
+    }
+
+    if (this.readyState === this.CLOSING || this.readyState === this.CLOSED) {
+      this.bufferedAmount += getDataSize(data)
+
       /**
-       * @todo Calculate the buffer amount.
+       * @todo Should actually buffer the data and send it all
+       * once the socket becomes connected.
        */
-      Reflect.set(this.ws, 'bufferAmount', this.ws.bufferedAmount + 0)
       return
     }
 
-    queueMicrotask(() => {
-      // Notify the "connection" object so the user could
-      // react to the outgoing (client) data in the handler.
-      this.connection[kOnOutgoingMessage](data)
-    })
+    /**
+     * @todo
+     */
   }
+
+  public close(code?: number | undefined, reason?: string | undefined): void {
+    const CODE_RANGE_ERROR =
+      'InvalidAccessError: close code out of user configurable range'
+
+    invariant(code, CODE_RANGE_ERROR)
+    invariant(code === 1000 || (code >= 3000 && code < 5000), CODE_RANGE_ERROR)
+
+    if (this.readyState === this.CLOSING || this.readyState === this.CLOSED) {
+      return
+    }
+
+    const closeEvent = new Event('close')
+    extendEvent(closeEvent, {
+      target: this,
+      code,
+      reason,
+      wasClean: code === 1000,
+    })
+    this.dispatchEvent(closeEvent)
+
+    // Remove all listeners.
+    this._onopen = null
+    this._onmessage = null
+    this._onerror = null
+    this._onclose = null
+  }
+
+  public addEventListener<WebSocketEvent extends keyof WebSocketEventMap>(
+    type: WebSocketEvent,
+    listener:
+      | ((this: WebSocket, event: WebSocketEventMap[WebSocketEvent]) => void)
+      | null,
+    options?: boolean | AddEventListenerOptions
+  ): void
+  public addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions
+  ): void
+  public addEventListener<WebSocketEvent extends keyof WebSocketEventMap>(
+    type: WebSocketEvent | string,
+    listener:
+      | ((this: WebSocket, event: WebSocketEventMap[WebSocketEvent]) => void)
+      | EventListenerOrEventListenerObject
+      | null,
+    options?: boolean | AddEventListenerOptions
+  ): void {
+    if (listener !== null) {
+      this._events.set(
+        type,
+        (this._events.get(type) || new Set()).add(listener)
+      )
+    }
+
+    return super.addEventListener(type, listener, options)
+  }
+
+  set onopen(listener: ((this: WebSocket, event: Event) => void) | null) {
+    this.removeEventListener('open', this._onopen)
+    this._onopen = listener
+    this.addEventListener('open', this._onopen)
+  }
+
+  set onmessage(
+    listener: ((this: WebSocket, event: MessageEvent) => void) | null
+  ) {
+    this.removeEventListener('message', this._onmessage)
+    this._onmessage = listener
+    this.addEventListener('message', this._onmessage)
+  }
+
+  set onclose(listener: ((this: WebSocket, event: CloseEvent) => void) | null) {
+    this.removeEventListener('message', this._onclose)
+    this._onclose = listener
+    this.addEventListener('close', this._onclose)
+  }
+
+  set onerror(listener: ((this: WebSocket, event: Event) => void) | null) {
+    this.removeEventListener('error', this._onerror)
+    this._onerror = listener
+    this.addEventListener('error', this._onerror)
+  }
+}
+
+function getDataSize(data: WebSocketData): number {
+  if (typeof data === 'string') {
+    return data.length
+  }
+
+  if (data instanceof Blob) {
+    return data.size
+  }
+
+  return data.byteLength
 }

--- a/src/interceptors/WebSocket/WebSocketController.ts
+++ b/src/interceptors/WebSocket/WebSocketController.ts
@@ -1,0 +1,103 @@
+import { createProxy } from '../../utils/createProxy'
+import { Connection, kOnOutgoingMessage } from './connections/Connection'
+import { WebSocketConnection } from './connections/WebSocketConnection'
+import { extendEvent } from './utils/extendEvent'
+import type { WebSocketData } from './transports/Transport'
+
+export class WebSocketController {
+  public ws: WebSocket
+  public connection: Connection
+
+  constructor(originalWebSocket: WebSocket) {
+    this.connection = new WebSocketConnection(originalWebSocket)
+
+    this.ws = createProxy(originalWebSocket, {
+      methodCall: ([methodName, args], next) => {
+        switch (methodName) {
+          case 'send': {
+            return this.send(args[0] as WebSocketData)
+          }
+
+          case 'addEventListener': {
+            const [event] = args as [string]
+
+            // Suppress the original "error" and "close" events
+            // from propagating to the user-attached listeners.
+            // The user will be in charge of those events via
+            // the connection received in the handler.
+            if (['error', 'close'].includes(event)) {
+              return
+            }
+
+            return next()
+          }
+
+          default: {
+            return next()
+          }
+        }
+      },
+
+      setProperty: ([propertyName, nextValue], next) => {
+        switch (propertyName) {
+          case 'onopen':
+          case 'onmessage':
+          case 'onclose':
+          case 'onerror': {
+            const eventName = propertyName.replace(/^on/, '')
+            this.ws.addEventListener(
+              eventName,
+              nextValue as EventListenerOrEventListenerObject
+            )
+            return true
+          }
+
+          default: {
+            return next()
+          }
+        }
+      },
+    })
+
+    this.setReadyState(WebSocket.CONNECTING)
+
+    this.ws.addEventListener('close', () => this.connection.close(), {
+      once: true,
+    })
+
+    // Open connection.
+    queueMicrotask(() => {
+      this.setReadyState(WebSocket.OPEN)
+
+      this.connection.open()
+
+      const openEvent = new Event('open')
+      extendEvent(openEvent, { target: this.ws })
+
+      this.ws.dispatchEvent(openEvent)
+    })
+  }
+
+  private setReadyState(nextState: number): void {
+    Reflect.set(this.ws, 'readyState', nextState)
+  }
+
+  private send(data: WebSocketData): void {
+    if (
+      this.ws.readyState === WebSocket.CLOSING ||
+      this.ws.readyState === WebSocket.CLOSED
+    ) {
+      /**
+       * @todo Calculate the buffer amount.
+       */
+      Reflect.set(this.ws, 'bufferAmount', this.ws.bufferedAmount + 0)
+      return
+    }
+
+    queueMicrotask(() => {
+      // Notify the "connection" object so the user could
+      // react to the outgoing (client) data in the handler.
+      this.connection[kOnOutgoingMessage](data)
+    })
+  }
+}

--- a/src/interceptors/WebSocket/WebSocketController.ts
+++ b/src/interceptors/WebSocket/WebSocketController.ts
@@ -64,18 +64,6 @@ export class WebSocketController {
     this.ws.addEventListener('close', () => this.connection.close(), {
       once: true,
     })
-
-    // Open connection.
-    queueMicrotask(() => {
-      this.setReadyState(WebSocket.OPEN)
-
-      this.connection.open()
-
-      const openEvent = new Event('open')
-      extendEvent(openEvent, { target: this.ws })
-
-      this.ws.dispatchEvent(openEvent)
-    })
   }
 
   private setReadyState(nextState: number): void {

--- a/src/interceptors/WebSocket/connections/Connection.ts
+++ b/src/interceptors/WebSocket/connections/Connection.ts
@@ -16,18 +16,26 @@ export interface ConnectionOptions {
  */
 export abstract class Connection {
   public url: string
+  public isOpen: boolean
 
   protected transport: Transport
   private [kEmitter]: EventTarget
 
   constructor(options: ConnectionOptions) {
     this[kEmitter] = new EventTarget()
+
     this.url = options.url
     this.transport = options.transport
+    this.isOpen = false
   }
 
   public open(): void {
+    if (this.isOpen) {
+      return
+    }
+
     this.transport.open()
+    this.isOpen = true
   }
 
   public on(event: string, listener: (...data: Array<unknown>) => void): void {
@@ -53,6 +61,10 @@ export abstract class Connection {
   }
 
   public close(): void {
+    if (!this.isOpen) {
+      return
+    }
+
     this.transport.close()
   }
 

--- a/src/interceptors/WebSocket/connections/Connection.ts
+++ b/src/interceptors/WebSocket/connections/Connection.ts
@@ -1,0 +1,57 @@
+import { invariant } from 'outvariant'
+import type { Transport, WebSocketData } from '../transports/Transport'
+
+export const kOnOutgoingMessage = Symbol('kOnOutgoingMessage')
+
+/**
+ * Connection represents server-side connection to a particular
+ * WebSocket client.
+ */
+export abstract class Connection {
+  private emitter: EventTarget
+
+  constructor(protected readonly transport: Transport) {
+    this.emitter = new EventTarget()
+  }
+
+  public open(): void {
+    this.transport.open()
+  }
+
+  public on(event: string, listener: (...data: Array<unknown>) => void): void {
+    this.emitter.addEventListener(event, (event) => {
+      if (event instanceof MessageEvent) {
+        listener(event.data)
+      }
+    })
+  }
+
+  /**
+   * Send data to the connected client.
+   */
+  public send(data: WebSocketData): void {
+    this.transport.send(data)
+  }
+
+  /**
+   * Emit event to the connected client.
+   */
+  public emit(event: string, data: WebSocketData): void {
+    invariant(false, `The "emit" method is not implemented on this Connection`)
+  }
+
+  public close(): void {
+    this.transport.close()
+  }
+
+  /**
+   * Handle outgoing (intercepted) client messages.
+   */
+  [kOnOutgoingMessage](data: unknown) {
+    // Note that this "message" will be emitted on the connection itself
+    // so the user could listen to outgoing client data like:
+    //
+    // connection.on('message', listener)
+    this.emitter.dispatchEvent(new MessageEvent('message', { data }))
+  }
+}

--- a/src/interceptors/WebSocket/connections/WebSocketConnection.ts
+++ b/src/interceptors/WebSocket/connections/WebSocketConnection.ts
@@ -8,17 +8,25 @@ import type { WebSocketData } from '../transports/Transport'
  * class in JavaScript. Note that with that class you can
  * only emit and accept "MessageEvent".
  */
-export class WebSocketConnection extends Connection {
+export class WebSocketConnection extends Connection<WebSocketTransport> {
   constructor(ws: WebSocket) {
     super({
       url: ws.url,
       transport: new WebSocketTransport(ws),
     })
+
+    // Forward the "close" events initialted outside
+    // of the connection (e.g. by the client).
+    ws.addEventListener(
+      'close',
+      (event) => this.close(event.code, event.reason),
+      { once: true }
+    )
   }
 
   public emit(event: string, data: WebSocketData): void {
-    // Throw when emitting arbitrary events with the standard
-    // WebSocket class usage. That's against the spec.
+    // Throw when emitting arbitrary events when using the
+    // standard WebSocket class. Those aren't supported.
     invariant(
       event === 'message',
       `Failed to emit unknown WebSocket event "%s". The standard WebSocket class implementation only supports the "message" event.`,
@@ -29,6 +37,12 @@ export class WebSocketConnection extends Connection {
   }
 
   public close(code = 1000, reason?: string): void {
+    /**
+     * @todo This should probably not have the same call signature
+     * as the client-side "WebSocket.prototype.close". Instead,
+     * make the connection "close" method accept an optional "error"
+     * and alternatve between a successful and unsuccessful closures.
+     */
     this.transport.close(code, reason)
   }
 }

--- a/src/interceptors/WebSocket/connections/WebSocketConnection.ts
+++ b/src/interceptors/WebSocket/connections/WebSocketConnection.ts
@@ -1,0 +1,27 @@
+import { invariant } from 'outvariant'
+import { WebSocketTransport } from '../transports/WebSocketTransport'
+import { Connection } from './Connection'
+import type { WebSocketData } from '../transports/Transport'
+
+/**
+ * Connection implementation for the standard "WebSocket"
+ * class in JavaScript. Note that with that class you can
+ * only emit and accept "MessageEvent".
+ */
+export class WebSocketConnection extends Connection {
+  constructor(ws: WebSocket) {
+    super(new WebSocketTransport(ws))
+  }
+
+  public emit(event: string, data: WebSocketData): void {
+    // Throw when emitting arbitrary events with the standard
+    // WebSocket class usage. That's against the spec.
+    invariant(
+      event === 'message',
+      `Failed to emit unknown WebSocket event "%s". The standard WebSocket class implementation only supports the "message" event.`,
+      event
+    )
+
+    this.transport.send(data)
+  }
+}

--- a/src/interceptors/WebSocket/connections/WebSocketConnection.ts
+++ b/src/interceptors/WebSocket/connections/WebSocketConnection.ts
@@ -27,4 +27,8 @@ export class WebSocketConnection extends Connection {
 
     this.transport.send(data)
   }
+
+  public close(code = 1000, reason?: string): void {
+    this.transport.close(code, reason)
+  }
 }

--- a/src/interceptors/WebSocket/connections/WebSocketConnection.ts
+++ b/src/interceptors/WebSocket/connections/WebSocketConnection.ts
@@ -10,7 +10,10 @@ import type { WebSocketData } from '../transports/Transport'
  */
 export class WebSocketConnection extends Connection {
   constructor(ws: WebSocket) {
-    super(new WebSocketTransport(ws))
+    super({
+      url: ws.url,
+      transport: new WebSocketTransport(ws),
+    })
   }
 
   public emit(event: string, data: WebSocketData): void {

--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -26,12 +26,16 @@ export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
         args: ConstructorParameters<typeof globalThis.WebSocket>,
         newTarget
       ) => {
-        const originalWebSocket = Reflect.construct(target, args, newTarget)
-        const controller = new WebSocketController(originalWebSocket)
+        let originalWebSocket: WebSocket
 
-        this.emitter.emit('connection', controller.connection)
-
-        return controller.ws
+        try {
+          originalWebSocket = Reflect.construct(target, args, newTarget)
+          const controller = new WebSocketController(originalWebSocket)
+          this.emitter.emit('connection', controller.connection)
+          return controller.ws
+        } finally {
+          //
+        }
       },
     })
 

--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -1,0 +1,44 @@
+import { Interceptor } from '../../Interceptor'
+import type { WebSocketConnection } from './connections/WebSocketConnection'
+import { WebSocketController } from './WebSocketController'
+
+export type WebSocketEventMap = {
+  connection: [WebSocketConnection]
+}
+
+export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
+  static interceptorSymbol = Symbol('websocket-class-interceptor')
+
+  constructor() {
+    super(WebSocketInterceptor.interceptorSymbol)
+  }
+
+  protected checkEnvironment(): boolean {
+    return (
+      typeof window !== 'undefined' && typeof window.WebSocket !== 'undefined'
+    )
+  }
+
+  protected setup(): void {
+    const WebSocketProxy = Proxy.revocable(globalThis.WebSocket, {
+      construct: (
+        target,
+        args: ConstructorParameters<typeof globalThis.WebSocket>,
+        newTarget
+      ) => {
+        const originalWebSocket = Reflect.construct(target, args, newTarget)
+        const controller = new WebSocketController(originalWebSocket)
+
+        this.emitter.emit('connection', controller.connection)
+
+        return controller.ws
+      },
+    })
+
+    globalThis.WebSocket = WebSocketProxy.proxy
+
+    this.subscriptions.push(() => {
+      WebSocketProxy.revoke()
+    })
+  }
+}

--- a/src/interceptors/WebSocket/transports/Transport.ts
+++ b/src/interceptors/WebSocket/transports/Transport.ts
@@ -12,5 +12,5 @@ export type WebSocketData = string | ArrayBufferLike | Blob | ArrayBufferView
 export abstract class Transport {
   public open(): void {}
   public send(data: WebSocketData): void {}
-  public close(): void {}
+  public close(code: number = 1000, reason?: string): void {}
 }

--- a/src/interceptors/WebSocket/transports/Transport.ts
+++ b/src/interceptors/WebSocket/transports/Transport.ts
@@ -1,0 +1,16 @@
+export type WebSocketData = string | ArrayBufferLike | Blob | ArrayBufferView
+
+/**
+ * Transport is an abstract that handles connection events
+ * depending on the underlying WebSocket implementation.
+ *
+ * For example, a standard WebSocket transport can simply
+ * dispatch "MessageEvent" to implement "send", while a
+ * Socket.io implementation would have to emit a message
+ * with a specific numeric prefix to be recognized as data.
+ */
+export abstract class Transport {
+  public open(): void {}
+  public send(data: WebSocketData): void {}
+  public close(): void {}
+}

--- a/src/interceptors/WebSocket/transports/WebSocketTransport.ts
+++ b/src/interceptors/WebSocket/transports/WebSocketTransport.ts
@@ -22,7 +22,40 @@ export class WebSocketTransport extends Transport {
   public send(data: unknown) {
     const event = new MessageEvent('message', { data })
     extendEvent(event, { target: this.ws })
-
     this.ws.dispatchEvent(event)
+  }
+
+  public close(code: number, reason?: string): void {
+    if (!code || !(code === 1000 || (code > 3000 && code < 5000))) {
+      throw new Error(
+        'InvalidAccessError: close code out of user configurable range'
+      )
+    }
+
+    if (
+      this.ws.readyState === WebSocket.CLOSING ||
+      this.ws.readyState === WebSocket.CLOSED
+    ) {
+      return
+    }
+
+    Reflect.set(this.ws, 'readyState', WebSocket.CLOSING)
+
+    queueMicrotask(() => {
+      const closeEvent = new CloseEvent('close')
+      extendEvent(closeEvent, {
+        target: this.ws,
+        code,
+        reason,
+        wasClean: code === 1000,
+      })
+
+      /**
+       * @fixme This won't trigger the client-side
+       * "onclose" listeners because they are suppressed
+       * to prevent initial connection close.
+       */
+      this.ws.dispatchEvent(closeEvent)
+    })
   }
 }

--- a/src/interceptors/WebSocket/transports/WebSocketTransport.ts
+++ b/src/interceptors/WebSocket/transports/WebSocketTransport.ts
@@ -6,6 +6,16 @@ export class WebSocketTransport extends Transport {
     super()
   }
 
+  public open(): void {
+    queueMicrotask(() => {
+      Reflect.set(this.ws, 'readyState', WebSocket.OPEN)
+
+      const openEvent = new Event('open')
+      extendEvent(openEvent, { target: this.ws })
+      this.ws.dispatchEvent(openEvent)
+    })
+  }
+
   /**
    * Send data from the server to the client.
    */

--- a/src/interceptors/WebSocket/transports/WebSocketTransport.ts
+++ b/src/interceptors/WebSocket/transports/WebSocketTransport.ts
@@ -1,0 +1,18 @@
+import { extendEvent } from '../utils/extendEvent'
+import { Transport } from './Transport'
+
+export class WebSocketTransport extends Transport {
+  constructor(protected ws: WebSocket) {
+    super()
+  }
+
+  /**
+   * Send data from the server to the client.
+   */
+  public send(data: unknown) {
+    const event = new MessageEvent('message', { data })
+    extendEvent(event, { target: this.ws })
+
+    this.ws.dispatchEvent(event)
+  }
+}

--- a/src/interceptors/WebSocket/utils/extendEvent.ts
+++ b/src/interceptors/WebSocket/utils/extendEvent.ts
@@ -1,0 +1,8 @@
+export function extendEvent(
+  event: Event,
+  properties: Record<string, unknown>
+): void {
+  for (const name in properties) {
+    Reflect.set(event, name, properties[name])
+  }
+}

--- a/test/modules/WebSocket/web/compliance/ws-open.browser.test.ts
+++ b/test/modules/WebSocket/web/compliance/ws-open.browser.test.ts
@@ -1,0 +1,79 @@
+import { WebSocketServer } from '@open-draft/test-server/ws'
+import { WebSocketInterceptor } from '../../../../../src/interceptors/WebSocket'
+import { test, expect } from '../../../../playwright.extend'
+
+declare namespace window {
+  export const interceptor: WebSocketInterceptor
+}
+
+const wsServer = new WebSocketServer()
+
+test.beforeAll(async () => {
+  await wsServer.listen()
+})
+test.afterAll(async () => {
+  await wsServer.close()
+})
+
+test('emits the "open" event when connected to the actual server', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(require.resolve('../ws-empty.runtime.js'))
+
+  const connectionPromise = page.evaluate(() => {
+    const { interceptor } = window
+
+    return new Promise<boolean>((resolve) => {
+      interceptor.apply()
+      interceptor.on('connection', () => {
+        // Do not handshake so that the connection to the
+        // actual server is established instead.
+        resolve(true)
+      })
+    })
+  })
+
+  const openListenerPromise = page.evaluate((url) => {
+    const ws = new WebSocket(url)
+
+    return new Promise<boolean>((resolve, reject) => {
+      ws.onopen = () => resolve(true)
+      ws.onerror = reject
+    })
+  }, wsServer.ws.address.href)
+
+  await expect(openListenerPromise).resolves.toBe(true)
+  await expect(connectionPromise).resolves.toBe(true)
+})
+
+test('emits the "open" event when mocked the connection', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(require.resolve('../ws-empty.runtime.js'))
+
+  const connectionPromise = page.evaluate(() => {
+    const { interceptor } = window
+
+    return new Promise<boolean>((resolve) => {
+      interceptor.apply()
+      interceptor.on('connection', (connection) => {
+        connection.handshake()
+        resolve(true)
+      })
+    })
+  })
+
+  const openListenerPromise = page.evaluate((url) => {
+    const ws = new WebSocket(url)
+
+    return new Promise<boolean>((resolve, reject) => {
+      ws.onopen = () => resolve(true)
+      ws.onerror = reject
+    })
+  }, wsServer.ws.address.href)
+
+  await expect(connectionPromise).resolves.toBe(true)
+  await expect(openListenerPromise).resolves.toBe(true)
+})

--- a/test/modules/WebSocket/web/ws-close.browser.test.ts
+++ b/test/modules/WebSocket/web/ws-close.browser.test.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '../../../playwright.extend'
+import type { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket'
+
+declare namespace window {
+  export const interceptor: WebSocketInterceptor
+}
+
+test('emits the "close" event upon successful close', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(require.resolve('./ws-empty.runtime.js'))
+
+  const closeEvent = await page.evaluate(() => {
+    const { interceptor } = window
+
+    interceptor.on('connection', (connection) => {
+      // Close the connection immediately.
+      connection.close()
+    })
+
+    const ws = new WebSocket('ws://non-existing-host.com')
+
+    return new Promise((resolve, reject) => {
+      ws.addEventListener('error', (error) => reject(error))
+
+      ws.addEventListener('close', (event) => {
+        resolve({
+          code: event.code,
+          reason: event.reason,
+          wasClean: event.wasClean,
+        })
+      })
+    })
+  })
+
+  await page.pause()
+
+  expect(closeEvent).toEqual({
+    code: 1000,
+    reason: undefined,
+    wasClean: true,
+  })
+})

--- a/test/modules/WebSocket/web/ws-empty.runtime.js
+++ b/test/modules/WebSocket/web/ws-empty.runtime.js
@@ -1,0 +1,4 @@
+import { WebSocketInterceptor } from '@mswjs/interceptors/WebSocket'
+
+const interceptor = new WebSocketInterceptor()
+window.interceptor = interceptor

--- a/test/modules/WebSocket/web/ws.browser.test.ts
+++ b/test/modules/WebSocket/web/ws.browser.test.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '../../../playwright.extend'
+
+test('support basic client-server communication', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(require.resolve('./ws.runtime.js'))
+
+  await expect(page.getByText('[client]: Hi! My name is John.')).toBeVisible()
+  await expect(page.getByText('[server]: Greetings, John!')).toBeVisible()
+  await expect(page.getByText('[client]: Happy to be here')).toBeVisible()
+})

--- a/test/modules/WebSocket/web/ws.browser.test.ts
+++ b/test/modules/WebSocket/web/ws.browser.test.ts
@@ -6,6 +6,8 @@ test('support basic client-server communication', async ({
 }) => {
   await loadExample(require.resolve('./ws.runtime.js'))
 
+  await page.pause()
+
   await expect(page.getByText('[client]: Hi! My name is John.')).toBeVisible()
   await expect(page.getByText('[server]: Greetings, John!')).toBeVisible()
   await expect(page.getByText('[client]: Happy to be here')).toBeVisible()

--- a/test/modules/WebSocket/web/ws.runtime.js
+++ b/test/modules/WebSocket/web/ws.runtime.js
@@ -1,0 +1,52 @@
+import { WebSocketInterceptor } from '@mswjs/interceptors/WebSocket'
+
+const chatElement = document.createElement('div')
+chatElement.setAttribute('id', 'chat')
+document.body.appendChild(chatElement)
+
+function addMessage(text, sender) {
+  const message = document.createElement('p')
+  message.innerText = `[${sender}]: ${text}`
+  chatElement.appendChild(message)
+}
+
+const interceptor = new WebSocketInterceptor()
+interceptor.apply()
+
+interceptor.on('connection', (connection) => {
+  connection.on('message', async (data) => {
+    addMessage(data, 'client')
+
+    await new Promise((resolve) => setTimeout(resolve, 750))
+
+    if (data.includes('My name is John')) {
+      connection.send(`Greetings, John!`)
+    }
+  })
+})
+
+const ws = new WebSocket('ws://non-existing-host.com')
+ws.addEventListener('open', () => {
+  console.log('[ws] event:open')
+
+  ws.send('Hi! My name is John.')
+
+  ws.addEventListener('message', async (event) => {
+    console.log('[ws] event:message', event.data)
+
+    addMessage(event.data, 'server')
+
+    if (event.data.includes('Greetings')) {
+      await new Promise((resolve) => setTimeout(resolve, 750))
+      ws.send('Happy to be here!')
+    }
+  })
+})
+
+ws.addEventListener('error', (error) => {
+  console.log('[ws] event:error', error)
+})
+
+ws.addEventListener('close', (event) => {
+  console.trace('[ws] event:close', event)
+})

--- a/test/modules/WebSocket/web/ws.runtime.js
+++ b/test/modules/WebSocket/web/ws.runtime.js
@@ -14,6 +14,8 @@ const interceptor = new WebSocketInterceptor()
 interceptor.apply()
 
 interceptor.on('connection', (connection) => {
+  connection.open()
+
   connection.on('message', async (data) => {
     addMessage(data, 'client')
 

--- a/test/modules/WebSocket/web/ws.runtime.js
+++ b/test/modules/WebSocket/web/ws.runtime.js
@@ -23,6 +23,7 @@ interceptor.on('connection', (connection) => {
 
     if (data.includes('My name is John')) {
       connection.send(`Greetings, John!`)
+      connection.close()
     }
   })
 })

--- a/test/modules/WebSocket/web/ws.runtime.js
+++ b/test/modules/WebSocket/web/ws.runtime.js
@@ -14,7 +14,7 @@ const interceptor = new WebSocketInterceptor()
 interceptor.apply()
 
 interceptor.on('connection', (connection) => {
-  connection.open()
+  connection.handshake()
 
   connection.on('message', async (data) => {
     addMessage(data, 'client')

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -17,7 +17,10 @@ const config: PlaywrightTestConfig = {
       // Some of the browser tests perform HTTPS requests
       // to the locally running test server with a self-signed certificate.
       // Allow those despite the certificate issues.
-      args: ['--allow-insecure-localhost'],
+      args: [
+        '--allow-insecure-localhost',
+        '--proxy-bypass-list=ws://*localhost',
+      ],
     },
   },
   fullyParallel: true,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -21,6 +21,7 @@ const browserConfig: Options = {
     './src/presets/browser.ts',
     './src/interceptors/XMLHttpRequest/index.ts',
     './src/interceptors/fetch/index.ts',
+    './src/interceptors/WebSocket/index.ts',
   ],
   outDir: './lib/browser',
   platform: 'browser',


### PR DESCRIPTION
A refreshed look at the WebSocket interception originally drafted in #236. 

## Roadmap

- [ ] Test the current behavior completely before moving to the next WebSocket transport. 
- [ ] Implement `connection.close(code)` to mock server connection close.
- [ ] Implement `connection.error(error)` to mock server connection errors. 