### PR TITLE
fix(WebSocket): emit "connection" event on the next tick

### DIFF
--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -26,7 +26,7 @@ export type WebSocketEventMap = {
        * The original WebSocket server connection.
        */
       server: WebSocketServerConnection
-    },
+    }
   ]
 }
 
@@ -68,16 +68,21 @@ export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
         const socket = new WebSocketOverride(url, protocols)
         const transport = new WebSocketClassTransport(socket)
 
-        // The "globalThis.WebSocket" class stands for
-        // the client-side connection. Assume it's established
-        // as soon as the WebSocket instance is constructed.
-        this.emitter.emit('connection', {
-          client: new WebSocketClientConnection(socket, transport),
-          server: new WebSocketServerConnection(
-            socket,
-            transport,
-            createConnection
-          ),
+        // Emit the "connection" event to the interceptor on the next tick
+        // so the client can modify WebSocket options, like "binaryType"
+        // while the connection is already pending.
+        queueMicrotask(() => {
+          // The "globalThis.WebSocket" class stands for
+          // the client-side connection. Assume it's established
+          // as soon as the WebSocket instance is constructed.
+          this.emitter.emit('connection', {
+            client: new WebSocketClientConnection(socket, transport),
+            server: new WebSocketServerConnection(
+              socket,
+              transport,
+              createConnection
+            ),
+          })
         })
 
         return socket

--- a/test/modules/WebSocket/compliance/websocket.connection.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.connection.test.ts
@@ -4,6 +4,7 @@
 import { vi, it, expect, beforeAll, afterAll } from 'vitest'
 import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket/index'
 import { UUID_REGEXP } from '../../../helpers'
+import { waitForNextTick } from '../utils/waitForNextTick'
 
 const interceptor = new WebSocketInterceptor()
 
@@ -15,30 +16,35 @@ afterAll(() => {
   interceptor.dispose()
 })
 
-it('emits the correct connection event', async () => {
+it('emits the correct "connection" event on the interceptor', async () => {
   const connectionListener = vi.fn()
   interceptor.once('connection', connectionListener)
 
   new WebSocket('wss://example.com')
 
-  await vi.waitFor(() => {
-    expect(connectionListener).toHaveBeenCalledTimes(1)
-    expect(connectionListener).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        client: expect.objectContaining({
-          id: expect.stringMatching(UUID_REGEXP),
-          send: expect.any(Function),
-          addEventListener: expect.any(Function),
-          removeEventListener: expect.any(Function),
-          close: expect.any(Function),
-        }),
-        server: expect.objectContaining({
-          send: expect.any(Function),
-          addEventListener: expect.any(Function),
-          removeEventListener: expect.any(Function),
-        }),
-      })
-    )
-  })
+  // Must not emit the "connection" event on this tick.
+  expect(connectionListener).toHaveBeenCalledTimes(0)
+
+  await waitForNextTick()
+
+  // Must emit the "connection" event on the next tick
+  // so the client can modify the WebSocket instance meanwhile.
+  expect(connectionListener).toHaveBeenCalledTimes(1)
+  expect(connectionListener).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({
+      client: expect.objectContaining({
+        id: expect.stringMatching(UUID_REGEXP),
+        send: expect.any(Function),
+        addEventListener: expect.any(Function),
+        removeEventListener: expect.any(Function),
+        close: expect.any(Function),
+      }),
+      server: expect.objectContaining({
+        send: expect.any(Function),
+        addEventListener: expect.any(Function),
+        removeEventListener: expect.any(Function),
+      }),
+    })
+  )
 })


### PR DESCRIPTION
Right now, the `connection` event is emitted to the interceptors on the same tick as the WebSocket instance is created. It makes it impossible to observe the changes to that instance while connecting. 

For example, the client may set a different `.binaryType` on the socket _after_ it's constructed (i.e. starts connecting):

```js
const socket = new WebSocket(url)
socket.binaryType = 'arraybuffer'
```

For the interceptor to know about that change, we have to emit the connection event on the next tick, when any modifications to the socket are complete (including the event listeners). 

This will allow us to properly inherit `.binaryType` on the real socket when calling `server.connect()`. This also gives us a behavior similar to production code, where the `open` event will always be emitted on the next tick. The `connection` interceptor event must _not_ be emitted before the open event. 