### PR TITLE
fix: set "WebSocket.protocol" to an empty string by default

### DIFF
--- a/src/interceptors/WebSocket/WebSocketOverride.ts
+++ b/src/interceptors/WebSocket/WebSocketOverride.ts
@@ -51,7 +51,12 @@ export class WebSocketOverride extends EventTarget implements WebSocket {
     Reflect.set(this, 'readyState', this.CONNECTING)
     queueMicrotask(() => {
       Reflect.set(this, 'readyState', this.OPEN)
-      this.protocol = protocols ? protocols[0] : 'ws'
+      this.protocol =
+        typeof protocols === 'string'
+          ? protocols
+          : Array.isArray(protocols) && protocols.length > 0
+          ? protocols[0]
+          : ''
 
       this.dispatchEvent(bindEvent(this, new Event('open')))
     })


### PR DESCRIPTION
This issue came up in #577, see that thread for more information.

The WebSocket specification uses an empty string if no protocol is agreed upon, not `ws`.