### PR TITLE
feat(WebSocket): forward client messages to the server by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,10 +305,10 @@ Unlike the HTTP-based interceptors that share the same `request`/`response` even
 
 ### Important defaults
 
-1. Intercepted WebSocket connections are _not_ opened. To open the actual WebSocket connection, call [`server.connect()`](#connect) in the interceptor.
-1. Once connected to the actual server, the outgoing client events are _not_ forwarded to that server. You must add a message listener for the `client` and forward the events manually using [`server.send()`](#senddata-1).
-1. Once connected to the actual server, the incoming server events _are_ forwarded to the client by default. You can prevent that forwarding by calling `event.preventDefault()` in the message event listener for the `server`.
-1. Once connected to the actual server, the `close` event received from that server is forwarded to the intercepted client by default. You can prevent that forwarding by calling `event.preventDefault()` in the close event listener for the `server`.
+1. Intercepted WebSocket connections are _not opened_. To open the actual WebSocket connection, call [`server.connect()`](#connect) in the interceptor.
+1. Once connected to the actual server, the outgoing client events are _forwarded to that server by default_. If you wish to prevent a client message from reaching the server, call `event.preventDefault()` for that client message event.
+1. Once connected to the actual server, the incoming server events are _forwarded to the client by default_. If you wish to prevent a server message from reaching the client, call `event.preventDefault()` for the server message event.
+1. Once connected to the actual server, the `close` event received from that server is _forwarded to the client by default_. If you wish to prevent that, call `event.preventDefault()` for that close event of the server.
 
 ### WebSocket connection
 

--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
   "scripts": {
     "start": "tsc --build -w",
     "test": "pnpm test:unit && pnpm test:integration",
-    "test:unit": "vitest run",
+    "test:unit": "vitest",
     "test:integration": "pnpm test:node && pnpm test:browser",
-    "test:node": "vitest run -c test/vitest.config.js",
+    "test:node": "vitest -c test/vitest.config.js",
     "test:browser": "pnpm playwright test -c test/playwright.config.ts",
     "clean": "rimraf lib",
     "build": "pnpm clean && cross-env NODE_ENV=production tsup --splitting",

--- a/src/interceptors/WebSocket/WebSocketClassTransport.ts
+++ b/src/interceptors/WebSocket/WebSocketClassTransport.ts
@@ -6,7 +6,7 @@ import {
   WebSocketTransportEventMap,
 } from './WebSocketTransport'
 import { kOnSend, kClose, WebSocketOverride } from './WebSocketOverride'
-import { CloseEvent } from './utils/events'
+import { CancelableMessageEvent, CloseEvent } from './utils/events'
 
 /**
  * Abstraction over the given mock `WebSocket` instance that allows
@@ -34,9 +34,12 @@ export class WebSocketClassTransport
       this.dispatchEvent(
         bindEvent(
           this.socket,
-          new MessageEvent('outgoing', {
+          // Dispatch this as cancelable because "client" connection
+          // re-creates this message event (cannot dispatch the same event).
+          new CancelableMessageEvent('outgoing', {
             data,
             origin: this.socket.url,
+            cancelable: true,
           })
         )
       )

--- a/src/interceptors/WebSocket/WebSocketClassTransport.ts
+++ b/src/interceptors/WebSocket/WebSocketClassTransport.ts
@@ -1,50 +1,83 @@
 import { bindEvent } from './utils/bindEvent'
 import {
+  StrictEventListenerOrEventListenerObject,
   WebSocketData,
   WebSocketTransport,
-  WebSocketTransportOnCloseCallback,
-  WebSocketTransportOnIncomingCallback,
-  WebSocketTransportOnOutgoingCallback,
+  WebSocketTransportEventMap,
 } from './WebSocketTransport'
 import { kOnSend, kClose, WebSocketOverride } from './WebSocketOverride'
+import { CloseEvent } from './utils/events'
 
 /**
  * Abstraction over the given mock `WebSocket` instance that allows
  * for controlling that instance (e.g. sending and receiving messages).
  */
-export class WebSocketClassTransport extends WebSocketTransport {
-  public onOutgoing: WebSocketTransportOnOutgoingCallback = () => {}
-  public onIncoming: WebSocketTransportOnIncomingCallback = () => {}
-  public onClose: WebSocketTransportOnCloseCallback = () => {}
-
+export class WebSocketClassTransport
+  extends EventTarget
+  implements WebSocketTransport
+{
   constructor(protected readonly socket: WebSocketOverride) {
     super()
 
-    this.socket.addEventListener('close', (event) => this.onClose(event), {
-      once: true,
+    // Emit the "close" event on the transport if the close
+    // originates from the WebSocket client. E.g. the application
+    // calls "ws.close()", not the interceptor.
+    this.socket.addEventListener('close', (event) => {
+      this.dispatchEvent(bindEvent(this.socket, new CloseEvent('close', event)))
     })
-    this.socket[kOnSend] = (...args) => this.onOutgoing(...args)
+
+    /**
+     * Emit the "outgoing" event on the transport
+     * whenever the WebSocket client sends data ("ws.send()").
+     */
+    this.socket[kOnSend] = (data) => {
+      this.dispatchEvent(
+        bindEvent(
+          this.socket,
+          new MessageEvent('outgoing', {
+            data,
+            origin: this.socket.url,
+          })
+        )
+      )
+    }
+  }
+
+  public addEventListener<EventType extends keyof WebSocketTransportEventMap>(
+    type: EventType,
+    callback: StrictEventListenerOrEventListenerObject<
+      WebSocketTransportEventMap[EventType]
+    > | null,
+    options?: boolean | AddEventListenerOptions
+  ): void {
+    return super.addEventListener(type, callback as EventListener, options)
+  }
+
+  public dispatchEvent<EventType extends keyof WebSocketTransportEventMap>(
+    event: WebSocketTransportEventMap[EventType]
+  ): boolean {
+    return super.dispatchEvent(event)
   }
 
   public send(data: WebSocketData): void {
     queueMicrotask(() => {
-      const message = bindEvent(
-        /**
-         * @note Setting this event's "target" to the
-         * WebSocket override instance is important.
-         * This way it can tell apart original incoming events
-         * (must be forwarded to the transport) from the
-         * mocked message events like the one below
-         * (must be dispatched on the client instance).
-         */
-        this.socket,
-        new MessageEvent('message', {
-          data,
-          origin: this.socket.url,
-        })
+      this.socket.dispatchEvent(
+        bindEvent(
+          /**
+           * @note Setting this event's "target" to the
+           * WebSocket override instance is important.
+           * This way it can tell apart original incoming events
+           * (must be forwarded to the transport) from the
+           * mocked message events like the one below
+           * (must be dispatched on the client instance).
+           */
+          this.socket,
+          new MessageEvent('message', {
+            data,
+            origin: this.socket.url,
+          })
+        )
       )
-
-      this.socket.dispatchEvent(message)
     })
   }
 

--- a/src/interceptors/WebSocket/WebSocketClientConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketClientConnection.ts
@@ -1,14 +1,7 @@
-/**
- * WebSocket client class.
- * This represents an incoming WebSocket client connection.
- * @note Keep this class implementation-agnostic because it's
- * meant to be used over any WebSocket implementation
- * (not all of them follow the one from WHATWG).
- */
 import type { WebSocketData, WebSocketTransport } from './WebSocketTransport'
 import { WebSocketEventListener } from './WebSocketOverride'
 import { bindEvent } from './utils/bindEvent'
-import { CloseEvent } from './utils/events'
+import { CancelableMessageEvent, CloseEvent } from './utils/events'
 import { createRequestId } from '../../createRequestId'
 
 const kEmitter = Symbol('kEmitter')
@@ -47,18 +40,33 @@ export class WebSocketClientConnection
     this[kEmitter] = new EventTarget()
 
     // Emit outgoing client data ("ws.send()") as "message"
-    // events on the client connection.
-    this.transport.onOutgoing = (data) => {
+    // events on the "client" connection.
+    this.transport.addEventListener('outgoing', (event) => {
       this[kEmitter].dispatchEvent(
-        bindEvent(this.socket, new MessageEvent('message', { data }))
+        bindEvent(
+          this.socket,
+          new CancelableMessageEvent('message', {
+            data: event.data,
+            origin: event.origin,
+            cancelable: true,
+          })
+        )
       )
-    }
+    })
 
-    this.transport.onClose = (event) => {
+    /**
+     * Emit the "close" event on the "client" connection
+     * whenever the underlying transport is closed.
+     * @note "client.close()" does NOT dispatch the "close"
+     * event on the WebSocket because it uses non-configurable
+     * close status code. Thus, we listen to the transport
+     * instead of the WebSocket's "close" event.
+     */
+    this.transport.addEventListener('close', (event) => {
       this[kEmitter].dispatchEvent(
         bindEvent(this.socket, new CloseEvent('close', event))
       )
-    }
+    })
   }
 
   /**

--- a/src/interceptors/WebSocket/WebSocketOverride.ts
+++ b/src/interceptors/WebSocket/WebSocketOverride.ts
@@ -4,8 +4,8 @@ import { bindEvent } from './utils/bindEvent'
 import { CloseEvent } from './utils/events'
 
 export type WebSocketEventListener<
-  T extends WebSocketEventMap[keyof WebSocketEventMap] = Event,
-> = (this: WebSocket, event: T) => void
+  EventType extends WebSocketEventMap[keyof WebSocketEventMap] = Event
+> = (this: WebSocket, event: EventType) => void
 
 const WEBSOCKET_CLOSE_CODE_RANGE_ERROR =
   'InvalidAccessError: close code out of user configurable range'

--- a/src/interceptors/WebSocket/WebSocketTransport.ts
+++ b/src/interceptors/WebSocket/WebSocketTransport.ts
@@ -1,40 +1,39 @@
+import { CloseEvent } from './utils/events'
+
 export type WebSocketData = string | ArrayBufferLike | Blob | ArrayBufferView
 
-export type WebSocketTransportOnIncomingCallback = (
-  event: MessageEvent<WebSocketData>
-) => void
+export type WebSocketTransportEventMap = {
+  incoming: MessageEvent<WebSocketData>
+  outgoing: MessageEvent<WebSocketData>
+  close: CloseEvent
+}
 
-export type WebSocketTransportOnOutgoingCallback = (data: WebSocketData) => void
+export type StrictEventListenerOrEventListenerObject<EventType extends Event> =
+  | ((event: EventType) => void)
+  | {
+      handleEvent(event: EventType): void
+    }
 
-export type WebSocketTransportOnCloseCallback = (event: CloseEvent) => void
+export interface WebSocketTransport {
+  addEventListener<EventType extends keyof WebSocketTransportEventMap>(
+    event: EventType,
+    listener: StrictEventListenerOrEventListenerObject<
+      WebSocketTransportEventMap[EventType]
+    > | null,
+    options?: boolean | AddEventListenerOptions
+  ): void
 
-export abstract class WebSocketTransport {
-  /**
-   * A callback for the incoming server events.
-   * This is called when the WebSocket client receives
-   * a message from the server.
-   */
-  abstract onIncoming: WebSocketTransportOnIncomingCallback
-
-  /**
-   * A callback for outgoing client events.
-   * This is called when the WebSocket client sends data.
-   */
-  abstract onOutgoing: WebSocketTransportOnOutgoingCallback
-
-  /**
-   * A callback for the close client event.
-   * This is called when the WebSocket client is closed.
-   */
-  abstract onClose: WebSocketTransportOnCloseCallback
+  dispatchEvent<EventType extends keyof WebSocketTransportEventMap>(
+    event: WebSocketTransportEventMap[EventType]
+  ): boolean
 
   /**
    * Send the data from the server to this client.
    */
-  abstract send(data: WebSocketData): void
+  send(data: WebSocketData): void
 
   /**
    * Close the client connection.
    */
-  abstract close(code?: number, reason?: string): void
+  close(code?: number, reason?: string): void
 }

--- a/test/modules/WebSocket/compliance/websocket.send.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.send.test.ts
@@ -60,7 +60,7 @@ it('sends text data to the original server', async () => {
     })
   })
 
-  interceptor.once('connection', ({ client, server }) => {
+  interceptor.once('connection', ({ server }) => {
     server.connect()
   })
 
@@ -85,7 +85,7 @@ it('sends Blob data to the original server', async () => {
     })
   })
 
-  interceptor.once('connection', ({ client, server }) => {
+  interceptor.once('connection', ({ server }) => {
     server.connect()
   })
 
@@ -111,7 +111,7 @@ it('sends ArrayBuffer data to the original server', async () => {
     ws.on('message', (data) => messagePromise.resolve(data))
   })
 
-  interceptor.once('connection', ({ client, server }) => {
+  interceptor.once('connection', ({ server }) => {
     server.connect()
   })
 

--- a/test/modules/WebSocket/compliance/websocket.send.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.send.test.ts
@@ -62,7 +62,6 @@ it('sends text data to the original server', async () => {
 
   interceptor.once('connection', ({ client, server }) => {
     server.connect()
-    client.addEventListener('message', (event) => server.send(event.data))
   })
 
   const ws = new WebSocket(getWsUrl(wsServer))
@@ -88,7 +87,6 @@ it('sends Blob data to the original server', async () => {
 
   interceptor.once('connection', ({ client, server }) => {
     server.connect()
-    client.addEventListener('message', (event) => server.send(event.data))
   })
 
   const ws = new WebSocket(getWsUrl(wsServer))
@@ -115,7 +113,6 @@ it('sends ArrayBuffer data to the original server', async () => {
 
   interceptor.once('connection', ({ client, server }) => {
     server.connect()
-    client.addEventListener('message', (event) => server.send(event.data))
   })
 
   const ws = new WebSocket(getWsUrl(wsServer))

--- a/test/modules/WebSocket/compliance/websocket.server.connect.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.server.connect.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment node-with-websocket
+ */
+import { vi, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import { Data, WebSocketServer } from 'ws'
+import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket'
+import { getWsUrl } from '../utils/getWsUrl'
+import { waitForWebSocketEvent } from '../utils/waitForWebSocketEvent'
+
+const interceptor = new WebSocketInterceptor()
+
+const wsServer = new WebSocketServer({
+  host: '127.0.0.1',
+  port: 0,
+})
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterEach(() => {
+  wsServer.clients.forEach((client) => client.close(1000))
+})
+
+afterAll(() => {
+  interceptor.dispose()
+  wsServer.close()
+})
+
+it('forwards client messages to the server by default', async () => {
+  const messageListener = vi.fn<[Data]>()
+
+  wsServer.once('connection', (ws) => {
+    ws.addEventListener('message', (event) => {
+      messageListener(event.data)
+
+      if (event.data === 'howdy') {
+        ws.close()
+      }
+    })
+  })
+
+  interceptor.once('connection', ({ client, server }) => {
+    server.connect()
+  })
+
+  const ws = new WebSocket(getWsUrl(wsServer))
+  ws.onopen = () => {
+    ws.send('hello')
+    ws.send('howdy')
+  }
+  await waitForWebSocketEvent('close', ws)
+
+  expect(messageListener).toHaveBeenCalledWith('hello')
+  expect(messageListener).toHaveBeenCalledWith('howdy')
+  expect(messageListener).toHaveBeenCalledTimes(2)
+})
+
+it('prevents client-to-server forwarding by calling "event.preventDefault()"', async () => {
+  const messageListener = vi.fn<[Data]>()
+
+  wsServer.once('connection', (ws) => {
+    ws.addEventListener('message', (event) => {
+      messageListener(event.data)
+
+      if (event.data === 'howdy') {
+        ws.close()
+      }
+    })
+  })
+
+  interceptor.once('connection', ({ client, server }) => {
+    server.connect()
+
+    client.addEventListener('message', (event) => {
+      if (event.data === 'prevent-this') {
+        event.preventDefault()
+      }
+    })
+  })
+
+  const ws = new WebSocket(getWsUrl(wsServer))
+  ws.onopen = () => {
+    ws.send('hello')
+    ws.send('prevent-this')
+    ws.send('howdy')
+  }
+  await waitForWebSocketEvent('close', ws)
+
+  expect(messageListener).toHaveBeenCalledWith('hello')
+  expect(messageListener).toHaveBeenCalledWith('howdy')
+  expect(messageListener).not.toHaveBeenCalledWith('prevent-this')
+})

--- a/test/modules/WebSocket/exchange/websocket.server.connect.browser.test.ts
+++ b/test/modules/WebSocket/exchange/websocket.server.connect.browser.test.ts
@@ -57,7 +57,7 @@ test('forwards incoming server data from the original server', async ({
   expect(receivedString).toBe('hello from server')
 })
 
-test('forwards outgoing client data to the original server', async ({
+test('forwards outgoing client data to the original server by default', async ({
   loadExample,
   page,
 }) => {
@@ -74,9 +74,6 @@ test('forwards outgoing client data to the original server', async ({
 
     interceptor.on('connection', ({ client, server }) => {
       server.connect()
-
-      // Forward outgoing events to the original WebSocket server.
-      client.addEventListener('message', (event) => server.send(event.data))
     })
     interceptor.apply()
   })

--- a/test/modules/WebSocket/exchange/websocket.server.connect.test.ts
+++ b/test/modules/WebSocket/exchange/websocket.server.connect.test.ts
@@ -88,9 +88,9 @@ it('closes the actual server connection when the client closes', async () => {
 
     client.addEventListener('message', (event) => {
       if (event.data === 'close') {
+        event.preventDefault()
         return client.close()
       }
-      server.send(event.data)
     })
   })
 

--- a/test/modules/WebSocket/third-party/socket.io.browser.test.ts
+++ b/test/modules/WebSocket/third-party/socket.io.browser.test.ts
@@ -110,20 +110,15 @@ test('intercepts and modifies data sent to socket.io server', async ({
     interceptor.on('connection', ({ client, server }) => {
       server.connect()
 
-      client.addEventListener('message', (event) => {
+      client.addEventListener('message', async (event) => {
         const data = decodeMessage(event.data)
 
         if (data?.[0] === 'hello') {
-          event.stopImmediatePropagation()
-          encodeMessage('mocked hello!').then((packet) => {
-            // @ts-expect-error TS in Playwright is hard.
-            server.send(packet)
-          })
+          event.preventDefault()
+          const packet = await encodeMessage('mocked hello!')
+          // @ts-expect-error TS in Playwright is hard.
+          server.send(packet)
         }
-      })
-
-      client.addEventListener('message', (event) => {
-        server.send(event.data)
       })
     })
 


### PR DESCRIPTION
- Implements https://github.com/mswjs/msw/discussions/2010#discussioncomment-9024640

## Changes

Outgoing client messages are now forwarded to the actual server by default after `server.connect()` is called. To prevent this, call `event.preventDefault()` on the respective client message.

## Roadmap

- [x] Add the `event.preventDefault()` test for the client-to-server forwarding prevention. 
- [x] Update `README` to reflect this change. 
- [x] Update in-progress MSW WebSocket docs. 