### PR TITLE
fix(ClientRequest): decode uri for username and password before setting basic authentication header

### DIFF
--- a/src/interceptors/ClientRequest/utils/createRequest.ts
+++ b/src/interceptors/ClientRequest/utils/createRequest.ts
@@ -26,7 +26,9 @@ export function createRequest(clientRequest: NodeClientRequest): Request {
    * @see https://github.com/mswjs/interceptors/issues/438
    */
   if (clientRequest.url.username || clientRequest.url.password) {
-    const auth = `${clientRequest.url.username || ''}:${clientRequest.url.password || ''}`
+    const username = decodeURIComponent(clientRequest.url.username || '')
+    const password = decodeURIComponent(clientRequest.url.password || '')
+    const auth = `${username}:${password}`
     headers.set('Authorization', `Basic ${btoa(auth)}`)
 
     // Remove the credentials from the URL since you cannot

--- a/test/third-party/axios.test.ts
+++ b/test/third-party/axios.test.ts
@@ -1,9 +1,25 @@
 // @vitest-environment jsdom
-import { it, expect, beforeAll, afterAll } from 'vitest'
+import { it, expect, beforeAll, afterAll, afterEach } from 'vitest'
 import axios from 'axios'
 import { HttpServer } from '@open-draft/test-server/http'
 import { ClientRequestInterceptor } from '../../src/interceptors/ClientRequest'
 import { useCors } from '../helpers'
+import { DeferredPromise } from '@open-draft/deferred-promise'
+
+function createMockResponse() {
+  return new Response(
+    JSON.stringify({
+      mocked: true,
+    }),
+    {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        'x-header': 'yes',
+      },
+    }
+  )
+}
 
 const httpServer = new HttpServer((app) => {
   app.use(useCors)
@@ -22,30 +38,14 @@ const httpServer = new HttpServer((app) => {
 })
 
 const interceptor = new ClientRequestInterceptor()
-interceptor.on('request', ({ request }) => {
-  const url = new URL(request.url)
-
-  if (url.pathname === '/user') {
-    request.respondWith(
-      new Response(
-        JSON.stringify({
-          mocked: true,
-        }),
-        {
-          status: 200,
-          headers: {
-            'content-type': 'application/json',
-            'x-header': 'yes',
-          },
-        }
-      )
-    )
-  }
-})
 
 beforeAll(async () => {
   await httpServer.listen()
   interceptor.apply()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
 })
 
 afterAll(async () => {
@@ -54,6 +54,10 @@ afterAll(async () => {
 })
 
 it('responds with a mocked response to an "axios()" request', async () => {
+  interceptor.on('request', ({ request }) => {
+    request.respondWith(createMockResponse())
+  })
+
   const res = await axios('/user')
 
   expect(res.status).toEqual(200)
@@ -62,6 +66,10 @@ it('responds with a mocked response to an "axios()" request', async () => {
 })
 
 it('responds with a mocked response to an "axios.get()" request', async () => {
+  interceptor.on('request', ({ request }) => {
+    request.respondWith(createMockResponse())
+  })
+
   const res = await axios.get('/user')
 
   expect(res.status).toEqual(200)
@@ -70,6 +78,10 @@ it('responds with a mocked response to an "axios.get()" request', async () => {
 })
 
 it('responds with a mocked response to an "axios.post()" request', async () => {
+  interceptor.on('request', ({ request }) => {
+    request.respondWith(createMockResponse())
+  })
+
   const res = await axios.post('/user')
 
   expect(res.status).toEqual(200)
@@ -78,6 +90,10 @@ it('responds with a mocked response to an "axios.post()" request', async () => {
 })
 
 it('bypass the interceptor and return the original response', async () => {
+  interceptor.on('request', () => {
+    // Intentionally do nothing.
+  })
+
   const res = await axios.get(httpServer.http.url('/books'))
 
   expect(res.status).toEqual(200)
@@ -91,4 +107,34 @@ it('bypass the interceptor and return the original response', async () => {
       author: 'J. R. R. Tolkien',
     },
   ])
+})
+
+/**
+ * @see https://github.com/mswjs/interceptors/issues/564
+ */
+it('preserves "auth" (Authorization)', async () => {
+  const getRequestPromise = new DeferredPromise<Request>()
+
+  interceptor.on('request', ({ request }) => {
+    // Axios/XHR also dispatches an "OPTIONS" preflight request.
+    // We only ever care about GET here.
+    if (request.method === 'GET') {
+      getRequestPromise.resolve(request)
+    }
+  })
+
+  // Construct an Axios request with "auth".
+  await axios.get(httpServer.http.url('/books'), {
+    auth: {
+      // Use an email address as the username.
+      // This must NOT be encoded.
+      username: 'foo@bar.com',
+      password: 'secret123',
+    },
+  })
+
+  const request = await getRequestPromise
+  expect(request.headers.get('Authorization')).toBe(
+    `Basic ${btoa('foo@bar.com:secret123')}`
+  )
 })

--- a/test/third-party/axios.test.ts
+++ b/test/third-party/axios.test.ts
@@ -125,6 +125,7 @@ it('preserves "auth" (Authorization)', async () => {
 
   // Construct an Axios request with "auth".
   await axios.get(httpServer.http.url('/books'), {
+    adapter: 'http',
     auth: {
       // Use an email address as the username.
       // This must NOT be encoded.


### PR DESCRIPTION
- Fixes #564 