### PR TITLE
fix(WebSocket): treat interceptor exceptions as closures with error

### DIFF
--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -83,41 +83,55 @@ export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
         // so the client can modify WebSocket options, like "binaryType"
         // while the connection is already pending.
         queueMicrotask(() => {
-          const server = new WebSocketServerConnection(
-            socket,
-            transport,
-            createConnection
-          )
+          try {
+            const server = new WebSocketServerConnection(
+              socket,
+              transport,
+              createConnection
+            )
 
-          // The "globalThis.WebSocket" class stands for
-          // the client-side connection. Assume it's established
-          // as soon as the WebSocket instance is constructed.
-          const hasConnectionListeners = this.emitter.emit('connection', {
-            client: new WebSocketClientConnection(socket, transport),
-            server,
-            info: {
-              protocols,
-            },
-          })
-
-          if (hasConnectionListeners) {
-            socket[kPassthroughPromise].resolve(false)
-          } else {
-            socket[kPassthroughPromise].resolve(true)
-
-            server.connect()
-
-            // Forward the "open" event from the original server
-            // to the mock WebSocket client in the case of a passthrough connection.
-            server.addEventListener('open', () => {
-              socket.dispatchEvent(bindEvent(socket, new Event('open')))
-
-              // Forward the original connection protocol to the
-              // mock WebSocket client.
-              if (server['realWebSocket']) {
-                socket.protocol = server['realWebSocket'].protocol
-              }
+            // The "globalThis.WebSocket" class stands for
+            // the client-side connection. Assume it's established
+            // as soon as the WebSocket instance is constructed.
+            const hasConnectionListeners = this.emitter.emit('connection', {
+              client: new WebSocketClientConnection(socket, transport),
+              server,
+              info: {
+                protocols,
+              },
             })
+
+            if (hasConnectionListeners) {
+              socket[kPassthroughPromise].resolve(false)
+            } else {
+              socket[kPassthroughPromise].resolve(true)
+
+              server.connect()
+
+              // Forward the "open" event from the original server
+              // to the mock WebSocket client in the case of a passthrough connection.
+              server.addEventListener('open', () => {
+                socket.dispatchEvent(bindEvent(socket, new Event('open')))
+
+                // Forward the original connection protocol to the
+                // mock WebSocket client.
+                if (server['realWebSocket']) {
+                  socket.protocol = server['realWebSocket'].protocol
+                }
+              })
+            }
+          } catch (error) {
+            /**
+             * @note Translate unhandled exceptions during the connection
+             * handling (i.e. interceptor exceptions) as WebSocket connection
+             * closures with error. This prevents from the exceptions occurring
+             * in `queueMicrotask` from being process-wide and uncatchable.
+             */
+            if (error instanceof Error) {
+              socket.dispatchEvent(new Event('error'))
+              socket.close(1000, error.message)
+              console.error(error)
+            }
           }
         })
 

--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -129,7 +129,16 @@ export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
              */
             if (error instanceof Error) {
               socket.dispatchEvent(new Event('error'))
-              socket.close(1000, error.message)
+
+              // No need to close the connection if it's already being closed.
+              // E.g. the interceptor called `client.close()` and then threw an error.
+              if (
+                socket.readyState !== WebSocket.CLOSING &&
+                socket.readyState !== WebSocket.CLOSED
+              ) {
+                socket.close(1000, error.message)
+              }
+
               console.error(error)
             }
           }

--- a/test/modules/WebSocket/exchange/websocket.interceptor.exception.test.ts
+++ b/test/modules/WebSocket/exchange/websocket.interceptor.exception.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node-with-websocket
+import { it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest'
+import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket'
+
+const interceptor = new WebSocketInterceptor()
+
+beforeAll(() => {
+  interceptor.apply()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+  vi.resetAllMocks()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+  vi.restoreAllMocks()
+})
+
+it('handles interceptor exception as WebSocket connection closure with error', async () => {
+  const interceptorError = new Error('Interceptor error')
+  interceptor.on('connection', () => {
+    throw interceptorError
+  })
+
+  const ws = new WebSocket('ws://localhost')
+  const closeListener = vi.fn<[CloseEvent]>()
+  const errorListener = vi.fn()
+  ws.onerror = errorListener
+  ws.onclose = closeListener
+
+  await vi.waitFor(() => {
+    expect(errorListener).toHaveBeenCalledOnce()
+    expect(closeListener).toHaveBeenCalledOnce()
+  })
+
+  expect(ws.readyState).toBe(WebSocket.CLOSED)
+
+  const [closeEvent] = closeListener.mock.calls[0]
+  expect(closeEvent.code).toBe(1000)
+  expect(closeEvent.reason).toBe('Interceptor error')
+  expect(closeEvent.wasClean).toBe(true)
+
+  expect(console.error).toHaveBeenCalledWith(interceptorError)
+})


### PR DESCRIPTION
- Related to https://github.com/mswjs/msw/pull/2011

While testing the `onUnhandledException` event in MSW, I noticed that unhandled exceptions in the `connection` listener are thrown on the entire process and are uncatchable. That's caused by the `connection` event being emitted in the `queueMicrotask` in the WebSocket interceptor. The queuing itself is correct.

I'm solving this by catching those interceptor exceptions and translating them to WebSocket connection closure with error. This means an unhandled interceptor exception will trigger `error` and `close` events, and also print the caught error to stderr. 