### PR TITLE
fix(WebSocket): buffer sending the data until connection is open

### DIFF
--- a/test/modules/WebSocket/compliance/websocket.client.send.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.client.send.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node-with-websocket
+import { beforeAll, afterEach, afterAll, vi, it, expect } from 'vitest'
+import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket'
+
+const interceptor = new WebSocketInterceptor()
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+})
+
+it('buffers client sends until the connection is open', async () => {
+  const events: Array<string> = []
+
+  interceptor.on('connection', ({ client }) => {
+    client.socket.addEventListener('open', () => {
+      events.push('open')
+    })
+    client.socket.addEventListener('message', () => {
+      events.push('send')
+    })
+
+    client.send('hello world')
+  })
+
+  const socket = new WebSocket('ws://localhost')
+  const messageListener = vi.fn()
+  socket.addEventListener('message', messageListener)
+
+  await vi.waitFor(() => {
+    expect(messageListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: 'hello world',
+      })
+    )
+  })
+
+  expect(events).toEqual(['open', 'send'])
+})
+
+it('does not send data if the client connection is closing', async () => {
+  const events: Array<string> = []
+
+  interceptor.on('connection', ({ client }) => {
+    client.socket.addEventListener('close', () => {
+      events.push('close')
+    })
+    client.socket.addEventListener('message', () => {
+      events.push('send')
+    })
+
+    client.close()
+    client.send('hello world')
+  })
+
+  const socket = new WebSocket('ws://localhost')
+  const messageListener = vi.fn()
+  const closeListener = vi.fn()
+  socket.addEventListener('message', messageListener)
+  socket.addEventListener('close', closeListener)
+
+  await vi.waitFor(() => {
+    expect(closeListener).toHaveBeenCalledOnce()
+  })
+
+  expect(messageListener).not.toHaveBeenCalled()
+  expect(events).toEqual(['close'])
+})
+
+it('does not send data if the client connection is closed', async () => {
+  const events: Array<string> = []
+
+  interceptor.on('connection', ({ client }) => {
+    client.socket.addEventListener('close', () => {
+      events.push('close')
+    })
+    client.socket.addEventListener('message', () => {
+      events.push('send')
+    })
+
+    client.close()
+    queueMicrotask(() => client.send('hello world'))
+  })
+
+  const socket = new WebSocket('ws://localhost')
+  const messageListener = vi.fn()
+  const closeListener = vi.fn()
+  socket.addEventListener('message', messageListener)
+  socket.addEventListener('close', closeListener)
+
+  await vi.waitFor(() => {
+    expect(closeListener).toHaveBeenCalledOnce()
+  })
+
+  expect(messageListener).not.toHaveBeenCalled()
+  expect(events).toEqual(['close'])
+})

--- a/test/modules/WebSocket/compliance/websocket.connection.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.connection.test.ts
@@ -15,7 +15,7 @@ const wsServer = new WebSocketServer({
   port: 0,
 })
 
-beforeAll(async () => {
+beforeAll(() => {
   interceptor.apply()
 })
 

--- a/test/modules/WebSocket/intercept/websocket.dispose.test.ts
+++ b/test/modules/WebSocket/intercept/websocket.dispose.test.ts
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment node-with-websocket
- */
+// @vitest-environment node-with-websocket
 import { vi, it, expect, beforeAll, afterAll } from 'vitest'
 import { WebSocketServer } from 'ws'
 import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket/index'

--- a/test/modules/WebSocket/intercept/websocket.server.events.test.ts
+++ b/test/modules/WebSocket/intercept/websocket.server.events.test.ts
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment node-with-websocket
- */
+// @vitest-environment node-with-websocket
 import { vi, it, expect, beforeAll, afterAll } from 'vitest'
 import { WebSocketServer } from 'ws'
 import { WebSocketInterceptor } from '../../../../src/interceptors/WebSocket'


### PR DESCRIPTION
When fixing the tests for our Socket.IO bunding, I've discovered that `client.send()` dispatches the message event on the WebSocket client immediately. If the client connection is still `CONNECTING` at the point, the message will be lost. 

## Changes

- `client.send()` schedules data send for once the connection is open if it's not yet.
- `client.send()` does nothing if the connection is `CLOSING` or `CLOSED`.