### PR TITLE
fix(WebSocket): inherit "binaryType" for original server connections

### DIFF
--- a/src/interceptors/WebSocket/WebSocketServerConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketServerConnection.ts
@@ -103,6 +103,9 @@ export class WebSocketServerConnection {
 
     const ws = this.createConnection()
 
+    // Inherit the binary type from the mock WebSocket client.
+    ws.binaryType = this.socket.binaryType
+
     // Close the original connection when the (mock)
     // client closes, regardless of the reason.
     this.socket.addEventListener(


### PR DESCRIPTION
Right now, if the client sets a custom `.binaryType` on the socket, the original server connection socket will ignore that. 

I'm adding the inheritance of the `.binaryType` property from the mock WebSocket instance to the original WebSocket instance (relevant only in the `server.connect()` scenario). 