### PR TITLE
Fix Request Proxy

### DIFF
--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
@@ -157,3 +157,12 @@ it('stops recording once the patches are restored', () => {
   // Must return the normalized headers (no access to raw headers).
   expect(getRawFetchHeaders(headers)).toEqual([['x-my-header', '1']])
 })
+
+it('rawHeaders should not interfere with the real API - need better name', () => {
+  recordRawFetchHeaders()
+  const headers = new Headers({ "x-header": "old" });
+  headers.set("x-header", "new");
+  const response = new Request(url, { headers })
+
+  expect(response.headers.get('x-header')).toEqual('new')
+})


### PR DESCRIPTION
https://github.com/nock/nock/issues/2780

Added failing test.

@kettanaito the root cause is that we use the [`kRawHeaders`](https://github.com/mswjs/interceptors/blob/main/src/interceptors/ClientRequest/utils/recordRawHeaders.ts#L153) to populate the `headers`.

Do you have any thoughts on how to solve this conflict? I might be able to sort this out later this week, but right now I'm not sure about the best way to proceed.