### PR TITLE
Unintended side-effect when importing the module

### DIFF
--- a/src/utils/bufferUtils.ts
+++ b/src/utils/bufferUtils.ts
@@ -1,7 +1,11 @@
-const encoder = new TextEncoder()
+let encoder: TextEncoder;
+
+function getEncoder() {
+  return encoder || (encoder = new TextEncoder());
+}
 
 export function encodeBuffer(text: string): Uint8Array {
-  return encoder.encode(text)
+  return getEncoder().encode(text)
 }
 
 export function decodeBuffer(buffer: ArrayBuffer, encoding?: string): string {


### PR DESCRIPTION
When using the @mswjs/interceptors, it fails when running tests because jsdom is not aware of TextEncoder ( [issue #2524](https://github.com/jsdom/jsdom/issues/2524) ) when the tests are run, and you get the following error:

```
ReferenceError: TextEncoder is not defined
```

This comes from this module (bufferUtils), which creates an instance of the TextEncoder as a side-effect, even when you are not using the object.

A possible solution is to add the TextEncoder to the (jest) globals or test setup. Still, in our case, we have a mono-repo with _many_ libraries and projects, and adding this config to all these projects does not feel like a good solution - and we ran into some issues with the global test setup. 

A simple fix for this is removing the side effect and only creating (and reusing) the TextEncoder object when needed.