### PR TITLE
fix(ClientRequest): decode uri for username and password before setting basic authentication header

### DIFF
--- a/src/interceptors/ClientRequest/utils/createRequest.ts
+++ b/src/interceptors/ClientRequest/utils/createRequest.ts
@@ -26,7 +26,9 @@ export function createRequest(clientRequest: NodeClientRequest): Request {
    * @see https://github.com/mswjs/interceptors/issues/438
    */
   if (clientRequest.url.username || clientRequest.url.password) {
-    const auth = `${clientRequest.url.username || ''}:${clientRequest.url.password || ''}`
+    const username = decodeURIComponent(clientRequest.url.username || '')
+    const password = decodeURIComponent(clientRequest.url.password || '')
+    const auth = `${username}:${password}`
     headers.set('Authorization', `Basic ${btoa(auth)}`)
 
     // Remove the credentials from the URL since you cannot

--- a/test/third-party/axios.test.ts
+++ b/test/third-party/axios.test.ts
@@ -125,6 +125,7 @@ it('preserves "auth" (Authorization)', async () => {
 
   // Construct an Axios request with "auth".
   await axios.get(httpServer.http.url('/books'), {
+    adapter: 'http',
     auth: {
       // Use an email address as the username.
       // This must NOT be encoded.


### PR DESCRIPTION
- Closes #565
- Fixes #564 