### PR TITLE
feat(ClientRequest): await response listeners before emitting the "end" response event

### DIFF
--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -669,7 +669,7 @@ export class NodeClientRequest extends ClientRequest {
         const callEmit = () => Reflect.apply(target, thisArg, args)
 
         if (event === 'end') {
-          promise.then(() => callEmit())
+          promise.finally(() => callEmit())
           return
         }
 

--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -367,32 +367,59 @@ export class NodeClientRequest extends ClientRequest {
         callback?.()
 
         this.logger.info('emitting the custom "response" event...')
-        this.emitter.emit('response', {
-          response: responseClone,
-          isMockedResponse: true,
-          request: capturedRequest,
-          requestId,
-        })
 
-        this.logger.info('request (mock) is completed')
+        until(async () => {
+          await emitAsync(this.emitter, 'response', {
+            response: responseClone,
+            isMockedResponse: true,
+            request: capturedRequest,
+            requestId,
+          })
+
+          // Mark the response as complete once all the response
+          // listeners have finished.
+          this.response.emit('end')
+
+          this.logger.info('request (mock) is completed')
+        })
 
         return this
       }
 
       this.logger.info('no mocked response received!')
 
-      this.once('response-internal', (message: IncomingMessage) => {
-        this.logger.info(message.statusCode, message.statusMessage)
-        this.logger.info('original response headers:', message.headers)
+      this.once(
+        'response-internal',
+        (message: IncomingMessage, originalMessage: IncomingMessage) => {
+          this.logger.info(message.statusCode, message.statusMessage)
+          this.logger.info('original response headers:', message.headers)
 
-        this.logger.info('emitting the custom "response" event...')
-        this.emitter.emit('response', {
-          response: createResponse(message),
-          isMockedResponse: false,
-          request: capturedRequest,
-          requestId,
-        })
-      })
+          this.logger.info('emitting the custom "response" event...')
+
+          const responseListenersPromise = emitAsync(this.emitter, 'response', {
+            response: createResponse(message),
+            isMockedResponse: false,
+            request: capturedRequest,
+            requestId,
+          })
+
+          originalMessage.emit = new Proxy(originalMessage.emit, {
+            apply(target, thisArg, args) {
+              const [event] = args
+              const callEmit = () => Reflect.apply(target, thisArg, args)
+
+              if (event === 'end') {
+                // Delay emitting the "end" event of the original IncomingMessage
+                // until all the response listeners are done.
+                responseListenersPromise.then(() => callEmit())
+                return
+              }
+
+              return callEmit()
+            },
+          })
+        }
+      )
 
       return this.passthrough(chunk, encoding, callback)
     })
@@ -419,7 +446,7 @@ export class NodeClientRequest extends ClientRequest {
         const firstClone = cloneIncomingMessage(response)
         const secondClone = cloneIncomingMessage(response)
 
-        this.emit('response-internal', secondClone)
+        this.emit('response-internal', secondClone, firstClone)
 
         this.logger.info(
           'response successfully cloned, emitting "response" event...'
@@ -616,7 +643,7 @@ export class NodeClientRequest extends ClientRequest {
 
     isResponseStreamFinished.then(() => {
       this.logger.info('finalizing response...')
-      this.response.emit('end')
+      // this.response.emit('end')
       this.terminate()
 
       this.logger.info('request complete!')

--- a/test/features/events/response.test.ts
+++ b/test/features/events/response.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { vi, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
 import https from 'https'
-import fetch from 'node-fetch'
+import nodeFetch from 'node-fetch'
 import waitForExpect from 'wait-for-expect'
 import { HttpServer, httpsAgent } from '@open-draft/test-server/http'
 import { HttpRequestEventMap } from '../../../src'
@@ -69,6 +69,7 @@ beforeAll(async () => {
 })
 
 afterEach(() => {
+  interceptor.removeAllListeners('response')
   vi.resetAllMocks()
 })
 
@@ -79,7 +80,7 @@ afterAll(async () => {
 
 it('ClientRequest: emits the "response" event for a mocked response', async () => {
   const responseListener = vi.fn<HttpRequestEventMap['response']>()
-  interceptor.on('response', responseListener)
+  interceptor.once('response', responseListener)
 
   const req = https.request(httpServer.https.url('/user'), {
     method: 'GET',
@@ -228,9 +229,9 @@ it('XMLHttpRequest: emits the "response" event upon the original response', asyn
 
 it('fetch: emits the "response" event upon a mocked response', async () => {
   const responseListener = vi.fn<HttpRequestEventMap['response']>()
-  interceptor.on('response', responseListener)
+  interceptor.once('response', responseListener)
 
-  await fetch(httpServer.https.url('/user'), {
+  await nodeFetch(httpServer.https.url('/user'), {
     headers: {
       'x-request-custom': 'yes',
     },
@@ -259,7 +260,7 @@ it('fetch: emits the "response" event upon the original response', async () => {
   const responseListener = vi.fn<HttpRequestEventMap['response']>()
   interceptor.on('response', responseListener)
 
-  await fetch(httpServer.https.url('/account'), {
+  await nodeFetch(httpServer.https.url('/account'), {
     agent: httpsAgent,
     method: 'POST',
     headers: {

--- a/test/modules/http/response/http-await-response-event.test.ts
+++ b/test/modules/http/response/http-await-response-event.test.ts
@@ -1,0 +1,61 @@
+import { vi, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import http from 'node:http'
+import { HttpServer } from '@open-draft/test-server/http'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+import { sleep, waitForClientRequest } from '../../../helpers'
+
+const httpServer = new HttpServer((app) => {
+  app.get('/resource', (req, res) => {
+    res.send('original response')
+  })
+})
+
+const interceptor = new ClientRequestInterceptor()
+
+beforeAll(async () => {
+  interceptor.apply()
+  await httpServer.listen()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+  await httpServer.close()
+})
+
+it('awaits asynchronous response event listener for a mocked response', async () => {
+  interceptor.on('request', ({ request }) => {
+    request.respondWith(new Response('hello world'))
+  })
+
+  const responseDone = vi.fn()
+  interceptor.on('response', async ({ response }) => {
+    await sleep(200)
+    const text = await response.text()
+    responseDone(text)
+  })
+
+  const request = http.get('http://localhost/')
+  const { text } = await waitForClientRequest(request)
+
+  expect(await text()).toBe('hello world')
+  expect(responseDone).toHaveBeenCalledWith('hello world')
+})
+
+it('awaits asynchronous response event listener for the original response', async () => {
+  const responseDone = vi.fn()
+  interceptor.on('response', async ({ response }) => {
+    await sleep(200)
+    const text = await response.text()
+    responseDone(text)
+  })
+
+  const request = http.get(httpServer.http.url('/resource'))
+  const { text } = await waitForClientRequest(request)
+
+  expect(await text()).toBe('original response')
+  expect(responseDone).toHaveBeenCalledWith('original response')
+})


### PR DESCRIPTION
- Fixes #569 

## Changes

- ClientRequest: Awaits all the `response` event listeners before finishing the response (emitting its `end` event). This affects both mocked and original responses (the approach is different for each). 