### PR TITLE
fix(ws): make "WebSocket" reference (client.socket) public

### DIFF
--- a/src/interceptors/WebSocket/WebSocketClientConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketClientConnection.ts
@@ -34,7 +34,7 @@ export class WebSocketClientConnection
   private [kEmitter]: EventTarget
 
   constructor(
-    private readonly socket: WebSocket,
+    public readonly socket: WebSocket,
     private readonly transport: WebSocketTransport
   ) {
     this.id = uuidv4()


### PR DESCRIPTION
I think it's a good idea to expose the original `WebSocket` instance on the `client` connection object. We also use it in MSW to add the `message` listeners for logging. 