### PR TITLE
fix: unify server error response across interceptors

### DIFF
--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -275,7 +275,10 @@ export class NodeClientRequest extends ClientRequest {
         // Treat them as request errors.
         if (isNodeLikeError(resolverResult.error)) {
           this.errorWith(resolverResult.error)
-        } else {
+          return this
+        }
+
+        if (resolverResult.error instanceof Error) {
           // Coerce unhandled exceptions in the "request" listeners
           // as 500 responses.
           this.respondWith(
@@ -294,8 +297,10 @@ export class NodeClientRequest extends ClientRequest {
               }
             )
           )
+          return this
         }
 
+        this.errorWith(resolverResult.error)
         return this
       }
 

--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -23,6 +23,7 @@ import { isPropertyAccessible } from '../../utils/isPropertyAccessible'
 import { isNodeLikeError } from '../../utils/isNodeLikeError'
 import { INTERNAL_REQUEST_ID_HEADER_NAME } from '../../Interceptor'
 import { createRequestId } from '../../createRequestId'
+import { createServerErrorResponse } from '../../utils/responseUtils'
 
 export type Protocol = 'http' | 'https'
 
@@ -220,7 +221,7 @@ export class NodeClientRequest extends ClientRequest {
 
     // Execute the resolver Promise like a side-effect.
     // Node.js 16 forces "ClientRequest.end" to be synchronous and return "this".
-    until(async () => {
+    until<unknown, Response | undefined>(async () => {
       // Notify the interceptor about the request.
       // This will call any "request" listeners the users have.
       this.logger.info(
@@ -266,6 +267,7 @@ export class NodeClientRequest extends ClientRequest {
           resolverResult.error
         )
 
+        // Treat thrown Responses as mocked responses.
         if (resolverResult.error instanceof Response) {
           this.respondWith(resolverResult.error)
           return
@@ -278,29 +280,11 @@ export class NodeClientRequest extends ClientRequest {
           return this
         }
 
-        if (resolverResult.error instanceof Error) {
-          // Coerce unhandled exceptions in the "request" listeners
-          // as 500 responses.
-          this.respondWith(
-            new Response(
-              JSON.stringify({
-                name: resolverResult.error.name,
-                message: resolverResult.error.message,
-                stack: resolverResult.error.stack,
-              }),
-              {
-                status: 500,
-                statusText: 'Unhandled Exception',
-                headers: {
-                  'Content-Type': 'application/json',
-                },
-              }
-            )
-          )
-          return this
-        }
+        // Unhandled exceptions in the request listeners are
+        // synonymous to unhandled exceptions on the server.
+        // Those are represented as 500 error responses.
+        this.respondWith(createServerErrorResponse(resolverResult.error))
 
-        this.errorWith(resolverResult.error)
         return this
       }
 

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestProxy.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestProxy.ts
@@ -4,6 +4,7 @@ import { XMLHttpRequestEmitter } from '.'
 import { toInteractiveRequest } from '../../utils/toInteractiveRequest'
 import { emitAsync } from '../../utils/emitAsync'
 import { XMLHttpRequestController } from './XMLHttpRequestController'
+import { createServerErrorResponse } from '../../utils/responseUtils'
 
 export interface XMLHttpRequestProxyOptions {
   emitter: XMLHttpRequestEmitter
@@ -94,35 +95,18 @@ export function createXMLHttpRequestProxy({
             resolverResult.error
           )
 
+          // Treat thrown Responses as mocked responses.
           if (resolverResult.error instanceof Response) {
             this.respondWith(resolverResult.error)
             return
           }
+          // Unhandled exceptions in the request listeners are
+          // synonymous to unhandled exceptions on the server.
+          // Those are represented as 500 error responses.
+          xhrRequestController.respondWith(
+            createServerErrorResponse(resolverResult.error)
+          )
 
-          if (resolverResult.error instanceof Error) {
-            // Treat unhandled exceptions in the "request" listener
-            // as 500 server errors.
-            xhrRequestController.respondWith(
-              new Response(
-                JSON.stringify({
-                  name: resolverResult.error.name,
-                  message: resolverResult.error.message,
-                  stack: resolverResult.error.stack,
-                }),
-                {
-                  status: 500,
-                  statusText: 'Unhandled Exception',
-                  headers: {
-                    'Content-Type': 'application/json',
-                  },
-                }
-              )
-            )
-            return
-          }
-
-          // Otherwise, error the request with the thrown data.
-          xhrRequestController.errorWith(resolverResult.error)
           return
         }
 

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestProxy.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestProxy.ts
@@ -99,31 +99,30 @@ export function createXMLHttpRequestProxy({
             return
           }
 
-          // Treat unhandled exceptions in the "request" listener
-          // as 500 server errors.
-          xhrRequestController.respondWith(
-            new Response(
-              JSON.stringify({
-                name: resolverResult.error.name,
-                message: resolverResult.error.message,
-                stack: resolverResult.error.stack,
-              }),
-              {
-                status: 500,
-                statusText: 'Unhandled Exception',
-                headers: {
-                  'Content-Type': 'application/json',
-                },
-              }
+          if (resolverResult.error instanceof Error) {
+            // Treat unhandled exceptions in the "request" listener
+            // as 500 server errors.
+            xhrRequestController.respondWith(
+              new Response(
+                JSON.stringify({
+                  name: resolverResult.error.name,
+                  message: resolverResult.error.message,
+                  stack: resolverResult.error.stack,
+                }),
+                {
+                  status: 500,
+                  statusText: 'Unhandled Exception',
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                }
+              )
             )
-          )
+            return
+          }
 
-          /**
-           * @todo Consider forwarding this error to the stderr as well
-           * since not all consumers are expecting to handle errors.
-           * If they don't, this error will be swallowed.
-           */
-          // xhrRequestController.errorWith(resolverResult.error)
+          // Otherwise, error the request with the thrown data.
+          xhrRequestController.errorWith(resolverResult.error)
           return
         }
 

--- a/src/utils/responseUtils.ts
+++ b/src/utils/responseUtils.ts
@@ -13,3 +13,27 @@ export const RESPONSE_STATUS_CODES_WITHOUT_BODY = new Set([
 export function isResponseWithoutBody(status: number): boolean {
   return RESPONSE_STATUS_CODES_WITHOUT_BODY.has(status)
 }
+
+/**
+ * Creates a generic 500 Unhandled Exception response.
+ */
+export function createServerErrorResponse(body: unknown): Response {
+  return new Response(
+    JSON.stringify(
+      body instanceof Error
+        ? {
+            name: body.name,
+            message: body.message,
+            stack: body.stack,
+          }
+        : body
+    ),
+    {
+      status: 500,
+      statusText: 'Unhandled Exception',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  )
+}

--- a/test/modules/XMLHttpRequest/compliance/xhr-middleware-exception.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-middleware-exception.test.ts
@@ -2,7 +2,7 @@
 /**
  * @see https://github.com/mswjs/msw/issues/355
  */
-import { it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import { vi, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
 import axios from 'axios'
 import { XMLHttpRequestInterceptor } from '../../../../src/interceptors/XMLHttpRequest'
 import { createXMLHttpRequest } from '../../../helpers'
@@ -76,4 +76,21 @@ it('treats a thrown Response instance as a mocked response', async () => {
   expect(request.status).toBe(200)
   expect(request.response).toBe('hello world')
   expect(request.responseText).toBe('hello world')
+})
+
+it('forwards thrown non-errors as request errors', async () => {
+  interceptor.on('request', () => {
+    throw 123
+  })
+
+  const requestErrorListener = vi.fn()
+  const request = await createXMLHttpRequest((request) => {
+    request.responseType = 'text'
+    request.open('GET', 'http://localhost/api')
+    request.addEventListener('error', requestErrorListener)
+    request.send()
+  })
+
+  expect(request.status).toBe(0)
+  expect(requestErrorListener).toHaveBeenCalledTimes(1)
 })

--- a/test/modules/XMLHttpRequest/compliance/xhr-middleware-exception.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-middleware-exception.test.ts
@@ -78,9 +78,9 @@ it('treats a thrown Response instance as a mocked response', async () => {
   expect(request.responseText).toBe('hello world')
 })
 
-it('forwards thrown non-errors as request errors', async () => {
-  interceptor.on('request', () => {
-    throw 123
+it('treats Response.error() as a network error', async () => {
+  interceptor.on('request', ({ request }) => {
+    request.respondWith(Response.error())
   })
 
   const requestErrorListener = vi.fn()

--- a/test/modules/fetch/fetch-exception.test.ts
+++ b/test/modules/fetch/fetch-exception.test.ts
@@ -46,9 +46,9 @@ it('treats a thrown Response as a mocked response', async () => {
   expect(await response.text()).toBe('hello world')
 })
 
-it('treats thrown non-errors a network error', async () => {
-  interceptor.on('request', () => {
-    throw 123
+it('treats Response.error() as a network error', async () => {
+  interceptor.on('request', ({ request }) => {
+    request.respondWith(Response.error())
   })
 
   const requestError = await fetch('http://localhost:3001/resource')
@@ -59,5 +59,5 @@ it('treats thrown non-errors a network error', async () => {
 
   expect(requestError.name).toBe('TypeError')
   expect(requestError.message).toBe('Failed to fetch')
-  expect(requestError.cause).toBe(123)
+  expect(requestError.cause).toBeInstanceOf(Response)
 })

--- a/test/modules/fetch/fetch-exception.test.ts
+++ b/test/modules/fetch/fetch-exception.test.ts
@@ -45,3 +45,19 @@ it('treats a thrown Response as a mocked response', async () => {
   expect(response.status).toBe(200)
   expect(await response.text()).toBe('hello world')
 })
+
+it('treats thrown non-errors a network error', async () => {
+  interceptor.on('request', () => {
+    throw 123
+  })
+
+  const requestError = await fetch('http://localhost:3001/resource')
+    .then(() => {
+      throw new Error('Must not resolve')
+    })
+    .catch<TypeError & { cause?: unknown }>((error) => error)
+
+  expect(requestError.name).toBe('TypeError')
+  expect(requestError.message).toBe('Failed to fetch')
+  expect(requestError.cause).toBe(123)
+})

--- a/test/modules/http/compliance/http-unhandled-exception.test.ts
+++ b/test/modules/http/compliance/http-unhandled-exception.test.ts
@@ -50,17 +50,3 @@ it('treats unhandled interceptor errors as 500 responses', async () => {
     stack: expect.any(String),
   })
 })
-
-it('treats thrown non-errors as request errors', async () => {
-  interceptor.on('request', () => {
-    throw 123
-  })
-
-  const request = http.get('http://localhost/resource')
-  const requestErrorPromise = new DeferredPromise<Error>()
-  request.on('error', (error) => requestErrorPromise.resolve(error))
-
-  const requestError = await requestErrorPromise
-
-  expect(requestError).toBe(123)
-})

--- a/test/modules/http/compliance/http-unhandled-exception.test.ts
+++ b/test/modules/http/compliance/http-unhandled-exception.test.ts
@@ -5,6 +5,7 @@ import { vi, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
 import http from 'node:http'
 import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
 import { waitForClientRequest } from '../../../helpers'
+import { DeferredPromise } from '@open-draft/deferred-promise'
 
 const interceptor = new ClientRequestInterceptor()
 
@@ -48,4 +49,18 @@ it('treats unhandled interceptor errors as 500 responses', async () => {
     message: 'Custom error',
     stack: expect.any(String),
   })
+})
+
+it('treats thrown non-errors as request errors', async () => {
+  interceptor.on('request', () => {
+    throw 123
+  })
+
+  const request = http.get('http://localhost/resource')
+  const requestErrorPromise = new DeferredPromise<Error>()
+  request.on('error', (error) => requestErrorPromise.resolve(error))
+
+  const requestError = await requestErrorPromise
+
+  expect(requestError).toBe(123)
 })


### PR DESCRIPTION
- If you throw a `Response` instance in a request listener, that instance will be used as a mocked response. 
- If you throw anything else, it will be coerced to a 500 error response, similar to how an actual server would handle an uncaught exception. 

> If you want to emulate a request error, do `request.respondWith(Response.error())`. 