### PR TITLE
fix(CancelableMessageEvent): add setters for "cancelable" and "defaultPrevented"

### DIFF
--- a/src/interceptors/WebSocket/utils/events.test.ts
+++ b/src/interceptors/WebSocket/utils/events.test.ts
@@ -50,6 +50,28 @@ describe(CancelableMessageEvent, () => {
     event.preventDefault()
     expect(event.defaultPrevented).toBe(false)
   })
+
+  it('supports setting the "cancelable" value directly', () => {
+    const event = new CancelableMessageEvent('message', {})
+    /**
+     * @note HappyDOM sets the "cancelable" and "preventDefault"
+     * event properties directly. That's no-op as far as I know
+     * but they do it and we have to account for that.
+     */
+    event.cancelable = true
+    expect(event.cancelable).toBe(true)
+  })
+
+  it('supports setting the "defaultPrevented" value directly', () => {
+    const event = new CancelableMessageEvent('message', {})
+    /**
+     * @note HappyDOM sets the "cancelable" and "preventDefault"
+     * event properties directly. That's no-op as far as I know
+     * but they do it and we have to account for that.
+     */
+    event.defaultPrevented = true
+    expect(event.defaultPrevented).toBe(true)
+  })
 })
 
 describe(CloseEvent, () => {

--- a/src/interceptors/WebSocket/utils/events.ts
+++ b/src/interceptors/WebSocket/utils/events.ts
@@ -22,8 +22,16 @@ export class CancelableMessageEvent<T = any> extends MessageEvent<T> {
     return this[kCancelable]
   }
 
+  set cancelable(nextCancelable) {
+    this[kCancelable] = nextCancelable
+  }
+
   get defaultPrevented() {
     return this[kDefaultPrevented]
+  }
+
+  set defaultPrevented(nextDefaultPrevented) {
+    this[kDefaultPrevented] = nextDefaultPrevented
   }
 
   public preventDefault(): void {


### PR DESCRIPTION
Without these setters, using `CancelableMessageEvent` in HappyDOM fails:

```
TypeError: Cannot set property defaultPrevented of #<CancelableMessageEvent> which has only a getter
 ❯ new Event node_modules/happy-dom/src/event/Event.ts:18:25
 ❯ new MessageEvent node_modules/happy-dom/src/event/events/MessageEvent.ts:25:3
 ❯ new CancelableMessageEvent node_modules/@mswjs/interceptors/src/interceptors/WebSocket/utils/events.ts:16:5
 ❯ WebSocketOverride.WebSocketClassTransport.socket.<computed> node_modules/@mswjs/interceptors/src/interceptors/WebSocket/WebSocketClassTransport.ts:40:13
 ❯ node_modules/@mswjs/interceptors/src/interceptors/WebSocket/WebSocketOverride.ts:140:3
 ❯ node:internal/process/task_queues:140:7
 ❯ AsyncResource.runInAsyncScope node:async_hooks:206:9
 ❯ AsyncResource.runMicrotask node:internal/process/task_queues:137:8
```

HappyDOM sets the `cancelable` and `defaultPrevented` properties directly although those properties have no setters per spec (I may be wrong). 

> HappyDOM sets those properties in the constructor so, technically, it's not forbidden since they use the setters to provide initial values for those properties. It's clashing syntax-wise since the Interceptor's implementation is more strict. 