### PR TITLE
fix(WebSocket): set correct "currentTarget" on client events

### DIFF
--- a/src/interceptors/WebSocket/utils/bindEvent.ts
+++ b/src/interceptors/WebSocket/utils/bindEvent.ts
@@ -4,10 +4,18 @@ export function bindEvent<E extends Event, T>(
   target: T,
   event: E
 ): EventWithTarget<E, T> {
-  Object.defineProperty(event, 'target', {
-    enumerable: true,
-    writable: true,
-    value: target,
+  Object.defineProperties(event, {
+    target: {
+      value: target,
+      enumerable: true,
+      writable: true,
+    },
+    currentTarget: {
+      value: target,
+      enumerable: true,
+      writable: true,
+    },
   })
+
   return event as EventWithTarget<E, T>
 }

--- a/test/modules/WebSocket/compliance/websocket.events.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.events.test.ts
@@ -1,5 +1,7 @@
 /**
  * @vitest-environment node-with-websocket
+ * This test suite asserts that the intercepted WebSocket client
+ * still dispatches the correct events in mocked/bypassed scenarios.
  */
 import { it, expect, beforeAll, afterAll } from 'vitest'
 import { DeferredPromise } from '@open-draft/deferred-promise'


### PR DESCRIPTION
- Fixes #524 