### PR TITLE
fix(WebSocket): add "client.id" property

### DIFF
--- a/src/interceptors/WebSocket/WebSocketClientConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketClientConnection.ts
@@ -9,6 +9,7 @@ import type { WebSocketRawData, WebSocketTransport } from './WebSocketTransport'
 import { WebSocketMessageListener } from './WebSocketOverride'
 import { bindEvent } from './utils/bindEvent'
 import { CloseEvent } from './utils/events'
+import { uuidv4 } from '../../utils/uuid'
 
 const kEmitter = Symbol('kEmitter')
 
@@ -27,7 +28,7 @@ export class WebSocketClientConnection {
     protected readonly ws: WebSocket,
     protected readonly transport: WebSocketTransport
   ) {
-    this.id = Math.random().toString(36).slice(2)
+    this.id = uuidv4()
     this.url = new URL(ws.url)
     this[kEmitter] = new EventTarget()
 

--- a/src/interceptors/WebSocket/WebSocketClientConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketClientConnection.ts
@@ -18,6 +18,7 @@ const kEmitter = Symbol('kEmitter')
  * send and receive events.
  */
 export class WebSocketClientConnection {
+  public readonly id: string
   public readonly url: URL
 
   protected [kEmitter]: EventTarget
@@ -26,6 +27,7 @@ export class WebSocketClientConnection {
     protected readonly ws: WebSocket,
     protected readonly transport: WebSocketTransport
   ) {
+    this.id = Math.random().toString(36).slice(2)
     this.url = new URL(ws.url)
     this[kEmitter] = new EventTarget()
 

--- a/test/modules/WebSocket/compliance/websocket.connection.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.connection.test.ts
@@ -3,6 +3,7 @@
  */
 import { vi, it, expect, beforeAll, afterAll } from 'vitest'
 import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket/index'
+import { UUID_REGEXP } from '../../../helpers'
 
 const interceptor = new WebSocketInterceptor()
 
@@ -26,7 +27,7 @@ it('emits the correct connection event', async () => {
       1,
       expect.objectContaining({
         client: expect.objectContaining({
-          id: expect.any(String),
+          id: expect.stringMatching(UUID_REGEXP),
           send: expect.any(Function),
           addEventListener: expect.any(Function),
           removeEventListener: expect.any(Function),

--- a/test/modules/WebSocket/compliance/websocket.connection.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.connection.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @vitest-environment node-with-websocket
+ */
+import { vi, it, expect, beforeAll, afterAll } from 'vitest'
+import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket/index'
+
+const interceptor = new WebSocketInterceptor()
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+})
+
+it('emits the correct connection event', async () => {
+  const connectionListener = vi.fn()
+  interceptor.once('connection', connectionListener)
+
+  new WebSocket('wss://example.com')
+
+  await vi.waitFor(() => {
+    expect(connectionListener).toHaveBeenCalledTimes(1)
+    expect(connectionListener).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        client: expect.objectContaining({
+          id: expect.any(String),
+          send: expect.any(Function),
+          addEventListener: expect.any(Function),
+          removeEventListener: expect.any(Function),
+          close: expect.any(Function),
+        }),
+        server: expect.objectContaining({
+          send: expect.any(Function),
+          addEventListener: expect.any(Function),
+          removeEventListener: expect.any(Function),
+        }),
+      })
+    )
+  })
+})


### PR DESCRIPTION
When implementing broadcasting, there has to be an identifier for each client connection. The `client.id` string serves as the identifier. 

## On broadcasting API in the Interceptors

I believe that the Interceptors library should remain low-level. This means that higher-level features such as event broadcasting have to be implemented by higher-level libraries like MSW. 