### PR TITLE
fix(fetch): clone passthrough request

### DIFF
--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -144,7 +144,7 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
         'no mocked response received, performing request as-is...'
       )
 
-      return pureFetch(request).then(async (response) => {
+      return pureFetch(request.clone()).then(async (response) => {
         this.logger.info('original fetch performed', response)
 
         if (this.emitter.listenerCount('response') > 0) {

--- a/test/modules/fetch/compliance/fetch-request-body-used.test.ts
+++ b/test/modules/fetch/compliance/fetch-request-body-used.test.ts
@@ -76,3 +76,25 @@ it('request body is unused in the listener when using input and init arguments',
 
   expect(await response.text()).toBe('received: Hello server')
 })
+
+it('request body is unused in the response listener after passthrough', async () => {
+  const requestInListenerPromise = new DeferredPromise<Request>()
+  interceptor.on('response', ({ request }) => {
+    requestInListenerPromise.resolve(request)
+  })
+
+  const responsePromise = fetch(httpServer.http.url('/resource'), {
+    method: 'POST',
+    body: 'Hello server',
+  })
+
+  const requestInListener = await requestInListenerPromise
+  const bodyUsedInListener = requestInListener.bodyUsed
+
+  const response = await responsePromise
+
+  expect(bodyUsedInListener).toBe(false)
+
+  expect(await response.text()).toBe('received: Hello server')
+})
+


### PR DESCRIPTION
Related to https://github.com/nock/nock/issues/2841

Clone the request so that it will be usable in the `response` listener