### PR TITLE
fix(ClientRequest): fix a custom agent context in `createConnection`

### DIFF
--- a/src/interceptors/ClientRequest/agents.ts
+++ b/src/interceptors/ClientRequest/agents.ts
@@ -39,7 +39,11 @@ export class MockAgent extends http.Agent {
 
     const socket = new MockHttpSocket({
       connectionOptions: options,
-      createConnection: createConnection.bind(this.customAgent || this, options, callback),
+      createConnection: createConnection.bind(
+        this.customAgent || this,
+        options,
+        callback
+      ),
       onRequest: this.onRequest.bind(this),
       onResponse: this.onResponse.bind(this),
     })
@@ -68,7 +72,11 @@ export class MockHttpsAgent extends https.Agent {
 
     const socket = new MockHttpSocket({
       connectionOptions: options,
-      createConnection: createConnection.bind(this.customAgent || this, options, callback),
+      createConnection: createConnection.bind(
+        this.customAgent || this,
+        options,
+        callback
+      ),
       onRequest: this.onRequest.bind(this),
       onResponse: this.onResponse.bind(this),
     })

--- a/src/interceptors/ClientRequest/agents.ts
+++ b/src/interceptors/ClientRequest/agents.ts
@@ -39,7 +39,7 @@ export class MockAgent extends http.Agent {
 
     const socket = new MockHttpSocket({
       connectionOptions: options,
-      createConnection: createConnection.bind(this, options, callback),
+      createConnection: createConnection.bind(this.customAgent || this, options, callback),
       onRequest: this.onRequest.bind(this),
       onResponse: this.onResponse.bind(this),
     })
@@ -68,7 +68,7 @@ export class MockHttpsAgent extends https.Agent {
 
     const socket = new MockHttpSocket({
       connectionOptions: options,
-      createConnection: createConnection.bind(this, options, callback),
+      createConnection: createConnection.bind(this.customAgent || this, options, callback),
       onRequest: this.onRequest.bind(this),
       onResponse: this.onResponse.bind(this),
     })

--- a/test/modules/http/compliance/http-custom-agent.test.ts
+++ b/test/modules/http/compliance/http-custom-agent.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment node
+ */
+import { vi, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import type { Mock } from 'vitest'
+import http from 'node:http'
+import https from 'node:https'
+import type { Socket } from 'node:net'
+import { HttpServer, httpsAgent } from '@open-draft/test-server/http'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest/index'
+import { waitForClientRequest } from '../../../../test/helpers'
+
+const httpServer = new HttpServer((app) => {
+  app.get('/', (req, res) => {
+    res.send('original')
+  })
+})
+
+const interceptor = new ClientRequestInterceptor()
+
+const createAgent = (BaseClass: http.Agent | https.Agent) => {
+  // @ts-expect-error T2507
+  class CustomAgent extends BaseClass {
+    mockFunction: Mock;
+
+    constructor () {
+      super()
+      this.mockFunction = vi.fn()
+    }
+
+    createConnection (options: any, callback: any): Socket {
+      const result = super.createConnection(options, callback)
+      this.mockFunction()
+      return result
+    }
+  }
+  return new CustomAgent()
+}
+
+beforeAll(async () => {
+  interceptor.apply()
+  await httpServer.listen()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+  await httpServer.close()
+})
+
+it('binds the custom agent context for an http createConnection', async () => {
+  const agent = createAgent(http.Agent)
+  const httpUrl = httpServer.http.url('/')
+  const options = {
+    agent,
+  }
+  const request = http.get(httpUrl, options)
+
+  await waitForClientRequest(request)
+
+  expect(agent.mockFunction).toHaveBeenCalledTimes(1)
+})
+
+it('binds the custom agent context for an https createConnection', async () => {
+  const agent = createAgent(https.Agent)
+  const httpUrl = httpServer.https.url('/')
+  const options = {
+    agent,
+    rejectUnauthorized: false,
+  }
+  const request = https.get(httpUrl, options)
+
+  await waitForClientRequest(request)
+
+  expect(agent.mockFunction).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
When an intercepted request is not handled (`interceptor.on('request'...`) and the request uses a custom HTTP Agent, the custom agent's `createConnection` method is bound to the `MockHttpAgent`'s this context instead of the custom agent's this context, so methods/local variables are unavailable causing an exception.

This PR binds `this.customAgent` instead of the `MockAgent`'s `this` to the `createConnection` function to ensure scope is correct.

Fixes #635
