### PR TITLE
fix(ClientRequest): support intercepting buffered requests

### DIFF
--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -68,12 +68,6 @@ export class MockHttpSocket extends MockSocket {
   constructor(options: MockHttpSocketOptions) {
     super({
       write: (chunk, encoding, callback) => {
-        // Mark the request header as sent once the
-        // socket receives its first write (which is the request header).
-        if (!this.requestHeaderSent) {
-          this.requestHeaderSent = true
-        }
-
         this.writeBuffer.push([chunk, encoding, callback])
 
         if (chunk) {
@@ -470,6 +464,7 @@ export class MockHttpSocket extends MockSocket {
   }) {
     const { path, headers, keepAlive } = args
 
+    this.requestHeaderSent = true
     this.shouldKeepAlive = keepAlive
 
     const method = this.connectionOptions.method?.toUpperCase() || 'GET'

--- a/test/modules/http/compliance/http-keepalive.test.ts
+++ b/test/modules/http/compliance/http-keepalive.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { vi, it, expect, afterAll, afterEach, beforeAll } from 'vitest'
+import http from 'node:http'
+import { HttpServer } from '@open-draft/test-server/http'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+import { waitForClientRequest } from '../../..//helpers'
+
+const interceptor = new ClientRequestInterceptor()
+
+const httpServer = new HttpServer((app) => {
+  app.get('/resource', (req, res) => {
+    res.send('original response')
+  })
+})
+
+beforeAll(async () => {
+  interceptor.apply()
+  await httpServer.listen()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+  await httpServer.close()
+})
+
+it('dispatches the "connect" socket event when reusing sockets ("keepAlive": true)', async () => {
+  const connectListener = vi.fn()
+
+  const agent = new http.Agent({
+    keepAlive: true,
+  })
+
+  async function makeRequest() {
+    const request = http.request(httpServer.http.url('/resource'), {
+      method: 'GET',
+      agent,
+    })
+    request.on('socket', (socket) => {
+      socket.on('connect', connectListener)
+    })
+    request.end()
+    await waitForClientRequest(request)
+  }
+
+  await Promise.all([makeRequest(), makeRequest(), makeRequest()])
+
+  expect(connectListener).toHaveBeenCalledTimes(3)
+})

--- a/test/modules/http/compliance/http-req-end.test.ts
+++ b/test/modules/http/compliance/http-req-end.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+import { it, expect, afterAll, afterEach, beforeAll } from 'vitest'
+import http from 'node:http'
+import { HttpServer } from '@open-draft/test-server/http'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+import { waitForClientRequest } from '../../..//helpers'
+import { DeferredPromise } from '@open-draft/deferred-promise'
+
+const interceptor = new ClientRequestInterceptor()
+
+const httpServer = new HttpServer((app) => {
+  app.post('/resource', (req, res) => {
+    res.send('original response')
+  })
+})
+
+beforeAll(async () => {
+  interceptor.apply()
+  await httpServer.listen()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+  await httpServer.close()
+})
+
+it('allows calling "req.end()" in the "connect" socket event (bypass)', async () => {
+  const request = http.request(httpServer.http.url('/resource'), {
+    method: 'POST',
+    headers: { 'X-My-Header': '1' },
+  })
+  request.on('socket', (socket) => {
+    socket.on('connect', () => {
+      request.end()
+    })
+  })
+
+  const { text } = await waitForClientRequest(request)
+  await expect(text()).resolves.toBe('original response')
+})
+
+it('allows calling "req.end()" in the "connect" socket event (interceptor + bypass)', async () => {
+  const requestPromise = new DeferredPromise<Request>()
+  interceptor.on('request', ({ request }) => {
+    requestPromise.resolve(request)
+  })
+
+  const request = http.request(httpServer.http.url('/resource'), {
+    method: 'POST',
+    headers: { 'X-My-Header': '1' },
+  })
+  request.on('socket', (socket) => {
+    socket.on('connect', () => {
+      request.end()
+    })
+  })
+
+  const { text } = await waitForClientRequest(request)
+  await expect(text()).resolves.toBe('original response')
+
+  const interceptedRequest = await requestPromise
+  expect(interceptedRequest.method).toBe('POST')
+  expect(interceptedRequest.url).toBe(httpServer.http.url('/resource'))
+  expect(Array.from(interceptedRequest.headers)).toEqual([['x-my-header', '1']])
+})
+
+it('allows calling "req.end()" in the "connect" socket event (mocked)', async () => {
+  const requestPromise = new DeferredPromise<Request>()
+  interceptor.on('request', ({ request, controller }) => {
+    requestPromise.resolve(request)
+    controller.respondWith(new Response('mocked response'))
+  })
+
+  const request = http.request('http://localhost/irrelevant', {
+    method: 'POST',
+    headers: { 'X-My-Header': '1' },
+  })
+  request.on('socket', (socket) => {
+    socket.on('connect', () => {
+      request.end()
+    })
+  })
+
+  const { text } = await waitForClientRequest(request)
+  await expect(text()).resolves.toBe('mocked response')
+
+  const interceptedRequest = await requestPromise
+  expect(interceptedRequest.method).toBe('POST')
+  expect(interceptedRequest.url).toBe('http://localhost/irrelevant')
+  expect(Array.from(interceptedRequest.headers)).toEqual([['x-my-header', '1']])
+})


### PR DESCRIPTION
- Related https://github.com/mswjs/msw/issues/2259

## Changes

- The `MockHttpSocket` class now has a special scenario for _buffered_ requests. A buffered request is one whose stream is pending while the connection is being established. Example:

```js
req.on('socket', (socket) => {
  socket.on('connect', () => req.end())
})
```

> Here, the request header won't be sent until the socket connection is established. Previously, the interceptor would hang on this forever since writing the request header was mandatory as it triggers the request parser). 

- Refactors `MockHttpSocket` class a bit so both conventional write+end requests as well as write + end (deferred) requests trigger the same `_onRequestStart` processing pipeline. 