### PR TITLE
fix(WebSocket): use 1011 as close `code` for unhandled interceptor errors

### DIFF
--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -140,7 +140,7 @@ export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
                 socket.readyState !== WebSocket.CLOSING &&
                 socket.readyState !== WebSocket.CLOSED
               ) {
-                socket[kClose](1000, error.message, false)
+                socket[kClose](1011, error.message, false)
               }
 
               console.error(error)

--- a/test/modules/WebSocket/exchange/websocket.interceptor.exception.test.ts
+++ b/test/modules/WebSocket/exchange/websocket.interceptor.exception.test.ts
@@ -39,7 +39,7 @@ it('handles interceptor exception as WebSocket connection closure with error', a
   expect(ws.readyState).toBe(WebSocket.CLOSED)
 
   const [closeEvent] = closeCallback.mock.calls[0]
-  expect(closeEvent.code).toBe(1000)
+  expect(closeEvent.code).toBe(1011)
   expect(closeEvent.reason).toBe('Interceptor error')
   /**
    * @note Since the connection has been aborted due to the


### PR DESCRIPTION
Using `1000` as a close code for when the connection must be terminated non-gracefully is incorrect. 

I believe 1011 suits the best for this scenario:

> 1011
>
>  1011 indicates that a server is terminating the connection because
>  it encountered an unexpected condition that prevented it from
>  fulfilling the request.
> 