### PR TITLE
fix(ClientRequest): use `ServerResponse` to build the HTTP response string

### DIFF
--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -296,6 +296,18 @@ export class MockHttpSocket extends MockSocket {
     serverResponse.statusCode = response.status
     serverResponse.statusMessage = response.statusText
 
+    /**
+     * @note Remove the `Connection` and `Date` response headers
+     * injected by `ServerResponse` by default. Those are required
+     * from the server but the interceptor is NOT technically a server.
+     * It's confusing to add response headers that the developer didn't
+     * specify themselves. They can always add these if they wish.
+     * @see https://www.rfc-editor.org/rfc/rfc9110#field.date
+     * @see https://www.rfc-editor.org/rfc/rfc9110#field.connection
+     */
+    serverResponse.removeHeader('connection')
+    serverResponse.removeHeader('date')
+
     // Get the raw headers stored behind the symbol to preserve name casing.
     const headers = getRawFetchHeaders(response.headers) || response.headers
     for (const [name, value] of headers) {

--- a/test/modules/http/response/http-empty-response.test.ts
+++ b/test/modules/http/response/http-empty-response.test.ts
@@ -29,17 +29,3 @@ it('supports responding with an empty mocked response', async () => {
   expect(res.statusCode).toBe(200)
   expect(await text()).toBe('')
 })
-
-it('support transfer-encoding: chunked', async () => {
-  interceptor.once('request', ({ request }) => {
-    request.respondWith(new Response('OK', {
-      headers: { 'Transfer-Encoding': 'chunked' }
-    }))
-  })
-
-  const request = http.get('http://localhost')
-  const { res, text } = await waitForClientRequest(request)
-
-  expect(res.statusCode).toBe(200)
-  expect(await text()).toBe('OK')
-})

--- a/test/modules/http/response/http-empty-response.test.ts
+++ b/test/modules/http/response/http-empty-response.test.ts
@@ -27,5 +27,9 @@ it('supports responding with an empty mocked response', async () => {
   const { res, text } = await waitForClientRequest(request)
 
   expect(res.statusCode).toBe(200)
+  // Must not set any response headers that were not
+  // explicitly provided in the mocked response.
+  expect(res.headers).toEqual({})
+  expect(res.rawHeaders).toEqual([])
   expect(await text()).toBe('')
 })

--- a/test/modules/http/response/http-empty-response.test.ts
+++ b/test/modules/http/response/http-empty-response.test.ts
@@ -29,3 +29,17 @@ it('supports responding with an empty mocked response', async () => {
   expect(res.statusCode).toBe(200)
   expect(await text()).toBe('')
 })
+
+it('support transfer-encoding: chunked', async () => {
+  interceptor.once('request', ({ request }) => {
+    request.respondWith(new Response('OK', {
+      headers: { 'Transfer-Encoding': 'chunked' }
+    }))
+  })
+
+  const request = http.get('http://localhost')
+  const { res, text } = await waitForClientRequest(request)
+
+  expect(res.statusCode).toBe(200)
+  expect(await text()).toBe('OK')
+})

--- a/test/modules/http/response/http-response-transfer-encoding.test.ts
+++ b/test/modules/http/response/http-response-transfer-encoding.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @vitest-environment node
+ */
+import { it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import http from 'node:http'
+import { waitForClientRequest } from '../../../helpers'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+
+const interceptor = new ClientRequestInterceptor()
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+})
+
+it('responds with a mocked "transfer-encoding: chunked" response', async () => {
+  interceptor.on('request', ({ request }) => {
+    request.respondWith(
+      new Response('mock', {
+        headers: { 'Transfer-Encoding': 'chunked' },
+      })
+    )
+  })
+
+  const request = http.get('http://localhost')
+  const { res, text } = await waitForClientRequest(request)
+
+  expect(res.statusCode).toBe(200)
+  expect(res.headers).toHaveProperty('transfer-encoding', 'chunked')
+  expect(res.rawHeaders).toContain('Transfer-Encoding')
+  expect(await text()).toBe('mock')
+})


### PR DESCRIPTION
> Context: this allows us to support mocked responses with `Transfer-Encoding` and, potentially, other response transformations. 

I still need to give meaningful names to some variables, but it works as expected.

The idea here is that MSW acts as a Node.js server and uses the `ServerResponse` class to build the final chunks that we later push to our `socket`.

The only caveat I found is that we are maybe TOO close to the Node.js implementation 😅. For example, Nock's tests found that `ServerResponse` automatically returns `connection` and `date` headers, which we now add to the response. 
I think we can remove this default behavior, but I first want to know how you see it.
@kettanaito 