### PR TITLE
fix(RemoteHttpInterceptor): leaking event emitters

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,10 +486,7 @@ Enables request interception in the current process while delegating the respons
 import { RemoteHttpInterceptor } from '@mswjs/interceptors/RemoteHttpInterceptor'
 import { ClientRequestInterceptor } from '@mswjs/interceptors/ClientRequest'
 
-const interceptor = new RemoteHttpInterceptor({
-  // Alternatively, you can use presets.
-  interceptors: [new ClientRequestInterceptor()],
-})
+const interceptor = new RemoteHttpInterceptor()
 
 interceptor.apply()
 
@@ -502,7 +499,7 @@ You can still listen to and handle any requests in the child process via the `re
 
 ### `RemoteHttpResolver`
 
-Resolves an intercepted request in the given child `process`. Requires for that child process to enable request interception by calling the `createRemoteInterceptor` function.
+Resolves an intercepted request in the given child `process`. Requires for that child process to enable request interception by using the `RemoteHttpInterceptor` interceptor.
 
 ```js
 // parent.js
@@ -516,6 +513,7 @@ const appProcess = spawn('node', ['app.js'], {
 const resolver = new RemoteHttpResolver({
   process: appProcess,
 })
+resolver.apply();
 
 resolver.on('request', ({ request, requestId }) => {
   // Optionally, return a mocked response

--- a/src/utils/emitAsync.ts
+++ b/src/utils/emitAsync.ts
@@ -13,13 +13,13 @@ export async function emitAsync<
   eventName: EventName,
   ...data: Events[EventName]
 ): Promise<void> {
-  const listners = emitter.listeners(eventName)
+  const listeners = emitter.listeners(eventName)
 
-  if (listners.length === 0) {
+  if (listeners.length === 0) {
     return
   }
 
-  for (const listener of listners) {
-    await listener.apply(emitter, data)
+  for (const listener of listeners) {
+    await (listener as (...args: Events[EventName]) => Promise<void>).apply(emitter, data)
   }
 }


### PR DESCRIPTION
Motivation: The problem was that the event emitter for IPC messages was added over and over again and reached the max event listener limits.

Solution: Add it once.