### PR TITLE
test(XMLHttpRequest): synchronous mode support

### DIFF
--- a/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.browser.test.ts
+++ b/test/modules/XMLHttpRequest/intercept/XMLHttpRequest.browser.test.ts
@@ -178,3 +178,24 @@ test('ignores the body for GET requests', async ({
   const [request] = await call
   expect(request.body).toBe(null)
 })
+
+test('intercepts a synchronous XMLHttpRequest', async ({
+  loadExample,
+  callXMLHttpRequest,
+}) => {
+  await loadExample(require.resolve('./XMLHttpRequest.browser.runtime.js'))
+
+  const url = httpServer.http.url('/user')
+  const call = callXMLHttpRequest({
+    method: 'POST',
+    url,
+    body: 'hello world',
+    async: false,
+  })
+
+  await expect(call).resolves.not.toThrowError()
+
+  const [request] = await call
+  expect(request.method).toBe('POST')
+  await expect(request.text()).resolves.toBe('hello world')
+})

--- a/test/modules/XMLHttpRequest/response/xhr.browser.test.ts
+++ b/test/modules/XMLHttpRequest/response/xhr.browser.test.ts
@@ -125,3 +125,23 @@ test('bypasses any request when the interceptor is restored', async ({
   expect(secondResponse.statusText).toBe('OK')
   expect(secondResponse.body).toEqual(JSON.stringify({ route: '/get' }))
 })
+
+test('mocks response to a synchronous XMLHttpRequest', async ({
+  loadExample,
+  callXMLHttpRequest,
+  page,
+}) => {
+  await loadExample(require.resolve('./xhr.browser.runtime.js'))
+  await forwardServerUrls(page)
+
+  const [, response] = await callXMLHttpRequest({
+    method: 'GET',
+    url: httpServer.http.url('/'),
+    async: false,
+  })
+
+  expect(response.status).toBe(201)
+  expect(response.statusText).toBe('Created')
+  expect(response.headers).toBe('content-type: application/hal+json')
+  expect(response.body).toEqual(JSON.stringify({ mocked: true }))
+})


### PR DESCRIPTION
- Fixes #338 
- Closes #108

This adds browser tests for synchronous XMLHttpRequest. Both interception and mocking tests are passing in the browser as-is. I suspect the interceptor's rewrite to Proxy might have accidentally fixed the synchronous mode support. 

> [!IMPORTANT]
> Note that JSDOM doesn't seem to support synchronous XMLHttpRequests. The test hangs indefinitely if I do `request.open(method, url, false)`. 