### PR TITLE
fix(WebSocket): add "server.close()" method

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,8 +292,8 @@ interceptor.on(
 
 You can intercept a WebSocket communication using the `WebSocketInterceptor` class.
 
-> [!WARNING]
-> In practice, WebSocket connections can use different mechanisms to work (called "transports"). At this moment, the WebSocket interceptor only supports connections established using the `globalThis.WebSocket` class. Supporting third-party transports is challenging because they are non-standard and specific to individual WebSocket client libraries.
+> [!IMPORTANT]
+> This library only supports intercepting WebSocket connections created using the global WHATWG `WebSocket` class. Third-party transports, such as HTTP/XHR polling, are not supported by design due to their contrived nature.
 
 ```js
 import { WebSocketInterceptor } from '@mswjs/interceptors/WebSocket'
@@ -302,6 +302,13 @@ const interceptor = new WebSocketInterceptor()
 ```
 
 Unlike the HTTP-based interceptors that share the same `request`/`response` events, the WebSocket interceptor only emits the `connection` event and let's you handle the incoming/outgoing events in its listener.
+
+### Important defaults
+
+1. Intercepted WebSocket connections are _not_ opened. To open the actual WebSocket connection, call [`server.connect()`](#connect) in the interceptor.
+1. Once connected to the actual server, the outgoing client events are _not_ forwarded to that server. You must add a message listener for the `client` and forward the events manually using [`server.send()`](#senddata-1).
+1. Once connected to the actual server, the incoming server events _are_ forwarded to the client by default. You can prevent that forwarding by calling `event.preventDefault()` in the message event listener for the `server`.
+1. Once connected to the actual server, the `close` event received from that server is forwarded to the intercepted client by default. You can prevent that forwarding by calling `event.preventDefault()` in the close event listener for the `server`.
 
 ### WebSocket connection
 

--- a/src/interceptors/WebSocket/WebSocketServerConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketServerConnection.ts
@@ -168,6 +168,7 @@ export class WebSocketServerConnection {
    */
   public send(data: WebSocketData): void {
     const { realWebSocket } = this
+
     invariant(
       realWebSocket,
       'Failed to call "server.send()" for "%s": the connection is not open. Did you forget to call "await server.connect()"?',
@@ -190,5 +191,27 @@ export class WebSocketServerConnection {
 
     // Send the data to the original WebSocket server.
     realWebSocket.send(data)
+  }
+
+  /**
+   * Close the actual server connection.
+   */
+  public close(): void {
+    const { realWebSocket } = this
+
+    invariant(
+      realWebSocket,
+      'Failed to close server connection for "%s": the connection is not open. Did you forget to call "server.connect()"?',
+      this.socket.url
+    )
+
+    if (
+      realWebSocket.readyState === realWebSocket.CLOSING ||
+      realWebSocket.readyState === realWebSocket.CLOSED
+    ) {
+      return
+    }
+
+    realWebSocket.close()
   }
 }

--- a/src/interceptors/WebSocket/WebSocketServerConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketServerConnection.ts
@@ -175,10 +175,18 @@ export class WebSocketServerConnection {
       this.socket.url
     )
 
+    // Silently ignore writes on the closed original WebSocket.
+    if (
+      realWebSocket.readyState === WebSocket.CLOSING ||
+      realWebSocket.readyState === WebSocket.CLOSED
+    ) {
+      return
+    }
+
     // Delegate the send to when the original connection is open.
     // Unlike the mock, connecting to the original server may take time
     // so we cannot call this on the next tick.
-    if (realWebSocket.readyState === realWebSocket.CONNECTING) {
+    if (realWebSocket.readyState === WebSocket.CONNECTING) {
       realWebSocket.addEventListener(
         'open',
         () => {
@@ -206,8 +214,8 @@ export class WebSocketServerConnection {
     )
 
     if (
-      realWebSocket.readyState === realWebSocket.CLOSING ||
-      realWebSocket.readyState === realWebSocket.CLOSED
+      realWebSocket.readyState === WebSocket.CLOSING ||
+      realWebSocket.readyState === WebSocket.CLOSED
     ) {
       return
     }

--- a/test/modules/WebSocket/compliance/websocket.server.close.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.server.close.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment node-with-websocket
+ */
+import { DeferredPromise } from '@open-draft/deferred-promise'
+import { RawData } from 'engine.io-parser'
+import { vi, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import { WebSocketServer } from 'ws'
+import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket/index'
+import { getWsUrl } from '../utils/getWsUrl'
+import { waitForNextTick } from '../utils/waitForNextTick'
+
+const interceptor = new WebSocketInterceptor()
+
+const wsServer = new WebSocketServer({
+  host: '127.0.0.1',
+  port: 0,
+})
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterEach(() => {
+  wsServer.clients.forEach((client) => client.close())
+})
+
+afterAll(() => {
+  interceptor.dispose()
+  wsServer.close()
+})
+
+it('closes the actual server connection when called "server.close()"', async () => {
+  const clientOpenPromise = new DeferredPromise<void>()
+  const serverCallback = vi.fn<[number]>()
+  const clientMessageListener = vi.fn<[RawData]>()
+
+  wsServer.on('connection', (client) => {
+    client.addEventListener('message', (event) => {
+      clientMessageListener(event.data)
+    })
+  })
+
+  interceptor.on('connection', ({ client, server }) => {
+    server.connect()
+    serverCallback(server.readyState)
+
+    client.addEventListener('message', (event) => {
+      server.send(event.data)
+    })
+
+    /**
+     * @fixme Tapping into internals isn't nice.
+     */
+    server['realWebSocket']?.addEventListener('close', () => {
+      serverCallback(server.readyState)
+    })
+
+    client.addEventListener('message', (event) => {
+      if (event.data === 'close-server') {
+        server.close()
+      }
+    })
+  })
+
+  const ws = new WebSocket(getWsUrl(wsServer))
+  ws.onopen = () => clientOpenPromise.resolve()
+  ws.onerror = () => clientOpenPromise.reject()
+  await clientOpenPromise
+
+  // Must forward the client messages to the original server.
+  ws.send('hello from client')
+  await vi.waitFor(() => {
+    expect(clientMessageListener).toHaveBeenCalledWith('hello from client')
+  })
+
+  // Must close the server connection once "server.close()" is called.
+  ws.send('close-server')
+  await vi.waitFor(() => {
+    expect(serverCallback).toHaveBeenLastCalledWith(WebSocket.CLOSED)
+  })
+
+  // Must not forward the client messages to the original server
+  // after the connection has been closed.
+  ws.send('another hello')
+  await waitForNextTick()
+  expect(clientMessageListener).not.toHaveBeenCalledWith('another hello')
+})

--- a/test/modules/WebSocket/utils/waitForWebSocketEvent.ts
+++ b/test/modules/WebSocket/utils/waitForWebSocketEvent.ts
@@ -1,0 +1,14 @@
+import { DeferredPromise } from '@open-draft/deferred-promise'
+
+/**
+ * Returns a Promise that resolves when the given WebSocket
+ * instance emits the said event.
+ */
+export function waitForWebSocketEvent<Type extends keyof WebSocketEventMap>(
+  type: Type,
+  ws: WebSocket
+) {
+  const eventPromise = new DeferredPromise<void>()
+  ws.addEventListener(type, () => eventPromise.resolve(), { once: true })
+  return eventPromise
+}

--- a/test/modules/http/response/readable-stream.test.ts
+++ b/test/modules/http/response/readable-stream.test.ts
@@ -1,3 +1,4 @@
+import { performance } from 'node:perf_hooks'
 import { it, expect, beforeAll, afterAll } from 'vitest'
 import https from 'https'
 import { DeferredPromise } from '@open-draft/deferred-promise'
@@ -52,7 +53,7 @@ it('supports delays when enqueuing chunks', async () => {
       .on('data', (data) => {
         chunks.push({
           buffer: Buffer.from(data),
-          timestamp: Date.now(),
+          timestamp: performance.now(),
         })
       })
       .on('end', () => {


### PR DESCRIPTION
Allows closing the actual server connection by adding a new `server.close()` method. 

## Todo

- [x] Allow listening to the `server.addEventListener('close')` to know when the original server closes the connection. 
- [x] Using a special close reason for closures via `server.close()` isn't that nice. Consider a different logic? For example, properly awaiting the close frame and _then_ doing the `server.connect()` would solve this. 