### PR TITLE
fix(WebSocket): reassign global to restore WebSocket

### DIFF
--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -48,7 +48,9 @@ export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
   }
 
   protected setup(): void {
-    const webSocketProxy = Proxy.revocable(globalThis.WebSocket, {
+    const originalWebSocket = globalThis.WebSocket
+
+    const webSocketProxy = new Proxy(globalThis.WebSocket, {
       construct: (
         target,
         args: ConstructorParameters<typeof globalThis.WebSocket>,
@@ -82,10 +84,10 @@ export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
       },
     })
 
-    globalThis.WebSocket = webSocketProxy.proxy
+    globalThis.WebSocket = webSocketProxy
 
     this.subscriptions.push(() => {
-      webSocketProxy.revoke()
+      globalThis.WebSocket = originalWebSocket
     })
   }
 }

--- a/test/modules/WebSocket/intercept/websocket.dispose.test.ts
+++ b/test/modules/WebSocket/intercept/websocket.dispose.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment node-with-websocket
+ */
+import { vi, it, expect, beforeAll, afterAll } from 'vitest'
+import { WebSocketServer } from 'ws'
+import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket/index'
+import { getWsUrl } from '../utils/getWsUrl'
+
+const interceptor = new WebSocketInterceptor()
+
+const wsServer = new WebSocketServer({
+  host: '127.0.0.1',
+  port: 0,
+})
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+  wsServer.close()
+})
+
+it('restores the global WebSocket class after the interceptor is disposed', async () => {
+  const connectionListener = vi.fn()
+  interceptor.once('connection', connectionListener)
+
+  new WebSocket('wss://example.com')
+
+  await vi.waitFor(() => {
+    expect(connectionListener).toHaveBeenCalledTimes(1)
+  })
+
+  interceptor.dispose()
+
+  const socket = new WebSocket(getWsUrl(wsServer))
+  const openListener = vi.fn()
+  socket.onopen = openListener
+
+  await vi.waitFor(() => {
+    expect(openListener).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Calling `.revoke()` on a revocable Proxy _does not restore its impementation_. I was wrong to assume that. It simply blows up the proxy object so _any object operations that result in a trap **throw**_. 

Also added a test to ensure that the restored `WebSocket` class is fully operational after the interceptor is disposed. 