### PR TITLE
fix(MockHttpSocket): set tls socket properties on init

### DIFF
--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -111,6 +111,16 @@ export class MockHttpSocket extends MockSocket {
     // Once the socket is finished, nothing can write to it
     // anymore. It has also flushed any buffered chunks.
     this.once('finish', () => this.requestParser.free())
+
+    if (this.baseUrl.protocol === 'https:') {
+      Reflect.set(this, 'encrypted', true)
+      // The server certificate is not the same as a CA
+      // passed to the TLS socket connection options.
+      Reflect.set(this, 'authorized', false)
+      Reflect.set(this, 'getProtocol', () => 'TLSv1.3')
+      Reflect.set(this, 'getSession', () => undefined)
+      Reflect.set(this, 'isSessionReused', () => false)
+    }
   }
 
   public destroy(error?: Error | undefined): this {
@@ -371,14 +381,6 @@ export class MockHttpSocket extends MockSocket {
           Buffer.from('mock-session-renegotiate')
       )
       this.emit('session', Buffer.from('mock-session-resume'))
-
-      Reflect.set(this, 'encrypted', true)
-      // The server certificate is not the same as a CA
-      // passed to the TLS socket connection options.
-      Reflect.set(this, 'authorized', false)
-      Reflect.set(this, 'getProtocol', () => 'TLSv1.3')
-      Reflect.set(this, 'getSession', () => undefined)
-      Reflect.set(this, 'isSessionReused', () => false)
     }
   }
 

--- a/test/modules/http/compliance/http-ssl-socket.test.ts
+++ b/test/modules/http/compliance/http-ssl-socket.test.ts
@@ -28,9 +28,7 @@ it('emits a correct TLS Socket instance for a handled HTTPS request', async () =
 
   const request = https.get('https://example.com')
   const socketPromise = new DeferredPromise<TLSSocket>()
-  request.on('socket', (socket) => {
-    socket.on('connect', () => socketPromise.resolve(socket as TLSSocket))
-  })
+  request.on('socket', socketPromise.resolve)
 
   const socket = await socketPromise
 
@@ -48,9 +46,7 @@ it('emits a correct TLS Socket instance for a handled HTTPS request', async () =
 it('emits a correct TLS Socket instance for a bypassed HTTPS request', async () => {
   const request = https.get('https://example.com')
   const socketPromise = new DeferredPromise<TLSSocket>()
-  request.on('socket', (socket) => {
-    socket.on('connect', () => socketPromise.resolve(socket as TLSSocket))
-  })
+  request.on('socket', socketPromise.resolve)
 
   const socket = await socketPromise
 


### PR DESCRIPTION
It seems like Node.js set these properties on `TLSSocket` init, before the `connect` event ([source](https://github.com/nodejs/node/blob/main/lib/_tls_wrap.js#L574)).

With umocked `https`:
```js
https.get('https://example.com')
  .on('socket', socket => {
    console.log(socket.authorized); // false
    console.log(socket.encrypted);  // true
  }); 
```