### PR TITLE
fix(WebSocket): export "WebSocketConnectionData" type

### DIFF
--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -15,19 +15,19 @@ export {
 }
 
 export type WebSocketEventMap = {
-  connection: [
-    args: {
-      /**
-       * The incoming WebSocket client connection.
-       */
-      client: WebSocketClientConnection
+  connection: [args: WebSocketConnectionData]
+}
 
-      /**
-       * The original WebSocket server connection.
-       */
-      server: WebSocketServerConnection
-    }
-  ]
+export type WebSocketConnectionData = {
+  /**
+   * The incoming WebSocket client connection.
+   */
+  client: WebSocketClientConnection
+
+  /**
+   * The original WebSocket server connection.
+   */
+  server: WebSocketServerConnection
 }
 
 /**


### PR DESCRIPTION
It's quite annoying to annotate the `client`/`server` types manually whenever you need them in collocation (e.g. when forwarding/handling the emitted `connection` event). Let's export it as-is. 