### PR TITLE
feat: add "unhandledException" event

### DIFF
--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -19,4 +19,15 @@ export type HttpRequestEventMap = {
       requestId: string
     }
   ]
+  unhandledException: [
+    args: {
+      error: unknown
+      request: Request
+      requestId: string
+      controller: {
+        respondWith(response: Response): void
+        errorWith(reason: unknown): void
+      }
+    }
+  ]
 }

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -26,7 +26,7 @@ export type HttpRequestEventMap = {
       requestId: string
       controller: {
         respondWith(response: Response): void
-        errorWith(reason: unknown): void
+        errorWith(error?: Error): void
       }
     }
   ]

--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -293,10 +293,25 @@ export class NodeClientRequest extends ClientRequest {
           return this
         }
 
-        // Unhandled exceptions in the request listeners are
-        // synonymous to unhandled exceptions on the server.
-        // Those are represented as 500 error responses.
-        this.respondWith(createServerErrorResponse(resolverResult.error))
+        // Emit the "unhandledException" event to allow the client
+        // to opt-out from the default handling of exceptions
+        // as 500 error responses.
+        if (
+          !this.emitter.emit('unhandledException', {
+            error: resolverResult.error,
+            request: capturedRequest,
+            requestId,
+            controller: {
+              respondWith: this.respondWith.bind(this),
+              errorWith: this.errorWith.bind(this),
+            },
+          })
+        ) {
+          // Unhandled exceptions in the request listeners are
+          // synonymous to unhandled exceptions on the server.
+          // Those are represented as 500 error responses.
+          this.respondWith(createServerErrorResponse(resolverResult.error))
+        }
 
         return this
       }

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -49,10 +49,7 @@ export class XMLHttpRequestController {
   private responseBuffer: Uint8Array
   private events: Map<keyof XMLHttpRequestEventTargetEventMap, Array<Function>>
 
-  constructor(
-    readonly initialRequest: XMLHttpRequest,
-    public logger: Logger
-  ) {
+  constructor(readonly initialRequest: XMLHttpRequest, public logger: Logger) {
     this.events = new Map()
     this.requestId = createRequestId()
     this.requestHeaders = new Headers()
@@ -103,7 +100,7 @@ export class XMLHttpRequestController {
           case 'addEventListener': {
             const [eventName, listener] = args as [
               keyof XMLHttpRequestEventTargetEventMap,
-              Function,
+              Function
             ]
 
             this.registerEvent(eventName, listener)
@@ -123,7 +120,7 @@ export class XMLHttpRequestController {
 
           case 'send': {
             const [body] = args as [
-              body?: XMLHttpRequestBodyInit | Document | null,
+              body?: XMLHttpRequestBodyInit | Document | null
             ]
 
             if (body != null) {
@@ -524,7 +521,7 @@ export class XMLHttpRequestController {
   private trigger<
     EventName extends keyof (XMLHttpRequestEventTargetEventMap & {
       readystatechange: ProgressEvent<XMLHttpRequestEventTarget>
-    }),
+    })
   >(eventName: EventName, options?: ProgressEventInit): void {
     const callback = this.request[`on${eventName}`]
     const event = createEvent(this.request, eventName, options)

--- a/test/modules/XMLHttpRequest/compliance/xhr-middleware-exception.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-middleware-exception.test.ts
@@ -111,3 +111,101 @@ it('treats a thrown Response.error() as a network error', async () => {
   expect(request.status).toBe(0)
   expect(requestErrorListener).toHaveBeenCalledTimes(1)
 })
+
+it('handles exceptions by default if "unhandledException" listener is provided but does nothing', async () => {
+  const unhandledExceptionListener = vi.fn()
+
+  interceptor.on('request', () => {
+    throw new Error('Custom error')
+  })
+  interceptor.on('unhandledException', unhandledExceptionListener)
+
+  const request = await createXMLHttpRequest((request) => {
+    request.responseType = 'json'
+    request.open('GET', 'http://localhost/api')
+    request.send()
+  })
+
+  // Must emit the "unhandledException" interceptor event.
+  expect(unhandledExceptionListener).toHaveBeenCalledWith(
+    expect.objectContaining({
+      error: new Error('Custom error'),
+    })
+  )
+  expect(unhandledExceptionListener).toHaveBeenCalledOnce()
+
+  expect(request.status).toBe(500)
+  expect(request.statusText).toBe('Unhandled Exception')
+  expect(request.response).toEqual({
+    name: 'Error',
+    message: 'Custom error',
+    stack: expect.any(String),
+  })
+})
+
+it('handles exceptions as instructed in "unhandledException" listener (mock response)', async () => {
+  const unhandledExceptionListener = vi.fn()
+
+  interceptor.on('request', () => {
+    throw new Error('Custom error')
+  })
+  interceptor.on('unhandledException', (args) => {
+    const { controller } = args
+    unhandledExceptionListener(args)
+
+    // Handle exceptions as a fallback 200 OK response.
+    controller.respondWith(new Response('fallback response'))
+  })
+
+  const requestErrorListener = vi.fn()
+  const request = await createXMLHttpRequest((request) => {
+    request.responseType = 'text'
+    request.open('GET', 'http://localhost/api')
+    request.addEventListener('error', requestErrorListener)
+    request.send()
+  })
+
+  expect(request.status).toBe(200)
+  expect(request.response).toBe('fallback response')
+
+  expect(unhandledExceptionListener).toHaveBeenCalledWith(
+    expect.objectContaining({
+      error: new Error('Custom error'),
+    })
+  )
+  expect(unhandledExceptionListener).toHaveBeenCalledOnce()
+  expect(requestErrorListener).not.toHaveBeenCalled()
+})
+
+it('handles exceptions as instructed in "unhandledException" listener (request error)', async () => {
+  const unhandledExceptionListener = vi.fn()
+
+  interceptor.on('request', () => {
+    throw new Error('Custom error')
+  })
+  interceptor.on('unhandledException', (args) => {
+    const { request, controller } = args
+    unhandledExceptionListener(args)
+
+    // Handle exceptions as request errors.
+    controller.errorWith(new Error('Fallback error'))
+  })
+
+  const requestErrorListener = vi.fn()
+  const request = await createXMLHttpRequest((request) => {
+    request.responseType = 'text'
+    request.open('GET', 'http://localhost/api')
+    request.addEventListener('error', requestErrorListener)
+    request.send()
+  })
+
+  expect(requestErrorListener).toHaveBeenCalledOnce()
+  expect(request.readyState).toBe(request.DONE)
+
+  expect(unhandledExceptionListener).toHaveBeenCalledWith(
+    expect.objectContaining({
+      error: new Error('Custom error'),
+    })
+  )
+  expect(unhandledExceptionListener).toHaveBeenCalledOnce()
+})

--- a/test/modules/fetch/fetch-exception.test.ts
+++ b/test/modules/fetch/fetch-exception.test.ts
@@ -77,3 +77,85 @@ it('treats a thrown Response.error() as a network error', async () => {
   expect(requestError.message).toBe('Failed to fetch')
   expect(requestError.cause).toBeInstanceOf(Response)
 })
+
+it('performs request as-is if "unhandledException" is provided but does nothing', async () => {
+  const unhandledExceptionListener = vi.fn()
+
+  interceptor.on('request', () => {
+    throw new Error('Custom error')
+  })
+  interceptor.on('unhandledException', unhandledExceptionListener)
+
+  const response = await fetch('http://localhost/resource')
+
+  expect(response.status).toBe(500)
+  expect(response.statusText).toBe('Unhandled Exception')
+  expect(await response.json()).toEqual({
+    name: 'Error',
+    message: 'Custom error',
+    stack: expect.any(String),
+  })
+  expect(unhandledExceptionListener).toHaveBeenCalledWith(
+    expect.objectContaining({
+      error: new Error('Custom error'),
+    })
+  )
+  expect(unhandledExceptionListener).toHaveBeenCalledOnce()
+})
+
+it('handles exceptions as instructed in "unhandledException" listener (mock response)', async () => {
+  const unhandledExceptionListener = vi.fn()
+
+  interceptor.on('request', () => {
+    throw new Error('Custom error')
+  })
+  interceptor.on('unhandledException', (args) => {
+    const { controller } = args
+    unhandledExceptionListener(args)
+
+    // Handle exceptions as a fallback 200 OK response.
+    controller.respondWith(new Response('fallback response'))
+  })
+
+  const response = await fetch('http://localhost/resource')
+
+  expect(response.status).toBe(200)
+  expect(await response.text()).toBe('fallback response')
+
+  expect(unhandledExceptionListener).toHaveBeenCalledWith(
+    expect.objectContaining({
+      error: new Error('Custom error'),
+    })
+  )
+})
+
+it('handles exceptions as instructed in "unhandledException" listener (request error)', async () => {
+  const unhandledExceptionListener = vi.fn()
+
+  interceptor.on('request', () => {
+    throw new Error('Custom error')
+  })
+  interceptor.on('unhandledException', (args) => {
+    const { controller } = args
+    unhandledExceptionListener(args)
+
+    // Handle exceptions as a request error.
+    controller.errorWith(new Error('Fallback error'))
+  })
+
+  const requestError = await fetch('http://localhost:3001/resource')
+    .then(() => {
+      throw new Error('Must not resolve')
+    })
+    .catch<TypeError & { cause?: unknown }>((error) => error)
+
+  expect(requestError.name).toBe('Error')
+  expect(requestError.message).toBe('Fallback error')
+  expect(requestError.cause).toBeUndefined()
+
+  expect(unhandledExceptionListener).toHaveBeenCalledWith(
+    expect.objectContaining({
+      error: new Error('Custom error'),
+    })
+  )
+})

--- a/test/modules/fetch/fetch-exception.test.ts
+++ b/test/modules/fetch/fetch-exception.test.ts
@@ -78,7 +78,7 @@ it('treats a thrown Response.error() as a network error', async () => {
   expect(requestError.cause).toBeInstanceOf(Response)
 })
 
-it('performs request as-is if "unhandledException" is provided but does nothing', async () => {
+it('handles exceptions by default if "unhandledException" is provided but does nothing', async () => {
   const unhandledExceptionListener = vi.fn()
 
   interceptor.on('request', () => {

--- a/test/modules/http/compliance/http-unhandled-exception.test.ts
+++ b/test/modules/http/compliance/http-unhandled-exception.test.ts
@@ -5,7 +5,6 @@ import { vi, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
 import http from 'node:http'
 import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
 import { waitForClientRequest } from '../../../helpers'
-import { DeferredPromise } from '@open-draft/deferred-promise'
 
 const interceptor = new ClientRequestInterceptor()
 
@@ -49,4 +48,105 @@ it('treats unhandled interceptor errors as 500 responses', async () => {
     message: 'Custom error',
     stack: expect.any(String),
   })
+})
+
+it('performs request as-is if "unhandledException" listener is provided but does nothing', async () => {
+  const unhandledExceptionListener = vi.fn()
+
+  interceptor.on('request', () => {
+    throw new Error('Custom error')
+  })
+  interceptor.on('unhandledException', unhandledExceptionListener)
+
+  const request = http.get('http://localhost/resource')
+
+  const requestErrorListener = vi.fn()
+  request.on('error', requestErrorListener)
+
+  // Must emit the "unhandledException" interceptor event.
+  await vi.waitFor(() => {
+    expect(unhandledExceptionListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: new Error('Custom error'),
+      })
+    )
+  })
+
+  // Since the interceptor didn't handle the exception,
+  // it got swallowed. The request will continue as-is,
+  // and since it requests non-existing resource, it will error.
+  expect(requestErrorListener).toHaveBeenCalledWith(
+    expect.objectContaining({
+      code: 'ECONNREFUSED',
+      address: '::1',
+      port: 80,
+    })
+  )
+})
+
+it('handles exceptions as instructed in "unhandledException" listener (mock response)', async () => {
+  const unhandledExceptionListener = vi.fn()
+
+  interceptor.on('request', () => {
+    throw new Error('Custom error')
+  })
+  interceptor.on('unhandledException', (args) => {
+    const { request, controller } = args
+    unhandledExceptionListener(args)
+
+    // Handle exceptions as a fallback 200 OK response.
+    controller.respondWith(new Response('fallback response'))
+  })
+
+  const request = http.get('http://localhost/resource')
+
+  const requestErrorListener = vi.fn()
+  request.on('error', requestErrorListener)
+
+  const { res, text } = await waitForClientRequest(request)
+
+  expect(res.statusCode).toBe(200)
+  expect(res.statusMessage).toBe('OK')
+  expect(await text()).toBe('fallback response')
+
+  expect(unhandledExceptionListener).toHaveBeenCalledWith(
+    expect.objectContaining({
+      error: new Error('Custom error'),
+    })
+  )
+  expect(requestErrorListener).not.toHaveBeenCalled()
+})
+
+it('handles exceptions as instructed in "unhandledException" listener (request error)', async () => {
+  const unhandledExceptionListener = vi.fn()
+
+  interceptor.on('request', () => {
+    throw new Error('Custom error')
+  })
+  interceptor.on('unhandledException', (args) => {
+    const { request, controller } = args
+    unhandledExceptionListener(args)
+
+    // Handle exceptions as request errors.
+    controller.errorWith(new Error('Fallback error'))
+  })
+
+  const request = http.get('http://localhost/resource')
+
+  const requestErrorListener = vi.fn()
+  request.on('error', requestErrorListener)
+
+  await vi.waitFor(() => {
+    expect(requestErrorListener).toHaveBeenNthCalledWith(
+      1,
+      new Error('Fallback error')
+    )
+  })
+  expect(request.destroyed).toBe(true)
+
+  expect(unhandledExceptionListener).toHaveBeenCalledWith(
+    expect.objectContaining({
+      error: new Error('Custom error'),
+    })
+  )
 })

--- a/test/modules/http/compliance/http-unhandled-exception.test.ts
+++ b/test/modules/http/compliance/http-unhandled-exception.test.ts
@@ -50,7 +50,7 @@ it('treats unhandled interceptor errors as 500 responses', async () => {
   })
 })
 
-it('performs request as-is if "unhandledException" listener is provided but does nothing', async () => {
+it('handles exceptions by default if "unhandledException" listener is provided but does nothing', async () => {
   const unhandledExceptionListener = vi.fn()
 
   interceptor.on('request', () => {


### PR DESCRIPTION
- Related to https://github.com/mswjs/msw/pull/2135

## Changes

Adds a new event to the HTTP events map called `unhandledException`. If the listener for that event is provided, whenever an unhandled exception occurs in the `request` listener, the `unhandledException` listener will be called (if present).

This allows the client to opt-out from the default handling of exceptions (producing 500 error responses), as well as do so conditionally. If the `unhandledException` listener does nothing, the default handling kicks in. 

**Note:** The `unhandledException` listener receives a _readonly_ `request` instance (non-interactive request). To affect the request, it receives an additional `controller` object with methods `.respondWith()` and `.errorWith()`. 

> `request.respondWith()` operates on a promise basis and by the time exception occurs, that promise has been awaited already. Besides, I very much wish to move away from patching the `Request` instance with `.respondWith()` to the designated `controller` argument for the `request` listener as well. I see this as an incremental change in that direction. 

```js
interceptor.on('unhandledException', ({ error, request, requestId, controller }) => {
  controller.respondWith(new Response('fallback response'))
  // controller.errorWith(new Error('fallback error'))
})
```