### PR TITLE
fix(hasConfigurableGlobal): handle existing globals with undefined value

### DIFF
--- a/src/utils/hasConfigurableGlobal.test.ts
+++ b/src/utils/hasConfigurableGlobal.test.ts
@@ -26,13 +26,13 @@ it('returns false if the global property does not exist', () => {
   expect(hasConfigurableGlobal('_non-existing')).toBe(false)
 })
 
-it('returns false if the global property exists and it\'s value is undefined', () => {
+it('returns false for existing global with undefined as a value', () => {
   Object.defineProperty(global, '_existsAndUndefined', {
     value: undefined,
     configurable: true,
   })
 
-  expect(hasConfigurableGlobal('_existsAndUndefined')).toBe(true)
+  expect(hasConfigurableGlobal('_existsAndUndefined')).toBe(false)
 })
 
 it('returns false and prints an error for implicitly non-configurable global property', () => {

--- a/src/utils/hasConfigurableGlobal.test.ts
+++ b/src/utils/hasConfigurableGlobal.test.ts
@@ -26,6 +26,15 @@ it('returns false if the global property does not exist', () => {
   expect(hasConfigurableGlobal('_non-existing')).toBe(false)
 })
 
+it('returns false if the global property exists and it\'s value is undefined', () => {
+  Object.defineProperty(global, '_existsAndUndefined', {
+    value: undefined,
+    configurable: true,
+  })
+
+  expect(hasConfigurableGlobal('_existsAndUndefined')).toBe(true)
+})
+
 it('returns false and prints an error for implicitly non-configurable global property', () => {
   Object.defineProperty(global, '_implicitlyNonConfigurable', {
     value: 'something',

--- a/src/utils/hasConfigurableGlobal.test.ts
+++ b/src/utils/hasConfigurableGlobal.test.ts
@@ -31,8 +31,23 @@ it('returns false for existing global with undefined as a value', () => {
     value: undefined,
     configurable: true,
   })
-
   expect(hasConfigurableGlobal('_existsAndUndefined')).toBe(false)
+})
+
+it('returns false for existing global with null as a value', () => {
+  Object.defineProperty(global, '_existsAndNull', {
+    value: null,
+    configurable: true,
+  })
+  expect(hasConfigurableGlobal('_existsAndNull')).toBe(false)
+})
+
+it('returns false for existing global with a getter that returns undefined', () => {
+  Object.defineProperty(global, '_existsGetterUndefined', {
+    get: () => undefined,
+    configurable: true,
+  })
+  expect(hasConfigurableGlobal('_existsGetterUndefined')).toBe(false)
 })
 
 it('returns false and prints an error for implicitly non-configurable global property', () => {

--- a/src/utils/hasConfigurableGlobal.ts
+++ b/src/utils/hasConfigurableGlobal.ts
@@ -9,6 +9,10 @@ export function hasConfigurableGlobal(propertyName: string): boolean {
     return false
   }
 
+  if (descriptor.get != null && typeof descriptor.get() === "undefined") {
+    return false
+  }
+
   if (typeof descriptor.set === 'undefined' && !descriptor.configurable) {
     console.error(
       `[MSW] Failed to apply interceptor: the global \`${propertyName}\` property is non-configurable. This is likely an issue with your environment. If you are using a framework, please open an issue about this in their repository.`

--- a/src/utils/hasConfigurableGlobal.ts
+++ b/src/utils/hasConfigurableGlobal.ts
@@ -5,11 +5,21 @@
 export function hasConfigurableGlobal(propertyName: string): boolean {
   const descriptor = Object.getOwnPropertyDescriptor(globalThis, propertyName)
 
+  // The property is not set at all.
   if (typeof descriptor === 'undefined') {
     return false
   }
 
-  if (descriptor.get != null && typeof descriptor.get() === "undefined") {
+  // The property is set to a getter that returns undefined.
+  if (
+    typeof descriptor.get === 'function' &&
+    typeof descriptor.get() === 'undefined'
+  ) {
+    return false
+  }
+
+  // The property is set to a value equal to undefined.
+  if (typeof descriptor.get === 'undefined' && descriptor.value == null) {
     return false
   }
 


### PR DESCRIPTION
fix: https://github.com/mswjs/interceptors/issues/668