### PR TITLE
fix(MockAgent): add explicit return types to agent methods

### DIFF
--- a/src/interceptors/ClientRequest/agents.ts
+++ b/src/interceptors/ClientRequest/agents.ts
@@ -31,7 +31,7 @@ export class MockAgent extends http.Agent {
     this.onResponse = options.onResponse
   }
 
-  public createConnection(options: any, callback: any) {
+  public createConnection(options: any, callback: any): net.Socket {
     const createConnection =
       (this.customAgent instanceof http.Agent &&
         this.customAgent.createConnection) ||
@@ -64,7 +64,7 @@ export class MockHttpsAgent extends https.Agent {
     this.onResponse = options.onResponse
   }
 
-  public createConnection(options: any, callback: any) {
+  public createConnection(options: any, callback: any): net.Socket {
     const createConnection =
       (this.customAgent instanceof https.Agent &&
         this.customAgent.createConnection) ||

--- a/src/interceptors/XMLHttpRequest/utils/createEvent.ts
+++ b/src/interceptors/XMLHttpRequest/utils/createEvent.ts
@@ -7,7 +7,7 @@ export function createEvent(
   target: XMLHttpRequest | XMLHttpRequestUpload,
   type: string,
   init?: ProgressEventInit
-): EventPolyfill {
+): EventPolyfill | ProgressEvent {
   const progressEvents = [
     'error',
     'progress',


### PR DESCRIPTION
when running `npm run start` (which runs `tsc ...`) it reports errors due to missing or incorrect return types:
<img width="1139" alt="image" src="https://github.com/user-attachments/assets/9fd1132b-a4ac-4cb4-9515-1eacba3c5e65" />

This PR fixes it so `tsc` passes.
