### PR TITLE
fix: wrong absolute path for _http_common in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "types": ["@types/node"],
     "baseUrl": ".",
     "paths": {
-      "_http_commons": ["./_http.common.d.ts"]
+      "_http_common": ["./_http_common.d.ts"]
     }
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
fixes #633 

![image](https://github.com/user-attachments/assets/ff292bbc-653d-46c5-945a-d7a45a4b50f9)

I found an error occurring when using MSW starting from version 2.4.4  
The cause seems to be an incorrect absolute path in mswjs/interceptor 0.35.0

```
//tsconfig.json

...
    "paths": {
      "_http_commons": ["./_http.common.d.ts"]
      // In the usage(MockHttpSocket.ts), _http_common is being used instead of _http_commons.
      // We do not have _http.common.d.ts, but instead have _http_common.d.ts.
    }
...
```

I just fixed the letters to match the filename 😅