### PR TITLE
fix(MockHttpSocket): forward tls getCipher calls

### DIFF
--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -139,6 +139,7 @@ export class MockHttpSocket extends MockSocket {
       Reflect.set(this, 'getProtocol', () => 'TLSv1.3')
       Reflect.set(this, 'getSession', () => undefined)
       Reflect.set(this, 'isSessionReused', () => false)
+      Reflect.set(this, 'getCipher', () => ({ name: 'AES256-SHA', standardName: 'TLS_RSA_WITH_AES_256_CBC_SHA', version: 'TLSv1.3' }))
     }
   }
 
@@ -237,6 +238,7 @@ export class MockHttpSocket extends MockSocket {
         'getProtocol',
         'getSession',
         'isSessionReused',
+        'getCipher'
       ]
 
       tlsProperties.forEach((propertyName) => {

--- a/test/modules/http/compliance/http-ssl-socket.test.ts
+++ b/test/modules/http/compliance/http-ssl-socket.test.ts
@@ -41,6 +41,7 @@ it('emits a correct TLS Socket instance for a handled HTTPS request', async () =
   expect(socket.getSession()).toBeUndefined()
   expect(socket.getProtocol()).toBe('TLSv1.3')
   expect(socket.isSessionReused()).toBe(false)
+  expect(socket.getCipher()).toEqual({ name: 'AES256-SHA', standardName: 'TLS_RSA_WITH_AES_256_CBC_SHA', version: 'TLSv1.3' })
 })
 
 it('emits a correct TLS Socket instance for a bypassed HTTPS request', async () => {
@@ -58,5 +59,5 @@ it('emits a correct TLS Socket instance for a bypassed HTTPS request', async () 
 
   expect(socket.getSession()).toBeUndefined()
   expect(socket.getProtocol()).toBe('TLSv1.3')
-  expect(socket.isSessionReused()).toBe(false)
+  expect(socket.getCipher()).toEqual({ name: 'AES256-SHA', standardName: 'TLS_RSA_WITH_AES_256_CBC_SHA', version: 'TLSv1.3' })
 })


### PR DESCRIPTION
We are currently are experiencing an issue because our http client relies on the [`TLSSocket.getCipher()`](https://nodejs.org/docs/v22.12.0/api/tls.html#tlssocketgetcipher) method, which `msw` doesn't currently provide, which is causing the following error (stack trace redacted):

```bash
[dev]  ⨯ unhandledRejection: TypeError: this.getCipher is not a function
[dev]     at MockHttpSocket.<anonymous> (/path/to/location/custom-client.js:L:C)
[dev]     at Object.onceWrapper (node:events:633:28)
[dev]     at MockHttpSocket.emit (node:events:519:28)
[dev]     at MockHttpSocket.emit (node:domain:488:12)
[dev]     at MockHttpSocket.emit (webpack-internal:///(rsc)/./node_modules/msw/node_modules/@mswjs/interceptors/lib/node/chunk-KEULKBUZ.mjs:429:12)
[dev]     at MockHttpSocket.mockConnect (webpack-internal:///(rsc)/./node_modules/msw/node_modules/@mswjs/interceptors/lib/node/chunk-KEULKBUZ.mjs:593:12)
[dev]     at MockHttpSocket.respondWith (webpack-internal:///(rsc)/./node_modules/msw/node_modules/@mswjs/interceptors/lib/node/chunk-KEULKBUZ.mjs:518:10)
[dev]     at Object.onResponse (webpack-internal:///(rsc)/./node_modules/msw/node_modules/@mswjs/interceptors/lib/node/chunk-KEULKBUZ.mjs:946:18)
[dev]     at handleResponse (webpack-internal:///(rsc)/./node_modules/msw/node_modules/@mswjs/interceptors/lib/node/chunk-M4WQE4TR.mjs:107:21)
[dev]     at handleRequest (webpack-internal:///(rsc)/./node_modules/msw/node_modules/@mswjs/interceptors/lib/node/chunk-M4WQE4TR.mjs:193:12)
[dev]     at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

**Note:** I don't know whether or not this is the proper way to fix this issue, but a quick search lead to https://github.com/mswjs/interceptors/pull/556, which introduces this pattern