### PR TITLE
fix(WebSocket): prevent dispatching "open" event if the connection was closed

### DIFF
--- a/src/interceptors/WebSocket/WebSocketOverride.ts
+++ b/src/interceptors/WebSocket/WebSocketOverride.ts
@@ -58,8 +58,6 @@ export class WebSocketOverride extends EventTarget implements WebSocket {
         return
       }
 
-      this.readyState = this.OPEN
-
       this.protocol =
         typeof protocols === 'string'
           ? protocols
@@ -67,7 +65,15 @@ export class WebSocketOverride extends EventTarget implements WebSocket {
           ? protocols[0]
           : ''
 
-      this.dispatchEvent(bindEvent(this, new Event('open')))
+      /**
+       * @note Check that nothing has prevented this connection
+       * (e.g. called `client.close()` in the connection listener).
+       * If the connection has been prevented, never dispatch the open event,.
+       */
+      if (this.readyState === this.CONNECTING) {
+        this.readyState = this.OPEN
+        this.dispatchEvent(bindEvent(this, new Event('open')))
+      }
     })
   }
 

--- a/test/modules/WebSocket/compliance/websocket.reuse-listeners.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.reuse-listeners.test.ts
@@ -34,7 +34,14 @@ it('allows reusing the same function for multiple client listeners', async () =>
     client.addEventListener('message', clientMessageListener)
     client.addEventListener('message', clientMessageListener)
 
-    queueMicrotask(() => client.close())
+    /**
+     * @note Use `process.nextTick()` because `queueMicrotask()` has a
+     * higher priority. We need the connection to open, handle messages,
+     * and then close.
+     */
+    process.nextTick(() => {
+      client.close()
+    })
   })
 
   const socket = new WebSocket('wss://example.com')

--- a/test/modules/WebSocket/exchange/websocket.readystate.test.ts
+++ b/test/modules/WebSocket/exchange/websocket.readystate.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node-with-websocket
+import { vi, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket'
+import { waitForWebSocketEvent } from '../utils/waitForWebSocketEvent'
+import { waitForNextTick } from '../utils/waitForNextTick'
+
+const interceptor = new WebSocketInterceptor()
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+})
+
+it('dispatches the connection even when the client "readyState" is OPEN', async () => {
+  const readyStateListener = vi.fn<[number]>()
+
+  interceptor.on('connection', ({ client }) => {
+    // CONNECTING.
+    readyStateListener(client.socket.readyState)
+
+    /**
+     * @note Use `process.nextTick()` because it has lower priority
+     * than `queueMicrotask()`. If you queue a microtask here, it will
+     * run BEFORE a queued microtask that dispatches the open event.
+     */
+    process.nextTick(() => {
+      readyStateListener(client.socket.readyState)
+      client.close()
+    })
+  })
+
+  const socket = new WebSocket('wss://localhost')
+  await waitForWebSocketEvent('close', socket)
+
+  // The client ready state must be OPEN when the connection listener is called.
+  expect(readyStateListener).toHaveBeenNthCalledWith(1, WebSocket.CONNECTING)
+  expect(readyStateListener).toHaveBeenNthCalledWith(2, WebSocket.OPEN)
+  expect(readyStateListener).toHaveBeenCalledTimes(2)
+})
+
+it('updates "readyState" correctly when closing the connection in the interceptor', async () => {
+  const readyStateListener = vi.fn<[number]>()
+
+  interceptor.on('connection', ({ client }) => {
+    // CONNECTING.
+    readyStateListener(client.socket.readyState)
+
+    client.close()
+
+    // CLOSING.
+    readyStateListener(client.socket.readyState)
+
+    process.nextTick(() => {
+      // CLOSED.
+      readyStateListener(client.socket.readyState)
+    })
+  })
+
+  const openEventListener = vi.fn()
+  const socket = new WebSocket('wss://localhost')
+  socket.onopen = openEventListener
+  await waitForWebSocketEvent('close', socket)
+
+  expect(readyStateListener).toHaveBeenNthCalledWith(1, WebSocket.CONNECTING)
+  // Must set ready state to CLOSING in the same frame as "client.close()".
+  expect(readyStateListener).toHaveBeenNthCalledWith(2, WebSocket.CLOSING)
+
+  await waitForNextTick()
+  // Must set ready state to CLOSED in the next frame.
+  expect(readyStateListener).toHaveBeenNthCalledWith(3, WebSocket.CLOSED)
+
+  expect(openEventListener).not.toHaveBeenCalled()
+})

--- a/test/modules/WebSocket/utils/waitForNextTick.ts
+++ b/test/modules/WebSocket/utils/waitForNextTick.ts
@@ -1,5 +1,5 @@
 export async function waitForNextTick(): Promise<void> {
   return new Promise((resolve) => {
-    queueMicrotask(() => resolve())
+    process.nextTick(() => resolve())
   })
 }


### PR DESCRIPTION
This change prevents the WebSocket client from dispatching the open event if the connection has been rejected (closed/errored) in the connection event listener. 

Note that this keeps the oddity of the `client.socket.readtyState` being CONNECTING in the connection event listener. This isn't how an actual server connection event behaves, but this is necessary for the interceptor to reject the connection from within before it's ever opened (think of MSW rejecting the WebSocket connection if it's unhandled). 

## Previous approach

During play testing, I've discovered that `client.socket.readyState` value was `0` (CONNECTING) in the connection event listener's scope. I believe that's incorrect. The `readyState` of the intercepted client MUST be `1` (OPEN) in the connection event listener. 

The connection event is dispatched when the connection _has been successful_. In the interceptor's context, any WebSocket connection is considered successful if it has the connection listener.

This is also the behavior when using the actual WebSocket server:

```js
wss.on('connection', (ws) => {
  ws.readyState // 1
})
```

> [!WARNING]
> If the connection event is dispatched when `readyState` is OPEN, then MSW cannot reject that connection (onUnhandledRequest). The open even is always emitted, and then the close/error event. 

This isn't the right approach. Rejecting a connection is crucial. 

- The `readyState` can be CONNECTING in the connection event, that's quite okay.
- If you close `client.close()`, the client must NOT emit the OPEN event on the next frame at all. The closure must take priority (it's already delegated to the next frame). This is easily fixed by checking `if (this.readyState !== this.CLOSING)` before emitting the open event in the constructor. 