### PR TITLE
feat(WebSocket): support passthrough, correctly emit the `error` event

### DIFF
--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -5,7 +5,8 @@ import {
 } from './WebSocketClientConnection'
 import { WebSocketServerConnection } from './WebSocketServerConnection'
 import { WebSocketClassTransport } from './WebSocketClassTransport'
-import { WebSocketOverride } from './WebSocketOverride'
+import { kPassthroughPromise, WebSocketOverride } from './WebSocketOverride'
+import { bindEvent } from './utils/bindEvent'
 
 export { type WebSocketData, WebSocketTransport } from './WebSocketTransport'
 export {
@@ -82,20 +83,42 @@ export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
         // so the client can modify WebSocket options, like "binaryType"
         // while the connection is already pending.
         queueMicrotask(() => {
+          const server = new WebSocketServerConnection(
+            socket,
+            transport,
+            createConnection
+          )
+
           // The "globalThis.WebSocket" class stands for
           // the client-side connection. Assume it's established
           // as soon as the WebSocket instance is constructed.
-          this.emitter.emit('connection', {
+          const hasConnectionListeners = this.emitter.emit('connection', {
             client: new WebSocketClientConnection(socket, transport),
-            server: new WebSocketServerConnection(
-              socket,
-              transport,
-              createConnection
-            ),
+            server,
             info: {
               protocols,
             },
           })
+
+          if (hasConnectionListeners) {
+            socket[kPassthroughPromise].resolve(false)
+          } else {
+            socket[kPassthroughPromise].resolve(true)
+
+            server.connect()
+
+            // Forward the "open" event from the original server
+            // to the mock WebSocket client in the case of a passthrough connection.
+            server.addEventListener('open', () => {
+              socket.dispatchEvent(bindEvent(socket, new Event('open')))
+
+              // Forward the original connection protocol to the
+              // mock WebSocket client.
+              if (server['realWebSocket']) {
+                socket.protocol = server['realWebSocket'].protocol
+              }
+            })
+          }
         })
 
         return socket

--- a/test/modules/WebSocket/compliance/websocket.client.events.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.client.events.test.ts
@@ -77,25 +77,3 @@ it('emits "close" event when the client closes itself', async () => {
     expect(closeListener).toHaveBeenCalledTimes(1)
   })
 })
-
-it('emits "error" event on client connection failure', async () => {
-  // Connecting to a non-existing server URL without any
-  // interceptor listener set up MUST establish the connection as-is
-  // (no "open" event; "error" event; no "close" event).
-  const ws = new WebSocket('wss://localhost/non-existing-url')
-
-  const openListener = vi.fn()
-  const errorListener = vi.fn()
-  const closeListener = vi.fn()
-  ws.onopen = openListener
-  ws.onerror = errorListener
-  ws.onclose = closeListener
-
-  await vi.waitFor(() => {
-    expect(openListener).not.toHaveBeenCalled()
-    expect(errorListener).toHaveBeenCalledTimes(1)
-    expect(closeListener).not.toHaveBeenCalled()
-  })
-})
-
-it('does not emit "error" event on user non-configurable closure codes', async () => {})

--- a/test/modules/WebSocket/compliance/websocket.client.events.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.client.events.test.ts
@@ -3,7 +3,7 @@
  * This test suite asserts that the "client" connection object
  * dispatches the right events in different scenarios.
  */
-import { vi, it, expect, beforeAll, afterAll } from 'vitest'
+import { vi, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
 import {
   WebSocketData,
   WebSocketInterceptor,
@@ -14,6 +14,10 @@ const interceptor = new WebSocketInterceptor()
 
 beforeAll(() => {
   interceptor.apply()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
 })
 
 afterAll(() => {
@@ -73,3 +77,25 @@ it('emits "close" event when the client closes itself', async () => {
     expect(closeListener).toHaveBeenCalledTimes(1)
   })
 })
+
+it('emits "error" event on client connection failure', async () => {
+  // Connecting to a non-existing server URL without any
+  // interceptor listener set up MUST establish the connection as-is
+  // (no "open" event; "error" event; no "close" event).
+  const ws = new WebSocket('wss://localhost/non-existing-url')
+
+  const openListener = vi.fn()
+  const errorListener = vi.fn()
+  const closeListener = vi.fn()
+  ws.onopen = openListener
+  ws.onerror = errorListener
+  ws.onclose = closeListener
+
+  await vi.waitFor(() => {
+    expect(openListener).not.toHaveBeenCalled()
+    expect(errorListener).toHaveBeenCalledTimes(1)
+    expect(closeListener).not.toHaveBeenCalled()
+  })
+})
+
+it('does not emit "error" event on user non-configurable closure codes', async () => {})

--- a/test/modules/WebSocket/compliance/websocket.events.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.events.test.ts
@@ -3,9 +3,16 @@
  * This test suite asserts that the intercepted WebSocket client
  * still dispatches the correct events in mocked/bypassed scenarios.
  */
-import { it, expect, beforeAll, afterAll } from 'vitest'
+import { vi, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
 import { DeferredPromise } from '@open-draft/deferred-promise'
+import { WebSocketServer } from 'ws'
 import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket'
+import { getWsUrl } from '../utils/getWsUrl'
+
+const wsServer = new WebSocketServer({
+  host: '127.0.0.1',
+  port: 0,
+})
 
 const interceptor = new WebSocketInterceptor()
 
@@ -13,33 +20,67 @@ beforeAll(() => {
   interceptor.apply()
 })
 
-afterAll(() => {
-  interceptor.dispose()
+afterEach(() => {
+  interceptor.removeAllListeners()
+  wsServer.removeAllListeners()
+  wsServer.clients.forEach((client) => client.close())
 })
 
-it('emits "open" event when the connection is opened', async () => {
-  const openEventPromise = new DeferredPromise<Event>()
+afterAll(() => {
+  interceptor.dispose()
+  wsServer.close()
+})
 
-  const ws = new WebSocket('wss://example.com')
-  ws.onopen = openEventPromise.resolve
+it('emits "open" event when mocked connection is opened', async () => {
+  /**
+   * @note At least one "connection" listener has to be added
+   * in order for the WebSocket connections to be mock-first.
+   */
+  interceptor.once('connection', () => {})
 
-  const openEvent = await openEventPromise
+  const ws = new WebSocket('wss://localhost')
+  const openListener = vi.fn()
+  ws.onopen = openListener
+
+  await vi.waitFor(() => {
+    expect(openListener).toHaveBeenCalledTimes(1)
+  })
+
+  const [openEvent] = openListener.mock.calls[0]
   expect(openEvent.type).toBe('open')
   expect(openEvent.target).toBe(ws)
   expect(openEvent.currentTarget).toBe(ws)
 })
 
-it('emits "message" event on the incoming event from the server', async () => {
+it('emits "open" event when original connection is opened', async () => {
+  const ws = new WebSocket(getWsUrl(wsServer))
+  const openListener = vi.fn()
+  ws.onopen = openListener
+
+  await vi.waitFor(() => {
+    expect(openListener).toHaveBeenCalledTimes(1)
+  })
+
+  const [openEvent] = openListener.mock.calls[0]
+  expect(openEvent.type).toBe('open')
+  expect(openEvent.target).toBe(ws)
+  expect(openEvent.currentTarget).toBe(ws)
+})
+
+it('emits "message" event on incoming mock server data', async () => {
   interceptor.once('connection', ({ client }) => {
     client.send('hello')
   })
 
-  const messageEventPromise = new DeferredPromise<MessageEvent>()
+  const ws = new WebSocket('wss://localhost')
+  const messageListener = vi.fn()
+  ws.onmessage = messageListener
 
-  const ws = new WebSocket('wss://example.com')
-  ws.onmessage = messageEventPromise.resolve
+  await vi.waitFor(() => {
+    expect(messageListener).toHaveBeenCalledTimes(1)
+  })
 
-  const messageEvent = await messageEventPromise
+  const [messageEvent] = messageListener.mock.calls[0]
   expect(messageEvent.type).toBe('message')
   expect(messageEvent.data).toBe('hello')
   expect(messageEvent.target).toBe(ws)
@@ -47,75 +88,184 @@ it('emits "message" event on the incoming event from the server', async () => {
   expect(messageEvent.origin).toBe(ws.url)
 })
 
-it('emits "close" event when the connection is closed', async () => {
-  const closeEventPromise = new DeferredPromise<CloseEvent>()
-
-  const ws = new WebSocket('wss://example.com')
-  ws.onclose = closeEventPromise.resolve
-  ws.close()
-
-  expect(await closeEventPromise).toMatchObject({
-    type: 'close',
-    target: ws,
+it('emits "message" event on incoming original server data', async () => {
+  wsServer.once('connection', (ws) => {
+    ws.send('hello')
   })
+
+  const ws = new WebSocket(getWsUrl(wsServer))
+  const messageListener = vi.fn()
+  ws.onmessage = messageListener
+
+  await vi.waitFor(() => {
+    expect(messageListener).toHaveBeenCalledTimes(1)
+  })
+
+  const [messageEvent] = messageListener.mock.calls[0]
+  expect(messageEvent.type).toBe('message')
+  expect(messageEvent.data).toBe('hello')
+  expect(messageEvent.target).toBe(ws)
+  expect(messageEvent.currentTarget).toBe(ws)
+  expect(messageEvent.origin).toBe(ws.url)
 })
 
-it('emits "close" event when the connection is closed normally by the server', async () => {
-  interceptor.once('connection', ({ client }) => {
-    client.close()
+it('emits "close" event when the mocked client closes the connection', async () => {
+  interceptor.once('connection', () => {})
+
+  const ws = new WebSocket('wss://localhost')
+  const closeListener = vi.fn()
+  ws.onclose = closeListener
+  /**
+   * @note Closing the connection before it has been open
+   * results in an error.
+   */
+  ws.onopen = () => ws.close()
+
+  await vi.waitFor(() => {
+    expect(closeListener).toHaveBeenCalledTimes(1)
   })
 
-  const closeEventPromise = new DeferredPromise<CloseEvent>()
-
-  const ws = new WebSocket('wss://example.com')
-  ws.onclose = closeEventPromise.resolve
-
-  const closeEvent = await closeEventPromise
+  const [closeEvent] = closeListener.mock.calls[0]
   expect(closeEvent.type).toBe('close')
+  expect(closeEvent.code).toBe(1000)
+  expect(closeEvent.reason).toBe('')
+  expect(closeEvent.wasClean).toBe(true)
   expect(closeEvent.target).toBe(ws)
+  expect(closeEvent.currentTarget).toBe(ws)
 })
 
-it('emits "close" event when the connection is closed by the server with a code and a reason', async () => {
+it('emits "close" event when the original server closes the connection', async () => {
+  wsServer.once('connection', (ws) => {
+    ws.close(1000)
+  })
+
+  const ws = new WebSocket(getWsUrl(wsServer))
+  const closeListener = vi.fn()
+  ws.onclose = closeListener
+
+  await vi.waitFor(() => {
+    expect(closeListener).toHaveBeenCalledTimes(1)
+  })
+
+  const [closeEvent] = closeListener.mock.calls[0]
+  expect(closeEvent.type).toBe('close')
+  expect(closeEvent.code).toBe(1000)
+  expect(closeEvent.reason).toBe('')
+  expect(closeEvent.wasClean).toBe(true)
+  expect(closeEvent.target).toBe(ws)
+  expect(closeEvent.currentTarget).toBe(ws)
+})
+
+it('emits "close" event when the interceptor gracefully closes the connection', async () => {
+  interceptor.once('connection', ({ client }) => {
+    queueMicrotask(() => client.close())
+  })
+
+  const ws = new WebSocket('wss://localhost')
+  const closeListener = vi.fn()
+  ws.onclose = closeListener
+
+  await vi.waitFor(() => {
+    expect(closeListener).toHaveBeenCalledTimes(1)
+  })
+
+  const [closeEvent] = closeListener.mock.calls[0]
+  expect(closeEvent.type).toBe('close')
+  expect(closeEvent.code).toBe(1000)
+  expect(closeEvent.reason).toBe('')
+  expect(closeEvent.wasClean).toBe(true)
+  expect(closeEvent.target).toBe(ws)
+  expect(closeEvent.currentTarget).toBe(ws)
+})
+
+it('emits "close" event when the interceptor closes the connection with error code', async () => {
   interceptor.once('connection', ({ client }) => {
     client.close(3000, 'Oops!')
   })
 
   const closeEventPromise = new DeferredPromise<CloseEvent>()
 
-  const ws = new WebSocket('wss://example.com')
+  const ws = new WebSocket('wss://localhost')
   ws.onclose = closeEventPromise.resolve
 
   const closeEvent = await closeEventPromise
   expect(closeEvent.type).toBe('close')
   expect(closeEvent.code).toBe(3000)
   expect(closeEvent.reason).toBe('Oops!')
+  expect(closeEvent.wasClean).toBe(false)
   expect(closeEvent.target).toBe(ws)
   expect(closeEvent.currentTarget).toBe(ws)
 })
 
-it('emits "error" event when the connection is closed due to an error', async () => {
+it('emits "close" event when the original server closes the connection with error code', async () => {
+  wsServer.once('connection', (ws) => {
+    ws.close(1003, 'Server reason')
+  })
+
+  const ws = new WebSocket(getWsUrl(wsServer))
+  const closeListener = vi.fn()
+  ws.onclose = closeListener
+
+  await vi.waitFor(() => {
+    expect(closeListener).toHaveBeenCalledTimes(1)
+  })
+
+  const [closeEvent] = closeListener.mock.calls[0]
+  expect(closeEvent.type).toBe('close')
+  expect(closeEvent.code).toBe(1003)
+  expect(closeEvent.reason).toBe('Server reason')
+  expect(closeEvent.wasClean).toBe(false)
+  expect(closeEvent.target).toBe(ws)
+  expect(closeEvent.currentTarget).toBe(ws)
+})
+
+it('emits "error" event on passthrough client connection failure', async () => {
+  // Connecting to a non-existing server URL without any
+  // interceptor listener set up MUST establish the connection as-is
+  // (no "open" event; "error" event; no "close" event).
+  const ws = new WebSocket('wss://localhost/non-existing-url')
+
+  const openListener = vi.fn()
+  const errorListener = vi.fn()
+  const closeListener = vi.fn()
+  ws.onopen = openListener
+  ws.onerror = errorListener
+  ws.onclose = closeListener
+
+  await vi.waitFor(() => {
+    expect(openListener).not.toHaveBeenCalled()
+    expect(errorListener).toHaveBeenCalledTimes(1)
+    expect(closeListener).not.toHaveBeenCalled()
+  })
+})
+
+it('does not emit "error" event on mocked error code closures', async () => {
   interceptor.once('connection', ({ client }) => {
-    // Mock a connection close due to receiving the data
-    // the server cannot accept.
+    /**
+     * @note Closing the connection with non-configurable code
+     * does NOT result in the "error" event.
+     */
     client.close(1003)
   })
 
-  const errorEventPromise = new DeferredPromise<Event>()
-  const closeEventPromise = new DeferredPromise<CloseEvent>()
+  const ws = new WebSocket('wss://localhost')
 
-  const ws = new WebSocket('wss://example.com')
-  ws.onerror = errorEventPromise.resolve
-  ws.onclose = closeEventPromise.resolve
+  const errorListener = vi.fn()
+  const closeListener = vi.fn()
+  ws.onerror = errorListener
+  ws.onclose = closeListener
 
-  const errorEvent = await errorEventPromise
-  expect(errorEvent.type).toBe('error')
-  expect(errorEvent.target).toBe(ws)
+  await vi.waitFor(() => {
+    expect(closeListener).toHaveBeenCalledTimes(1)
+  })
 
-  const closeEvent = await closeEventPromise
+  const [closeEvent] = closeListener.mock.calls[0]
   expect(closeEvent.type).toBe('close')
   expect(closeEvent.code).toBe(1003)
   expect(closeEvent.reason).toBe('')
   expect(closeEvent.wasClean).toBe(false)
   expect(closeEvent.target).toBe(ws)
   expect(closeEvent.currentTarget).toBe(ws)
+
+  expect(errorListener).not.toHaveBeenCalled()
 })

--- a/test/modules/WebSocket/compliance/websocket.server.connect.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.server.connect.test.ts
@@ -19,7 +19,7 @@ beforeAll(() => {
 })
 
 afterEach(() => {
-  wsServer.clients.forEach((client) => client.close(1000))
+  wsServer.clients.forEach((client) => client.close())
 })
 
 afterAll(() => {

--- a/test/modules/WebSocket/intercept/websocket.send.browser.test.ts
+++ b/test/modules/WebSocket/intercept/websocket.send.browser.test.ts
@@ -1,17 +1,21 @@
 import { test, expect } from '../../../playwright.extend'
 import type { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket'
-import { WebSocketSendData } from '../../../../src/interceptors/WebSocket/WebSocketTransport'
+import { WebSocketData } from '../../../../src/interceptors/WebSocket/WebSocketTransport'
 
 declare global {
   interface Window {
     interceptor: WebSocketInterceptor
-    outgoingData: WebSocketSendData
+    outgoingData: WebSocketData
   }
 }
 
 test('errors when sending data before open', async ({ loadExample, page }) => {
   await loadExample(require.resolve('../websocket.runtime.js'))
-  await page.evaluate(() => window.interceptor.apply())
+  await page.evaluate(() => {
+    const { interceptor } = window
+    interceptor.apply()
+    interceptor.on('connection', () => {})
+  })
 
   const sendError = await page.evaluate(() => {
     const ws = new WebSocket('wss://example.com')
@@ -124,6 +128,7 @@ test('increases "bufferedAmount" before the data is sent', async ({
   await page.evaluate(() => {
     const { interceptor } = window
     interceptor.apply()
+    interceptor.on('connection', () => {})
   })
 
   const bufferedAmount = await page.evaluate(() => {

--- a/test/modules/WebSocket/intercept/websocket.send.test.ts
+++ b/test/modules/WebSocket/intercept/websocket.send.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment node-with-websocket
  */
-import { it, expect, beforeAll, afterAll } from 'vitest'
+import { it, expect, beforeAll, afterAll, afterEach } from 'vitest'
 import { DeferredPromise } from '@open-draft/deferred-promise'
 import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket'
 
@@ -11,11 +11,16 @@ beforeAll(() => {
   interceptor.apply()
 })
 
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
 afterAll(() => {
   interceptor.dispose()
 })
 
 it('errors when sending data before open', async () => {
+  interceptor.once('connection', () => {})
   const ws = new WebSocket('ws://example.com')
   expect(() => ws.send('no-op')).toThrow('InvalidStateError')
 })
@@ -68,6 +73,8 @@ it('intercepts ArrayBuffer sent over websocket', async () => {
 })
 
 it('increases "bufferAmmount" before data is sent', async () => {
+  interceptor.once('connection', () => {})
+
   const bufferAmountPromise = new DeferredPromise<{
     beforeSend: number
     afterSend: number


### PR DESCRIPTION
> [!WARNING]
> Since WebSocket connections will now be established as-is if you haven't provided any interceptors, this is technically a breaking change despite fixing a bug. 

Interceptors has a bug that it will always emit the `open` even on the WebSocket client, even when there are no interceptor set up for any connections (so the connection cannot physically be intercepted). This results in such connections pending forever. 

> This may be a big against previously established expectations of WebSocket interception always being mock-first. But this is still a bug for bypassed connections, and it has to be fixed. 

I'm fixing this here without breaking any previously established promises. 

- WebSocket connection will be mock-first if _at least one `connection` listener on the interceptor is present_;
- WebSocket connection will be established as-is if no `connection` listeners on the interceptors are present (previously, the connection would be OPEN and pend forever). 

## Discoveries

- The `error` event is NOT dispatched on non-configurable closure codes, even if those codes represent errors (e.g. data cannot be accepted). 
- The `error` event is dispatched in cases like connection errors or _abrupt_ connection closures. 
- Also, Undici v5 has a bug validating WebSocket protocols: https://github.com/nodejs/undici/issues/2844. Fixed in Node.js v20 but not in v18.

## Roadmap

- [x] Add a failing test.
- [x] Establish the connection as-is if there were no interceptors set (`this.emit()` returned `false`). 
- [x] Fix the issue where `.close()` would dispatch an `error` event on non-configurable closure codes (that's not how WebSocket behave). 