### PR TITLE
fix(fetch): update `response.url` correctly

### DIFF
--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -592,6 +592,8 @@ export class MockHttpSocket extends MockSocket {
       'Failed to handle a response: request does not exist'
     )
 
+    FetchResponse.setUrl(this.request.url, response)
+
     /**
      * @fixme Stop relying on the "X-Request-Id" request header
      * to figure out if one interceptor has been invoked within another.

--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -1,5 +1,26 @@
+import { getValueBySymbol } from './getValueBySymbol'
+
 export interface FetchResponseInit extends ResponseInit {
   url?: string
+}
+
+interface UndiciFetchInternalState {
+  aborted: boolean
+  rangeRequested: boolean
+  timingAllowPassed: boolean
+  requestIncludesCredentials: boolean
+  type: ResponseType
+  status: number
+  statusText: string
+  timingInfo: unknown
+  cacheState: unknown
+  headersList: Record<symbol, Map<string, unknown>>
+  urlList: Array<URL>
+  body?: {
+    stream: ReadableStream
+    source: unknown
+    length: number
+  }
 }
 
 export class FetchResponse extends Response {
@@ -28,20 +49,25 @@ export class FetchResponse extends Response {
   }
 
   static setUrl(url: string | undefined, response: Response): void {
-    if (!url) {
+    if (url == null) {
       return
     }
 
-    if (response.url != '') {
-      return
-    }
+    const state = getValueBySymbol<UndiciFetchInternalState>('state', response)
 
-    Object.defineProperty(response, 'url', {
-      value: url,
-      enumerable: true,
-      configurable: true,
-      writable: false,
-    })
+    if (state) {
+      // In Undici, push the URL to the internal list of URLs.
+      // This will respect the `response.url` getter logic correctly.
+      state.urlList.push(new URL(url))
+    } else {
+      // In other libraries, redefine the `url` property directly.
+      Object.defineProperty(response, 'url', {
+        value: url,
+        enumerable: true,
+        configurable: true,
+        writable: false,
+      })
+    }
   }
 
   /**

--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -49,7 +49,7 @@ export class FetchResponse extends Response {
   }
 
   static setUrl(url: string | undefined, response: Response): void {
-    if (url == null) {
+    if (url == null || url === 'about:') {
       return
     }
 

--- a/test/features/events/response.test.ts
+++ b/test/features/events/response.test.ts
@@ -113,6 +113,7 @@ it('ClientRequest: emits the "response" event for a mocked response', async () =
 
   expect(response.status).toBe(200)
   expect(response.statusText).toBe('OK')
+  expect(response.url).toBe(request.url)
   expect(response.headers.get('x-response-type')).toBe('mocked')
   await expect(response.text()).resolves.toBe('mocked-response-text')
 
@@ -147,6 +148,7 @@ it('ClientRequest: emits the "response" event upon the original response', async
 
   expect(response.status).toBe(200)
   expect(response.statusText).toBe('OK')
+  expect(response.url).toBe(request.url)
   expect(response.headers.get('x-response-type')).toBe('original')
   await expect(response.text()).resolves.toBe('original-response-text')
 
@@ -180,6 +182,7 @@ it('XMLHttpRequest: emits the "response" event upon a mocked response', async ()
 
   expect(response.status).toBe(200)
   expect(response.statusText).toBe('OK')
+  expect(response.url).toBe(request.url)
   expect(response.headers.get('x-response-type')).toBe('mocked')
   await expect(response.text()).resolves.toBe('mocked-response-text')
   expect(isMockedResponse).toBe(true)
@@ -224,6 +227,7 @@ it('XMLHttpRequest: emits the "response" event upon the original response', asyn
 
   expect(response.status).toBe(200)
   expect(response.statusText).toBe('OK')
+  expect(response.url).toBe(request.url)
   expect(response.headers.get('x-response-type')).toBe('original')
   await expect(response.text()).resolves.toBe('original-response-text')
 
@@ -260,6 +264,7 @@ it('fetch: emits the "response" event upon a mocked response', async () => {
 
   expect(response.status).toBe(200)
   expect(response.statusText).toBe('OK')
+  expect(response.url).toBe(request.url)
   expect(response.headers.get('x-response-type')).toBe('mocked')
   await expect(response.text()).resolves.toBe('mocked-response-text')
 
@@ -295,6 +300,7 @@ it('fetch: emits the "response" event upon the original response', async () => {
 
   expect(response.status).toBe(200)
   expect(response.statusText).toBe('OK')
+  expect(response.url).toBe(request.url)
   expect(response.headers.get('x-response-type')).toBe('original')
   await expect(response.text()).resolves.toBe('original-response-text')
 

--- a/test/modules/fetch/compliance/fetch-response-url.test.ts
+++ b/test/modules/fetch/compliance/fetch-response-url.test.ts
@@ -1,0 +1,71 @@
+import { it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import { HttpServer } from '@open-draft/test-server/http'
+import { FetchInterceptor } from '../../../../src/interceptors/fetch'
+
+const interceptor = new FetchInterceptor()
+
+const httpServer = new HttpServer((app) => {
+  app.get('/resource', (req, res) => {
+    res.send('original response')
+  })
+})
+
+beforeAll(async () => {
+  interceptor.apply()
+  await httpServer.listen()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+  await httpServer.close()
+})
+
+it('returns an empty string for a mocked response', async () => {
+  interceptor.on('request', ({ controller }) => {
+    controller.respondWith(new Response('hello world'))
+  })
+
+  const response = await fetch('about:')
+  expect(response.url).toBe('')
+})
+
+it('returns the request url for a mocked response', async () => {
+  interceptor.on('request', ({ controller }) => {
+    controller.respondWith(new Response('hello world'))
+  })
+
+  const response = await fetch('http://localhost/does-not-matter')
+  expect(response.url).toBe('http://localhost/does-not-matter')
+})
+
+it('returns the request url for a bypassed response', async () => {
+  const requestUrl = httpServer.http.url('/resource')
+  const response = await fetch(requestUrl)
+  expect(response.url).toBe(requestUrl)
+})
+
+it('returns the last response url in case of redirects', async () => {
+  interceptor.on('request', ({ request, controller }) => {
+    if (request.url.endsWith('/target')) {
+      controller.respondWith(
+        new Response(null, {
+          status: 302,
+          headers: {
+            location: 'http://localhost/destination',
+          },
+        })
+      )
+      return
+    }
+
+    controller.respondWith(new Response('hello world'))
+  })
+
+  const response = await fetch('http://localhost/target')
+  expect(response.url).toBe('http://localhost/destination')
+  await expect(response.text()).resolves.toBe('hello world')
+})

--- a/test/modules/fetch/compliance/fetch-response-url.test.ts
+++ b/test/modules/fetch/compliance/fetch-response-url.test.ts
@@ -42,6 +42,24 @@ it('returns the request url for a mocked response', async () => {
   expect(response.url).toBe('http://localhost/does-not-matter')
 })
 
+it('returns an empty string for a cloned mocked response', async () => {
+  interceptor.on('request', ({ controller }) => {
+    controller.respondWith(new Response('hello world'))
+  })
+
+  const response = await fetch('about:')
+  expect(response.clone().url).toBe('')
+})
+
+it('returns the request url for a cloned mocked response', async () => {
+  interceptor.on('request', ({ controller }) => {
+    controller.respondWith(new Response('hello world'))
+  })
+
+  const response = await fetch('http://localhost/does-not-matter')
+  expect(response.clone().url).toBe('http://localhost/does-not-matter')
+})
+
 it('returns the request url for a bypassed response', async () => {
   const requestUrl = httpServer.http.url('/resource')
   const response = await fetch(requestUrl)


### PR DESCRIPTION
- Follows #695 
- Fixes #690
- Related to https://github.com/nock/nock/issues/2821

## Changes

Our Fetch API representation of the response now sets `response.url` value correctly. 

If working with Undici, instead of redefining the `url` property, it grabs the response internal state and pushes a new entry to its `urlList`. This way, Interceptors doesn't interfere with Undici's `url` getter on the response, which is implemented per spec.

> Also per spec, `response.url` will be `''` if the `Response` instance was constructed manually, which is the case for Interceptors. During regular requests, the response `urlList` becomes a clone of the request's `urlList` (see [this](https://github.com/nodejs/undici/blob/981636f5fb882ff684c11177a3bfc8b1cf061f3a/lib/web/fetch/index.js#L1598)). We cannot do that, so we push a new entry to the list instead.

If working with other Fetch implementations, Interceptors will keep redefining the `url` property because that is the lowest predictable surface for us (no guarantee those third-party implementations implement `urlList` at all).

This pull request also modifies the existing tests and adds new `response.url` compliance tests. 

> [!IMPORTANT]
> Interceptors will still check if the provided `response.url` is a valid `URL` instance. **Relative URLs will not work** as they never have**. Setting such invalid URLs will be skipped, and `response.url` will remain an empty string. This is done intentionally to provide a better, spec-aligned experience vs having the user deal with `Invalid URL` cryptic errors. 