### PR TITLE
fix(ClientRequest): handle `Headers` without internal symbol

### DIFF
--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
@@ -206,3 +206,16 @@ it('overrides an existing multi-value header when calling ".set()"', () => {
   headers.set('a', '3')
   expect(headers.get('a')).toBe('3')
 })
+
+it('does not throw on using Headers before recording', () => {
+  // If the consumer constructs a Headers instance before
+  // the interceptor is enabled, it will have no internal symbol set.
+  const headers = new Headers()
+  recordRawFetchHeaders()
+  const request = new Request(url, { headers })
+
+  expect(getRawFetchHeaders(request.headers)).toEqual([])
+
+  request.headers.set('X-My-Header', '1')
+  expect(getRawFetchHeaders(request.headers)).toEqual([['X-My-Header', '1']])
+})

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
@@ -294,7 +294,7 @@ export function getRawFetchHeaders(headers: Headers): RawHeaders {
  */
 function inferRawHeaders(headers: HeadersInit): RawHeaders {
   if (headers instanceof Headers) {
-    return Reflect.get(headers, kRawHeaders)
+    return Reflect.get(headers, kRawHeaders) || []
   }
 
   return Reflect.get(new Headers(headers), kRawHeaders)


### PR DESCRIPTION
- Fixes https://github.com/mswjs/msw/actions/runs/10956113682/job/30421449419?pr=2293

## Changes

- Add handling for situations when a `Headers` instance has been constructed _before_ the interceptor started recording the raw headers. Previously, threw this error:

```
TypeError: inferRawHeaders(...) is not iterable (cannot read property undefined)
```

> We were trying to `...inferRawHeaders()` on a `Headers` instance that had no `kRawHeaders` symbol set (the recording hasn't started yet). 