### PR TITLE
fix(ClientRequest): account for missing `agent.destroy` when terminating a request

### DIFF
--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -634,12 +634,13 @@ export class NodeClientRequest extends ClientRequest {
    */
   private terminate(): void {
     /**
-     * @note Some request clients (e.g. Octokit) create a ClientRequest
-     * in a way that it has no Agent set. Now, whether that's correct is
+     * @note Some request clients (e.g. Octokit, or proxy providers like
+     * `global-agent`) create a ClientRequest in a way that it has no Agent set,
+     * or does not have a destroy method on it. Now, whether that's correct is
      * debatable, but we should still handle this case gracefully.
      * @see https://github.com/mswjs/interceptors/issues/304
      */
     // @ts-ignore
-    this.agent?.destroy()
+    this.agent?.destroy?.()
   }
 }

--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -640,7 +640,7 @@ export class NodeClientRequest extends ClientRequest {
      * debatable, but we should still handle this case gracefully.
      * @see https://github.com/mswjs/interceptors/issues/304
      */
-    // @ts-ignore
+    // @ts-ignore "agent" is a private property.
     this.agent?.destroy?.()
   }
 }


### PR DESCRIPTION
Follow-up from https://github.com/mswjs/interceptors/pull/330, see https://github.com/mswjs/interceptors/issues/304#issuecomment-2178645901 for details.

I understand that this is all highly unfortunate. But as long as some agent providers misbehave, this does help. Thank you!