### PR TITLE
fix(fetch): rebase relative redirect URL against `request.url`

### DIFF
--- a/src/interceptors/fetch/utils/followRedirect.ts
+++ b/src/interceptors/fetch/utils/followRedirect.ts
@@ -25,6 +25,7 @@ export async function followFetchRedirect(
 
   let locationUrl: URL
   try {
+    // If the location is a relative URL, use the request URL as the base URL.
     locationUrl = new URL(response.headers.get('location')!, request.url) 
   } catch (error) {
     return Promise.reject(createNetworkError(error))

--- a/src/interceptors/fetch/utils/followRedirect.ts
+++ b/src/interceptors/fetch/utils/followRedirect.ts
@@ -25,7 +25,7 @@ export async function followFetchRedirect(
 
   let locationUrl: URL
   try {
-    locationUrl = new URL(response.headers.get('location')!)
+    locationUrl = new URL(response.headers.get('location')!, request.url) 
   } catch (error) {
     return Promise.reject(createNetworkError(error))
   }

--- a/test/modules/fetch/compliance/fetch-follow-redirects.test.ts
+++ b/test/modules/fetch/compliance/fetch-follow-redirects.test.ts
@@ -48,6 +48,21 @@ it('follows a mocked redirect to the original server', async () => {
   await expect(response.text()).resolves.toBe('redirected')
 })
 
+it('follows a mocked relative redirect to the original server', async () => {
+  interceptor.on('request', ({ request, controller }) => {
+    if (request.url.endsWith('/original')) {
+      return controller.respondWith(
+        new Response(null, { status: 302, headers: { location: '/redirected' } })
+      )
+    }
+  })
+
+  const response = await fetch(httpServer.http.url('/original'))
+
+  expect(response.status).toBe(200)
+  await expect(response.text()).resolves.toBe('redirected')
+})
+
 it('follows a mocked redirect to a mocked response', async () => {
   interceptor.on('request', ({ request, controller }) => {
     if (request.url.endsWith('/original')) {


### PR DESCRIPTION
Should we add a comment to explain why we use `request.url` as a base?