### PR TITLE
feat(WebSocket): add connection "info" to the "connection" event payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,10 +322,11 @@ intereceptor.on('connection', ({ client }) => {
 
 The `connection` event exposes the following arguments:
 
-| Name     | Type                                                      | Description                                                      |
-| -------- | --------------------------------------------------------- | ---------------------------------------------------------------- |
-| `client` | [`WebSocketClientConnection`](#websocketclientconnection) | An object representing a connected WebSocket client instance.    |
-| `server` | [`WebSocketServerConnection`](#websocketserverconnection) | An object representing the original WebSocket server connection. |
+| Name        | Type                                                      | Description                                                      |
+| ----------- | --------------------------------------------------------- | ---------------------------------------------------------------- |
+| `client`    | [`WebSocketClientConnection`](#websocketclientconnection) | An object representing a connected WebSocket client instance.    |
+| `server`    | [`WebSocketServerConnection`](#websocketserverconnection) | An object representing the original WebSocket server connection. |
+| `protocols` | <code>string &#124; string[] &#124; undefined</code>      | The protocols supported by the WebSocket client.                 |
 
 ### `WebSocketClientConnection`
 

--- a/README.md
+++ b/README.md
@@ -322,11 +322,11 @@ intereceptor.on('connection', ({ client }) => {
 
 The `connection` event exposes the following arguments:
 
-| Name        | Type                                                      | Description                                                      |
-| ----------- | --------------------------------------------------------- | ---------------------------------------------------------------- |
-| `client`    | [`WebSocketClientConnection`](#websocketclientconnection) | An object representing a connected WebSocket client instance.    |
-| `server`    | [`WebSocketServerConnection`](#websocketserverconnection) | An object representing the original WebSocket server connection. |
-| `protocols` | <code>string &#124; string[] &#124; undefined</code>      | The protocols supported by the WebSocket client.                 |
+| Name     | Type                                                      | Description                                                                         |
+| -------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `client` | [`WebSocketClientConnection`](#websocketclientconnection) | An object representing a connected WebSocket client instance.                       |
+| `server` | [`WebSocketServerConnection`](#websocketserverconnection) | An object representing the original WebSocket server connection.                    |
+| `info`   | `object`                                                  | Additional WebSocket connection information (like the original client `protocols`). |
 
 ### `WebSocketClientConnection`
 

--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -30,9 +30,14 @@ export type WebSocketConnectionData = {
   server: WebSocketServerConnection
 
   /**
-   * The protocols supported by the WebSocket client.
+   * The connection information.
    */
-  protocols: ConstructorParameters<typeof globalThis.WebSocket>[1]
+  info: {
+    /**
+     * The protocols supported by the WebSocket client.
+     */
+    protocols: string | Array<string> | undefined
+  }
 }
 
 /**
@@ -87,7 +92,9 @@ export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
               transport,
               createConnection
             ),
-            protocols,
+            info: {
+              protocols,
+            },
           })
         })
 

--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -28,6 +28,11 @@ export type WebSocketConnectionData = {
    * The original WebSocket server connection.
    */
   server: WebSocketServerConnection
+
+  /**
+   * The protocols supported by the WebSocket client.
+   */
+  protocols: ConstructorParameters<typeof globalThis.WebSocket>[1]
 }
 
 /**
@@ -82,6 +87,7 @@ export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
               transport,
               createConnection
             ),
+            protocols,
           })
         })
 

--- a/test/modules/WebSocket/compliance/websocket.connection.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.connection.test.ts
@@ -57,6 +57,7 @@ it('emits the correct "connection" event on the interceptor', async () => {
         addEventListener: expect.any(Function),
         removeEventListener: expect.any(Function),
       }),
+      protocols: undefined,
     })
   )
 })
@@ -73,4 +74,20 @@ it('does not connect to the actual WebSocket server by default', async () => {
 
   expect(connectionListener).toHaveBeenCalledTimes(1)
   expect(realConnectionListener).not.toHaveBeenCalled()
+})
+
+it('passes client protocols to the "connection" event on the interceptor', async () => {
+  const connectionListener = vi.fn()
+  interceptor.once('connection', connectionListener)
+
+  new WebSocket('wss://example.com', ['protocol1', 'protocol2'])
+  await waitForNextTick()
+
+  expect(connectionListener).toHaveBeenCalledTimes(1)
+  expect(connectionListener).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({
+      protocols: ['protocol1', 'protocol2'],
+    })
+  )
 })

--- a/test/modules/WebSocket/compliance/websocket.connection.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.connection.test.ts
@@ -57,7 +57,9 @@ it('emits the correct "connection" event on the interceptor', async () => {
         addEventListener: expect.any(Function),
         removeEventListener: expect.any(Function),
       }),
-      protocols: undefined,
+      info: {
+        protocols: undefined,
+      },
     })
   )
 })
@@ -76,7 +78,7 @@ it('does not connect to the actual WebSocket server by default', async () => {
   expect(realConnectionListener).not.toHaveBeenCalled()
 })
 
-it('passes client protocols to the "connection" event on the interceptor', async () => {
+it('includes connection information in the "connection" event payload', async () => {
   const connectionListener = vi.fn()
   interceptor.once('connection', connectionListener)
 
@@ -87,7 +89,10 @@ it('passes client protocols to the "connection" event on the interceptor', async
   expect(connectionListener).toHaveBeenNthCalledWith(
     1,
     expect.objectContaining({
-      protocols: ['protocol1', 'protocol2'],
+      info: {
+        // Preserves the client protocols as-is.
+        protocols: ['protocol1', 'protocol2'],
+      },
     })
   )
 })


### PR DESCRIPTION
Currently, there is no way to access the full list of protocols supported by the WebSocket client. `WebSocketOverride` only exposes the first value ([relevant line](https://github.com/mswjs/interceptors/blob/main/src/interceptors/WebSocket/WebSocketOverride.ts#L54)).

This PR exposes the client protocols in the `connection` event, so tests can verify the client provided the right protocols.