### PR TITLE
fix(fetch): await response listener before resolving the response promise

### DIFF
--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -144,7 +144,7 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
         'no mocked response received, performing request as-is...'
       )
 
-      return pureFetch(request).then((response) => {
+      return pureFetch(request).then(async (response) => {
         this.logger.info('original fetch performed', response)
 
         if (this.emitter.listenerCount('response') > 0) {
@@ -152,7 +152,7 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
 
           const responseClone = response.clone()
 
-          this.emitter.emit('response', {
+          await emitAsync(this.emitter, 'response', {
             response: responseClone,
             isMockedResponse: false,
             request,

--- a/test/modules/fetch/response/fetch-await-response-event.test.ts
+++ b/test/modules/fetch/response/fetch-await-response-event.test.ts
@@ -1,8 +1,7 @@
 import { vi, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
-import http from 'node:http'
 import { HttpServer } from '@open-draft/test-server/http'
-import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
-import { sleep, waitForClientRequest } from '../../../helpers'
+import { FetchInterceptor } from '../../../../src/interceptors/fetch'
+import { sleep } from '../../../helpers'
 
 const httpServer = new HttpServer((app) => {
   app.get('/resource', (req, res) => {
@@ -10,7 +9,7 @@ const httpServer = new HttpServer((app) => {
   })
 })
 
-const interceptor = new ClientRequestInterceptor()
+const interceptor = new FetchInterceptor()
 
 beforeAll(async () => {
   interceptor.apply()
@@ -38,10 +37,9 @@ it('awaits asynchronous response event listener for a mocked response', async ()
     responseDone(text)
   })
 
-  const request = http.get('http://localhost/')
-  const { text } = await waitForClientRequest(request)
+  const response = await fetch('http://localhost/')
 
-  expect(await text()).toBe('hello world')
+  expect(await response.text()).toBe('hello world')
   expect(responseDone).toHaveBeenCalledWith('hello world')
 })
 
@@ -53,9 +51,9 @@ it('awaits asynchronous response event listener for the original response', asyn
     responseDone(text)
   })
 
-  const request = http.get(httpServer.http.url('/resource'))
-  const { text } = await waitForClientRequest(request)
+  
+  const response = await fetch(httpServer.http.url('/resource'))
 
-  expect(await text()).toBe('original response')
+  expect(await response.text()).toBe('original response')
   expect(responseDone).toHaveBeenCalledWith('original response')
 })


### PR DESCRIPTION
1. Added tests
2. wait for fetch unlocked request
3. reduce the sleep for the `ClientRequest` tests :) 

closes #656

@kettanaito Is it OK for the [`then` callback to be `async`](https://github.com/mswjs/interceptors/pull/658/files#diff-4593f50c24857397e849d8d6618757914a847fa2642a22bfaa3b703e15cb4969R147)?