### PR TITLE
fix(WebSocket): use literal values for ready state properties

### DIFF
--- a/src/interceptors/WebSocket/WebSocketOverride.ts
+++ b/src/interceptors/WebSocket/WebSocketOverride.ts
@@ -19,14 +19,14 @@ export const kOnSend = Symbol('kOnSend')
 export const kClose = Symbol('kClose')
 
 export class WebSocketOverride extends EventTarget implements WebSocket {
-  static readonly CONNECTING = WebSocket.CONNECTING
-  static readonly OPEN = WebSocket.OPEN
-  static readonly CLOSING = WebSocket.CLOSING
-  static readonly CLOSED = WebSocket.CLOSED
-  readonly CONNECTING = WebSocket.CONNECTING
-  readonly OPEN = WebSocket.OPEN
-  readonly CLOSING = WebSocket.CLOSING
-  readonly CLOSED = WebSocket.CLOSED
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+  readonly CONNECTING = 0
+  readonly OPEN = 1
+  readonly CLOSING = 2
+  readonly CLOSED = 3
 
   public url: string
   public protocol: string


### PR DESCRIPTION
This way, imports to `WebSocketOverride` do not produce a dependency on the global `WebSocket` class. Otherwise, the `WebSocket.CONNECTING` (and similar) throw an error when you import the WebSocket interceptor, even if you are not planning on doing anything with it.

Context: getting the WebSocket undefined error when migrating to the latest Interceptors in MSW:

```
 FAIL  src/browser/setupWorker/setupWorker.node.test.ts [ src/browser/setupWorker/setupWorker.node.test.ts ]
ReferenceError: WebSocket is not defined
 ❯ node_modules/.pnpm/@mswjs+interceptors@0.26.5/node_modules/@mswjs/interceptors/src/interceptors/WebSocket/WebSocketOverride.ts:22:32
``` 