### PR TITLE
fix(ClientRequest): prevent `rawHeaders` from being shared across instances

### DIFF
--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
@@ -242,14 +242,17 @@ it('does not throw on using Headers before recording', () => {
   expect(getRawFetchHeaders(request.headers)).toEqual([['X-My-Header', '1']])
 })
 
-it('does not use the same instance of rawHeaders', async () => {
+/**
+ * @see https://github.com/mswjs/interceptors/issues/681
+ */
+it('isolates headers between different headers instances', async () => {
   recordRawFetchHeaders()
-  const original = new Headers();
-  const clone1 = new Headers(original);
-  clone1.set('Content-Type', 'application/json')
-  const clone2 = new Headers(original);
+  const original = new Headers()
+  const firstClone = new Headers(original)
+  firstClone.set('Content-Type', 'application/json')
+  const secondClone = new Headers(original)
 
   expect(original.get('Content-Type')).toBeNull()
-  expect(clone1.get('Content-Type')).toBe('application/json')
-  expect(clone2.get('Content-Type')).toBeNull()
-});
+  expect(firstClone.get('Content-Type')).toBe('application/json')
+  expect(secondClone.get('Content-Type')).toBeNull()
+})

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
@@ -241,3 +241,15 @@ it('does not throw on using Headers before recording', () => {
   request.headers.set('X-My-Header', '1')
   expect(getRawFetchHeaders(request.headers)).toEqual([['X-My-Header', '1']])
 })
+
+it('does not use the same instance of rawHeaders', async () => {
+  recordRawFetchHeaders()
+  const original = new Headers();
+  const clone1 = new Headers(original);
+  clone1.set('Content-Type', 'application/json')
+  const clone2 = new Headers(original);
+
+  expect(original.get('Content-Type')).toBeNull()
+  expect(clone1.get('Content-Type')).toBe('application/json')
+  expect(clone2.get('Content-Type')).toBeNull()
+});

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
@@ -118,7 +118,7 @@ export function recordRawFetchHeaders() {
             [Reflect.get(headersInit, kRawHeaders)],
             newTarget
           )
-          ensureRawHeadersSymbol(headers, Reflect.get(headersInit, kRawHeaders))
+          ensureRawHeadersSymbol(headers, [...Reflect.get(headersInit, kRawHeaders)])
           return headers
         }
 

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
@@ -118,7 +118,14 @@ export function recordRawFetchHeaders() {
             [Reflect.get(headersInit, kRawHeaders)],
             newTarget
           )
-          ensureRawHeadersSymbol(headers, [...Reflect.get(headersInit, kRawHeaders)])
+          ensureRawHeadersSymbol(headers, [
+            /**
+             * @note Spread the retrieved headers to clone them.
+             * This prevents multiple Headers instances from pointing
+             * at the same internal "rawHeaders" array.
+             */
+            ...Reflect.get(headersInit, kRawHeaders),
+          ])
           return headers
         }
 


### PR DESCRIPTION
fixes #681