### PR TITLE
fix(ClientRequest): return correct boolean from `.emit()` proxy

### DIFF
--- a/src/interceptors/ClientRequest/NodeClientRequest.ts
+++ b/src/interceptors/ClientRequest/NodeClientRequest.ts
@@ -664,13 +664,13 @@ export class NodeClientRequest extends ClientRequest {
     response: IncomingMessage
   ): void {
     response.emit = new Proxy(response.emit, {
-      apply(target, thisArg, args) {
+      apply: (target, thisArg, args) => {
         const [event] = args
         const callEmit = () => Reflect.apply(target, thisArg, args)
 
         if (event === 'end') {
           promise.finally(() => callEmit())
-          return
+          return this.listenerCount('end') > 0
         }
 
         return callEmit()


### PR DESCRIPTION
The `.emit()` method must return a boolean indicating if the given event has any listeners. Do that in case we defer the `end` event too. 