### PR TITLE
fix(ClientRequest): prevent `req.write()` callbacks from being called twice on passthrough

### DIFF
--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -420,13 +420,17 @@ export class MockHttpSocket extends MockSocket {
   }
 
   private flushWriteBuffer(): void {
-    for (const [, , callback] of this.writeBuffer) {
-      /**
-       * @note If the write callbacks are ever called twice,
-       * we need to mark them with a symbol so they aren't called
-       * again in the `passthrough` method.
-       */
-      callback?.()
+    for (const writeCall of this.writeBuffer) {
+      if (typeof writeCall[2] === 'function') {
+        writeCall[2]()
+        /**
+         * @note Remove the callback from the write call
+         * so it doesn't get called twice on passthrough
+         * if `request.end()` was called within `request.write()`.
+         * @see https://github.com/mswjs/interceptors/issues/684
+         */
+        writeCall[2] = undefined
+      }
     }
   }
 

--- a/test/modules/http/compliance/http-req-write.test.ts
+++ b/test/modules/http/compliance/http-req-write.test.ts
@@ -220,3 +220,22 @@ it('calls the write callbacks when reading request body in the interceptor', asy
   // Must send the correct request body to the server.
   expect(await text()).toBe('onetwothree')
 })
+
+/**
+ * @see https://github.com/mswjs/interceptors/issues/684
+ */
+it('calls the write callback once for a request that ends inside a write', async () => {
+  const requestWriteCallback = vi.fn()
+
+  const request = http.request(httpServer.http.url('/resource'), {
+    method: 'POST',
+    headers: { 'content-type': 'text/plain' },
+  })
+  request.write('one', 'utf8', () => {
+    requestWriteCallback()
+    request.end()
+  })
+
+  await waitForClientRequest(request)
+  expect(requestWriteCallback).toHaveBeenCalledTimes(1)
+})

--- a/test/modules/http/compliance/http-req-write.test.ts
+++ b/test/modules/http/compliance/http-req-write.test.ts
@@ -195,7 +195,7 @@ it('calls all write callbacks before the mocked response', async () => {
   expect(await text()).toBe('hello world')
 })
 
-it('does not call write callbacks ...', async () => {
+it('calls the write callbacks when reading request body in the interceptor', async () => {
   const requestBodyCallback = vi.fn()
   const requestWriteCallback = vi.fn()
 


### PR DESCRIPTION
- Fixes #684 
- Related to #674 
- Related to https://github.com/mswjs/msw/issues/2326

## Changes

During the `flushWriteBuffer()`, set the invoked callback on the write args to `undefined` so it doesn't get called again (twice) during passthrough of requests that call `request.end()` within the `request.write()` callback. The issue is only reproducible in that scenario and doesn't happen on sequential write/end calls. 