### PR TITLE
fix(WebSocket): reference bound listener when calling `.removeEventListener()`

### DIFF
--- a/src/interceptors/WebSocket/WebSocketClientConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketClientConnection.ts
@@ -85,7 +85,11 @@ export class WebSocketClientConnection
     listener: WebSocketEventListener<WebSocketClientEventMap[EventType]>,
     options?: AddEventListenerOptions | boolean
   ): void {
-    this[kEmitter].addEventListener(type, listener as EventListener, options)
+    this[kEmitter].addEventListener(
+      type,
+      listener.bind(this.socket) as EventListener,
+      options
+    )
   }
 
   /**

--- a/src/interceptors/WebSocket/WebSocketClientConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketClientConnection.ts
@@ -1,5 +1,5 @@
 import type { WebSocketData, WebSocketTransport } from './WebSocketTransport'
-import { WebSocketEventListener } from './WebSocketOverride'
+import type { WebSocketEventListener } from './WebSocketOverride'
 import { bindEvent } from './utils/bindEvent'
 import { CancelableMessageEvent, CloseEvent } from './utils/events'
 import { createRequestId } from '../../createRequestId'

--- a/src/interceptors/WebSocket/WebSocketClientConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketClientConnection.ts
@@ -94,6 +94,7 @@ export class WebSocketClientConnection
       value: boundListener,
       enumerable: false,
     })
+
     this[kEmitter].addEventListener(
       type,
       boundListener as EventListener,

--- a/src/interceptors/WebSocket/WebSocketServerConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketServerConnection.ts
@@ -1,11 +1,22 @@
 import { invariant } from 'outvariant'
-import { kClose, WebSocketOverride } from './WebSocketOverride'
+import {
+  kClose,
+  WebSocketEventListener,
+  WebSocketOverride,
+} from './WebSocketOverride'
 import type { WebSocketData } from './WebSocketTransport'
 import type { WebSocketClassTransport } from './WebSocketClassTransport'
 import { bindEvent } from './utils/bindEvent'
 import { CancelableMessageEvent, CloseEvent } from './utils/events'
 
 const kEmitter = Symbol('kEmitter')
+
+interface WebSocketServerEventMap {
+  open: Event
+  message: MessageEvent<WebSocketData>
+  error: Event
+  close: CloseEvent
+}
 
 /**
  * The WebSocket server instance represents the actual production
@@ -135,9 +146,9 @@ export class WebSocketServerConnection {
   /**
    * Listen for the incoming events from the original WebSocket server.
    */
-  public addEventListener<K extends keyof WebSocketEventMap>(
-    event: K,
-    listener: (this: WebSocket, event: WebSocketEventMap[K]) => void,
+  public addEventListener<EventType extends keyof WebSocketServerEventMap>(
+    event: EventType,
+    listener: WebSocketEventListener<WebSocketServerEventMap[EventType]>,
     options?: AddEventListenerOptions | boolean
   ): void {
     this[kEmitter].addEventListener(
@@ -150,9 +161,9 @@ export class WebSocketServerConnection {
   /**
    * Remove the listener for the given event.
    */
-  public removeEventListener<K extends keyof WebSocketEventMap>(
-    event: K,
-    listener: (this: WebSocket, event: WebSocketEventMap[K]) => void,
+  public removeEventListener<EventType extends keyof WebSocketServerEventMap>(
+    event: EventType,
+    listener: WebSocketEventListener<WebSocketServerEventMap[EventType]>,
     options?: EventListenerOptions | boolean
   ): void {
     this[kEmitter].removeEventListener(

--- a/src/interceptors/WebSocket/WebSocketTransport.ts
+++ b/src/interceptors/WebSocket/WebSocketTransport.ts
@@ -9,9 +9,9 @@ export type WebSocketTransportEventMap = {
 }
 
 export type StrictEventListenerOrEventListenerObject<EventType extends Event> =
-  | ((event: EventType) => void)
+  | ((this: WebSocket, event: EventType) => void)
   | {
-      handleEvent(event: EventType): void
+      handleEvent(this: WebSocket, event: EventType): void
     }
 
 export interface WebSocketTransport {


### PR DESCRIPTION
- Adds `this: WebSocket` annotation to client event listeners.
- Binds the client listeners to `this.socket`.
- Stores the bound listeners for both client and server in `kBoundListener` so the same bound listener can be referenced when you call `.removeEventListener()`.

> This also fixed a bug where you wouldn't be able to remove the listener once it's bound. 