### PR TITLE
fix: define property in original init `Headers` as `Headers` instead of `string[]`

### DIFF
--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
@@ -126,6 +126,21 @@ it('records raw headers (Reqest / Request as init)', () => {
   expect(getRawFetchHeaders(request.headers)).toEqual([['X-My-Header', '1']])
 })
 
+it("doesn't change the init headers instanceof (Request / Request as init)", () => {
+  recordRawFetchHeaders()
+  const init = new Request(url, { headers: [['X-My-Header', '1']] })
+  new Request(init)
+  expect(init.headers).toBeInstanceOf(Headers)
+})
+
+it("doesn't change the init headers instanceof (Request / Request with Headers as init)", () => {
+  recordRawFetchHeaders()
+  const headers = new Headers([['X-My-Header', '1']])
+  const init = new Request(url, { headers })
+  new Request(init)
+  expect(init.headers).toBeInstanceOf(Headers)
+})
+
 it('records raw headers (Request / Request+Headers as init)', () => {
   recordRawFetchHeaders()
   const init = new Request(url, { headers: [['X-My-Header', '1']] })
@@ -141,6 +156,7 @@ it('records raw headers (Request / Request+Headers as init)', () => {
     ['X-My-Header', '1'],
     ['X-Another-Header', '2'],
   ])
+  expect(request.headers).toBeInstanceOf(Headers)
 })
 
 it('records raw headers (Response / object as init)', () => {
@@ -156,6 +172,7 @@ it('records raw headers (Response / object as init)', () => {
     ['Content-Type', 'application/json'],
     ['X-My-Header', '1'],
   ])
+  expect(response.headers).toBeInstanceOf(Headers)
 })
 
 it('records raw headers (Response / array as init)', () => {
@@ -165,6 +182,7 @@ it('records raw headers (Response / array as init)', () => {
   })
 
   expect(getRawFetchHeaders(response.headers)).toEqual([['X-My-Header', '1']])
+  expect(response.headers).toBeInstanceOf(Headers)
 })
 
 it('records raw headers (Response / Headers as init)', () => {

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
@@ -186,7 +186,7 @@ export function recordRawFetchHeaders() {
           Object.defineProperty(args[0], 'headers', {
             enumerable: false,
             configurable: true,
-            value: Reflect.get(args[0].headers, kRawHeaders),
+            value: new Headers(Reflect.get(args[0].headers, kRawHeaders)),
           })
         }
 
@@ -207,7 +207,7 @@ export function recordRawFetchHeaders() {
           Object.defineProperty(args[1], 'headers', {
             enumerable: false,
             configurable: true,
-            value: Reflect.get(args[1].headers, kRawHeaders),
+            value: new Headers(Reflect.get(args[1].headers, kRawHeaders)),
           })
         }
 
@@ -225,7 +225,7 @@ export function recordRawFetchHeaders() {
           inferredRawHeaders.push(...inferRawHeaders(args[1].headers))
         }
 
-        if (inferRawHeaders.length > 0) {
+        if (inferredRawHeaders.length > 0) {
           defineRawHeadersSymbol(request.headers, inferredRawHeaders)
         }
 


### PR DESCRIPTION
Closes #651 

Basically when defining the header property on the original `init` request or the original init headers we were assigning the value of `kRawHeaders` but that's just a string array. So if that `Request` is then used again trying to read the `headers` with `req.headers.get` it will fail since there's no `get` method in the array of strings.

Also i've noticed 
```ts
if (inferRawHeaders.length > 0) {
    defineRawHeadersSymbol(request.headers, inferredRawHeaders)
}
```
which is a classic TS mystake: you were checking if that function had more than one argument but that's always true so i switched to what i think you actually wanted to check.

I've added a couple of test to check this that fails before this PR.