### PR TITLE
fix: support already aborted requests

### DIFF
--- a/src/utils/handleRequest.ts
+++ b/src/utils/handleRequest.ts
@@ -98,13 +98,17 @@ export async function handleRequest(
    * @note `signal` is not always defined in React Native.
    */
   if (options.request.signal) {
-    options.request.signal.addEventListener(
-      'abort',
-      () => {
-        requestAbortPromise.reject(options.request.signal.reason)
-      },
-      { once: true }
-    )
+    if (options.request.signal.aborted) {
+      requestAbortPromise.reject(options.request.signal.reason)
+    } else {
+      options.request.signal.addEventListener(
+        'abort',
+        () => {
+          requestAbortPromise.reject(options.request.signal.reason)
+        },
+        { once: true }
+      )
+    }
   }
 
   const result = await until(async () => {


### PR DESCRIPTION
- Related to https://github.com/mswjs/msw/issues/2314

## Changes

The `handleRequest` function will now correctly handle intercepted requests where `request.signal.aborted` is `true`. Previously, it only added the listener for the `abort` event, but if the request has already been aborted by the time it's made, that event was never dispatched. 