### PR TITLE
fix(ClientRequest): improve rawHeaders recording

### DIFF
--- a/src/interceptors/ClientRequest/index.test.ts
+++ b/src/interceptors/ClientRequest/index.test.ts
@@ -54,7 +54,7 @@ it('abort the request if the abort signal is emitted', async () => {
   expect(request.destroyed).toBe(true)
 })
 
-it.only('patch the Headers object correctly after dispose and reapply', async () => {
+it('patch the Headers object correctly after dispose and reapply', async () => {
   interceptor.dispose()
   interceptor.apply()
 

--- a/src/interceptors/ClientRequest/index.test.ts
+++ b/src/interceptors/ClientRequest/index.test.ts
@@ -73,4 +73,3 @@ it('patch the Headers object correctly after dispose and reapply', async () => {
   )
   expect(res.headers['x-custom-header']).toEqual('Yes')
 })
-

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
@@ -57,6 +57,35 @@ it('records raw headers (Headers / Headers as init', () => {
   ])
 })
 
+it('records raw headers added via ".set()"', () => {
+  recordRawFetchHeaders()
+  const headers = new Headers([['X-My-Header', '1']])
+  headers.set('X-Another-Header', '2')
+
+  expect(getRawFetchHeaders(headers)).toEqual([
+    ['X-My-Header', '1'],
+    ['X-Another-Header', '2'],
+  ])
+})
+
+it('records raw headers added via ".append()"', () => {
+  recordRawFetchHeaders()
+  const headers = new Headers([['X-My-Header', '1']])
+  headers.append('X-My-Header', '2')
+
+  expect(getRawFetchHeaders(headers)).toEqual([
+    ['X-My-Header', '1'],
+    ['X-My-Header', '2'],
+  ])
+})
+
+it('deletes the header when called ".delete()"', () => {
+  const headers = new Headers([['X-My-Header', '1']])
+  headers.delete('X-My-Header')
+
+  expect(getRawFetchHeaders(headers)).toEqual([])
+})
+
 it('records raw headers (Request / object as init)', () => {
   recordRawFetchHeaders()
   const request = new Request(url, {

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+import { it, expect, afterEach } from 'vitest'
+import {
+  recordRawFetchHeaders,
+  restoreHeadersPrototype,
+  getRawFetchHeaders,
+} from './recordRawHeaders'
+
+const url = 'http://localhost'
+
+afterEach(() => {
+  restoreHeadersPrototype()
+})
+
+it('returns an empty list if no headers were set', () => {
+  expect(getRawFetchHeaders(new Headers())).toEqual([])
+  expect(getRawFetchHeaders(new Headers(undefined))).toEqual([])
+  expect(getRawFetchHeaders(new Headers({}))).toEqual([])
+  expect(getRawFetchHeaders(new Headers([]))).toEqual([])
+  expect(getRawFetchHeaders(new Request(url).headers)).toEqual([])
+  expect(getRawFetchHeaders(new Response().headers)).toEqual([])
+})
+
+it('records raw headers (Headers / object as init)', () => {
+  recordRawFetchHeaders()
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+    'X-My-Header': '1',
+  })
+
+  expect(getRawFetchHeaders(headers)).toEqual([
+    ['Content-Type', 'application/json'],
+    ['X-My-Header', '1'],
+  ])
+  expect(Object.fromEntries(headers)).toEqual({
+    'content-type': 'application/json',
+    'x-my-header': '1',
+  })
+})
+
+it('records raw headers (Headers / array as init)', () => {
+  recordRawFetchHeaders()
+  const headers = new Headers([['X-My-Header', '1']])
+
+  expect(getRawFetchHeaders(headers)).toEqual([['X-My-Header', '1']])
+  expect(Object.fromEntries(headers)).toEqual({
+    'x-my-header': '1',
+  })
+})
+
+it('records raw headers (Headers / Headers as init', () => {
+  recordRawFetchHeaders()
+  const headers = new Headers([['X-My-Header', '1']])
+
+  expect(getRawFetchHeaders(new Headers(headers))).toEqual([
+    ['X-My-Header', '1'],
+  ])
+})
+
+it('records raw headers (Request / object as init)', () => {
+  recordRawFetchHeaders()
+  const request = new Request(url, {
+    headers: {
+      'Content-Type': 'application/json',
+      'X-My-Header': '1',
+    },
+  })
+
+  expect(getRawFetchHeaders(request.headers)).toEqual([
+    ['Content-Type', 'application/json'],
+    ['X-My-Header', '1'],
+  ])
+})
+
+it('records raw headers (Request / array as init)', () => {
+  recordRawFetchHeaders()
+  const request = new Request(url, {
+    headers: [['X-My-Header', '1']],
+  })
+
+  expect(getRawFetchHeaders(request.headers)).toEqual([['X-My-Header', '1']])
+})
+
+it('records raw headers (Request / Headers as init)', () => {
+  recordRawFetchHeaders()
+  const headers = new Headers([['X-My-Header', '1']])
+  const request = new Request(url, { headers })
+
+  expect(getRawFetchHeaders(request.headers)).toEqual([['X-My-Header', '1']])
+})
+
+it('records raw headers (Response / object as init)', () => {
+  recordRawFetchHeaders()
+  const response = new Response(null, {
+    headers: {
+      'Content-Type': 'application/json',
+      'X-My-Header': '1',
+    },
+  })
+
+  expect(getRawFetchHeaders(response.headers)).toEqual([
+    ['Content-Type', 'application/json'],
+    ['X-My-Header', '1'],
+  ])
+})
+
+it('records raw headers (Response / array as init)', () => {
+  recordRawFetchHeaders()
+  const response = new Response(null, {
+    headers: [['X-My-Header', '1']],
+  })
+
+  expect(getRawFetchHeaders(response.headers)).toEqual([['X-My-Header', '1']])
+})
+
+it('records raw headers (Response / Headers as init)', () => {
+  recordRawFetchHeaders()
+  const headers = new Headers([['X-My-Header', '1']])
+  const response = new Response(null, { headers })
+
+  expect(getRawFetchHeaders(response.headers)).toEqual([['X-My-Header', '1']])
+})
+
+it('stops recording once the patches are restored', () => {
+  restoreHeadersPrototype()
+
+  const headers = new Headers({ 'X-My-Header': '1' })
+  // Must return the normalized headers (no access to raw headers).
+  expect(getRawFetchHeaders(headers)).toEqual([['x-my-header', '1']])
+})

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
@@ -46,8 +46,13 @@ export function recordRawFetchHeaders() {
 
       globalThis.Request = OriginalRequest
       globalThis.Response = OriginalResponse
+
+      Object.defineProperty(Headers, kRestorePatches, {
+        value: undefined
+      });
     },
     enumerable: false,
+    configurable: true,
   })
 
   Headers = new Proxy(Headers, {

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
@@ -152,18 +152,16 @@ export function recordRawFetchHeaders() {
 
   Response = new Proxy(Response, {
     construct(target, args, newTarget) {
-      const response = Reflect.construct(target, args, newTarget)
-
-      if (typeof args[1] === 'object' && args[1].headers != null) {
-        /**
-         * @note Pass the init argument directly because it gets
-         * transformed into a normalized Headers instance once it
-         * passes the Response constructor.
-         */
-        response.headers[kRawHeaders] = inferRawHeaders(args[1].headers)
+      if (
+        typeof args[1] === 'object' &&
+        args[1].headers != null &&
+        args[1].headers instanceof Headers &&
+        Reflect.has(args[1].headers, kRawHeaders)
+      ) {
+        args[1].headers = args[1].headers[kRawHeaders]
       }
 
-      return response
+      return Reflect.construct(target, args, newTarget)
     },
   })
 }

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
@@ -47,9 +47,7 @@ export function recordRawFetchHeaders() {
       globalThis.Request = OriginalRequest
       globalThis.Response = OriginalResponse
 
-      Object.defineProperty(Headers, kRestorePatches, {
-        value: undefined
-      });
+      Reflect.deleteProperty(Headers, kRestorePatches)
     },
     enumerable: false,
     configurable: true,

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
@@ -175,9 +175,14 @@ export function restoreHeadersPrototype() {
 }
 
 export function getRawFetchHeaders(headers: Headers): RawHeaders {
-  // Return the raw headers, if recorded (i.e. `.set()` or `.append()` was called).
-  // If no raw headers were recorded, return all the headers.
-  return Reflect.get(headers, kRawHeaders) || Array.from(headers.entries())
+  // If the raw headers recording failed for some reason,
+  // use the normalized header entries instead.
+  if (!Reflect.has(headers, kRawHeaders)) {
+    return Array.from(headers.entries())
+  }
+
+  const rawHeaders = Reflect.get(headers, kRawHeaders) as RawHeaders
+  return rawHeaders.length > 0 ? rawHeaders : Array.from(headers.entries())
 }
 
 /**

--- a/test/modules/http/compliance/http-res-raw-headers.test.ts
+++ b/test/modules/http/compliance/http-res-raw-headers.test.ts
@@ -172,24 +172,3 @@ it('preserves raw response headers for unmocked request', async () => {
   )
   expect(res.headers['x-custom-header']).toEqual('Yes')
 })
-
-it('make sure we patch the Headers object correctly after dispose and reapply', async () => {
-  interceptor.dispose()
-  interceptor.apply()
-
-  interceptor.on('request', ({ controller }) => {
-    const headers = new Headers({
-      'X-CustoM-HeadeR': 'Yes',
-    })
-    controller.respondWith(new Response(null, { headers }))
-  })
-
-  const request = http.get(httpServer.http.url('/'))
-  const { res } = await waitForClientRequest(request)
-
-  expect(res.rawHeaders).toEqual(
-    expect.arrayContaining(['X-CustoM-HeadeR', 'Yes'])
-  )
-  expect(res.headers['x-custom-header']).toEqual('Yes')
-})
-

--- a/test/modules/http/compliance/http-res-raw-headers.test.ts
+++ b/test/modules/http/compliance/http-res-raw-headers.test.ts
@@ -172,3 +172,24 @@ it('preserves raw response headers for unmocked request', async () => {
   )
   expect(res.headers['x-custom-header']).toEqual('Yes')
 })
+
+it('make sure we patch the Headers object correctly after dispose and reapply', async () => {
+  interceptor.dispose()
+  interceptor.apply()
+
+  interceptor.on('request', ({ controller }) => {
+    const headers = new Headers({
+      'X-CustoM-HeadeR': 'Yes',
+    })
+    controller.respondWith(new Response(null, { headers }))
+  })
+
+  const request = http.get(httpServer.http.url('/'))
+  const { res } = await waitForClientRequest(request)
+
+  expect(res.rawHeaders).toEqual(
+    expect.arrayContaining(['X-CustoM-HeadeR', 'Yes'])
+  )
+  expect(res.headers['x-custom-header']).toEqual('Yes')
+})
+


### PR DESCRIPTION
@kettanaito The [problem](https://github.com/mswjs/interceptors/pull/598#discussion_r1671313975) was that we didn't unset the `kRestorePatches` symbol on `dispose`

I think my solution may not be "private" enough because I set it to be `configurable`. Alternatively, we can conditionally return undefined by toggling a variable, but it's smelly and error-prone. 
What is the best solution here?