### PR TITLE
chore: update pnpm/action-setup to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 
-      - uses: pnpm/action-setup@v2
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
         with:
           version: 8.15
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,19 +15,20 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_ADMIN_TOKEN }}
 
-      - name: Setup Git
+      - name: Set up Git
         run: |
           git config --local user.name "Artem Zakharchenko"
           git config --local user.email "kettanaito@gmail.com"
 
-      - name: Setup Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18
           always-auth: true
           registry-url: https://registry.npmjs.org
 
-      - uses: pnpm/action-setup@v2
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
         with:
           version: 8.15
 


### PR DESCRIPTION
Looks like `pnpm/action-setup@v2` is reliably failing on CI: https://github.com/mswjs/interceptors/actions/runs/9785986585/job/27048245243