### PR TITLE
fix(WebSocket): forward "close" event to WebSocketClientConnection

### DIFF
--- a/src/interceptors/WebSocket/WebSocketClientConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketClientConnection.ts
@@ -6,11 +6,16 @@
  * (not all of them follow the one from WHATWG).
  */
 import type { WebSocketData, WebSocketTransport } from './WebSocketTransport'
-import { WebSocketMessageListener } from './WebSocketOverride'
+import { WebSocketEventListener } from './WebSocketOverride'
 import { bindEvent } from './utils/bindEvent'
 import { CloseEvent } from './utils/events'
 
 const kEmitter = Symbol('kEmitter')
+
+interface WebSocketClientEventMap {
+  message: MessageEvent<WebSocketData>
+  close: CloseEvent
+}
 
 export interface WebSocketClientConnectionProtocol {
   id: string
@@ -58,20 +63,20 @@ export class WebSocketClientConnection
   /**
    * Listen for the outgoing events from the connected WebSocket client.
    */
-  public addEventListener(
-    event: string,
-    listener: WebSocketMessageListener,
+  public addEventListener<EventType extends keyof WebSocketClientEventMap>(
+    type: EventType,
+    listener: WebSocketEventListener<WebSocketClientEventMap[EventType]>,
     options?: AddEventListenerOptions | boolean
   ): void {
-    this[kEmitter].addEventListener(event, listener as EventListener, options)
+    this[kEmitter].addEventListener(type, listener as EventListener, options)
   }
 
   /**
    * Removes the listener for the given event.
    */
-  public removeEventListener(
-    event: string,
-    listener: WebSocketMessageListener,
+  public removeEventListener<EventType extends keyof WebSocketClientEventMap>(
+    event: EventType,
+    listener: WebSocketEventListener<WebSocketClientEventMap[EventType]>,
     options?: EventListenerOptions | boolean
   ): void {
     this[kEmitter].removeEventListener(

--- a/src/interceptors/WebSocket/WebSocketOverride.ts
+++ b/src/interceptors/WebSocket/WebSocketOverride.ts
@@ -3,14 +3,9 @@ import type { WebSocketData } from './WebSocketTransport'
 import { bindEvent } from './utils/bindEvent'
 import { CloseEvent } from './utils/events'
 
-type WebSocketEventListener = (this: WebSocket, event: Event) => void
-
-export type WebSocketMessageListener = (
-  this: WebSocket,
-  event: MessageEvent
-) => void
-
-type WebSocketCloseListener = (this: WebSocket, event: CloseEvent) => void
+export type WebSocketEventListener<
+  T extends WebSocketEventMap[keyof WebSocketEventMap] = Event,
+> = (this: WebSocket, event: T) => void
 
 const WEBSOCKET_CLOSE_CODE_RANGE_ERROR =
   'InvalidAccessError: close code out of user configurable range'
@@ -36,9 +31,11 @@ export class WebSocketOverride extends EventTarget implements WebSocket {
   public bufferedAmount: number
 
   private _onopen: WebSocketEventListener | null = null
-  private _onmessage: WebSocketMessageListener | null = null
+  private _onmessage: WebSocketEventListener<
+    MessageEvent<WebSocketData>
+  > | null = null
   private _onerror: WebSocketEventListener | null = null
-  private _onclose: WebSocketCloseListener | null = null
+  private _onclose: WebSocketEventListener<CloseEvent> | null = null
 
   private [kOnSend]?: (data: WebSocketData) => void
 
@@ -71,7 +68,9 @@ export class WebSocketOverride extends EventTarget implements WebSocket {
     return this._onopen
   }
 
-  set onmessage(listener: WebSocketMessageListener | null) {
+  set onmessage(
+    listener: WebSocketEventListener<MessageEvent<WebSocketData>> | null
+  ) {
     this.removeEventListener(
       'message',
       this._onmessage as WebSocketEventListener
@@ -81,7 +80,7 @@ export class WebSocketOverride extends EventTarget implements WebSocket {
       this.addEventListener('message', listener)
     }
   }
-  get onmessage(): WebSocketMessageListener | null {
+  get onmessage(): WebSocketEventListener<MessageEvent<WebSocketData>> | null {
     return this._onmessage
   }
 
@@ -96,14 +95,14 @@ export class WebSocketOverride extends EventTarget implements WebSocket {
     return this._onerror
   }
 
-  set onclose(listener: WebSocketCloseListener | null) {
+  set onclose(listener: WebSocketEventListener<CloseEvent> | null) {
     this.removeEventListener('close', this._onclose as WebSocketEventListener)
     this._onclose = listener
     if (listener !== null) {
       this.addEventListener('close', listener)
     }
   }
-  get onclose(): WebSocketCloseListener | null {
+  get onclose(): WebSocketEventListener<CloseEvent> | null {
     return this._onclose
   }
 

--- a/test/modules/WebSocket/compliance/websocket.client.events.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.client.events.test.ts
@@ -41,11 +41,16 @@ it('emits "close" event when the client closes itself', async () => {
   })
 
   const ws = new WebSocket('wss://localhost')
-  ws.onopen = () => ws.close()
+  ws.onopen = () => ws.close(3123)
 
   await vi.waitFor(() => {
     expect(closeListener).toHaveBeenCalledWith(
-      expect.objectContaining({ target: ws })
+      expect.objectContaining({
+        code: 3123,
+        reason: '',
+        wasClean: false,
+        target: ws,
+      })
     )
     expect(closeListener).toHaveBeenCalledTimes(1)
   })

--- a/test/modules/WebSocket/compliance/websocket.client.events.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.client.events.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment node-with-websocket
+ */
+import { vi, it, expect, beforeAll, afterAll } from 'vitest'
+import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket'
+
+const interceptor = new WebSocketInterceptor()
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+})
+
+it('emits "message" event when the client sends data', async () => {
+  const messageListener = vi.fn()
+  interceptor.once('connection', ({ client }) => {
+    client.addEventListener('message', messageListener)
+  })
+
+  const ws = new WebSocket('wss://localhost')
+  ws.onopen = () => ws.send('hello')
+
+  await vi.waitFor(() => {
+    expect(messageListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: 'hello',
+        target: ws,
+      })
+    )
+    expect(messageListener).toHaveBeenCalledTimes(1)
+  })
+})
+
+it('emits "close" event when the client closes itself', async () => {
+  const closeListener = vi.fn()
+  interceptor.once('connection', ({ client }) => {
+    client.addEventListener('close', closeListener)
+  })
+
+  const ws = new WebSocket('wss://localhost')
+  ws.onopen = () => ws.close()
+
+  await vi.waitFor(() => {
+    expect(closeListener).toHaveBeenCalledWith(
+      expect.objectContaining({ target: ws })
+    )
+    expect(closeListener).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
- Also annotates the accepted event types on `client.addEventListener()`/`client.removeEventListener()`. 

Allow the interceptor to listen to the WebSocket client close events because the client can close itself as well. 