### PR TITLE
Emit response event before waiting for data

### DIFF
--- a/src/utils/handleRequest.ts
+++ b/src/utils/handleRequest.ts
@@ -116,7 +116,7 @@ export async function handleRequest(
     // for that event are finished (e.g. async listeners awaited).
     // By the end of this promise, the developer cannot affect the
     // request anymore.
-    const requestListtenersPromise = emitAsync(options.emitter, 'request', {
+    const requestListenersPromise = emitAsync(options.emitter, 'request', {
       requestId: options.requestId,
       request: options.request,
       controller: options.controller,
@@ -125,7 +125,7 @@ export async function handleRequest(
     await Promise.race([
       // Short-circuit the request handling promise if the request gets aborted.
       requestAbortPromise,
-      requestListtenersPromise,
+      requestListenersPromise,
       options.controller[kResponsePromise],
     ])
 

--- a/test/modules/http/compliance/http-res-event-order.test.ts
+++ b/test/modules/http/compliance/http-res-event-order.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { it, expect, beforeAll, afterEach, afterAll, vi } from 'vitest'
+import http from 'node:http'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+import { DeferredPromise } from '@open-draft/deferred-promise'
+
+const interceptor = new ClientRequestInterceptor()
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+})
+
+it('should fire response event before waiting for the response body', async () => {
+  interceptor.on('request', ({ controller }) => {
+    const stream = new ReadableStream({
+      start(controller) {
+        setTimeout(() => {
+          controller.enqueue(new TextEncoder().encode('hello world'))
+          controller.close()
+        }, 100)
+      },
+    })
+    controller.respondWith(new Response(stream))
+  })
+
+  const responseReceived = new DeferredPromise<number>()
+
+  http.get('http://localhost', (response) => {
+    const start = Date.now()
+    response.on('data', () => {
+      responseReceived.resolve(Date.now() - start)
+    })
+  })
+
+  expect(await responseReceived).toBeGreaterThan(100)
+})


### PR DESCRIPTION
Currently, we buffer the response data before we emit the `response` event, which is inconsistent with `node`.
I added a failing test to demonstrate the problem.