### PR TITLE
fix: add sourcemaps

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,6 +12,7 @@ const nodeConfig: Options = {
   outDir: './lib/node',
   platform: 'node',
   format: ['cjs', 'esm'],
+  sourcemap: true,
   dts: true,
 }
 
@@ -25,6 +26,7 @@ const browserConfig: Options = {
   outDir: './lib/browser',
   platform: 'browser',
   format: ['cjs', 'esm'],
+  sourcemap: true,
   dts: true,
 }
 


### PR DESCRIPTION
Adds sourcemaps to the build. Remix relies on sourcemaps for ESM it loads and Interceptors doesn't provide any, breaking the server-side build of Remix. 