### PR TITLE
fix: remove `jsdom` from `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "follow-redirects": "^1.15.1",
     "got": "^14.4.6",
     "happy-dom": "^17.3.0",
+    "jsdom": "^26.1.0",
     "node-fetch": "3.3.2",
     "rimraf": "^6.0.1",
     "simple-git-hooks": "^2.7.0",
@@ -173,7 +174,6 @@
     "@open-draft/logger": "^0.3.0",
     "@open-draft/until": "^2.0.0",
     "is-node-process": "^1.2.0",
-    "jsdom": "^26.0.0",
     "outvariant": "^1.4.3",
     "strict-event-emitter": "^0.5.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       is-node-process:
         specifier: ^1.2.0
         version: 1.2.0
-      jsdom:
-        specifier: ^26.0.0
-        version: 26.0.0
       outvariant:
         specifier: ^1.4.3
         version: 1.4.3
@@ -114,6 +111,9 @@ importers:
       happy-dom:
         specifier: ^17.3.0
         version: 17.3.0
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       node-fetch:
         specifier: 3.3.2
         version: 3.3.2
@@ -149,10 +149,10 @@ importers:
         version: 7.4.0
       vitest:
         specifier: ^3.0.8
-        version: 3.0.8(@types/node@22.13.9)(happy-dom@17.3.0)(jsdom@26.0.0)(terser@5.36.0)
+        version: 3.0.8(@types/node@22.13.9)(happy-dom@17.3.0)(jsdom@26.1.0)(terser@5.36.0)
       vitest-environment-miniflare:
         specifier: ^2.14.1
-        version: 2.14.4(vitest@3.0.8(@types/node@22.13.9)(happy-dom@17.3.0)(jsdom@26.0.0)(terser@5.36.0))
+        version: 2.14.4(vitest@3.0.8(@types/node@22.13.9)(happy-dom@17.3.0)(jsdom@26.1.0)(terser@5.36.0))
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1442,8 +1442,8 @@ packages:
       supports-color:
         optional: true
 
-  decimal.js@10.4.3:
-    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
+  decimal.js@10.5.0:
+    resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -2087,8 +2087,8 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
-  jsdom@26.0.0:
-    resolution: {integrity: sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==}
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
     engines: {node: '>=18'}
     peerDependencies:
       canvas: ^3.0.0
@@ -4676,7 +4676,7 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decimal.js@10.4.3: {}
+  decimal.js@10.5.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -5418,12 +5418,11 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@26.0.0:
+  jsdom@26.1.0:
     dependencies:
       cssstyle: 4.2.1
       data-urls: 5.0.0
-      decimal.js: 10.4.3
-      form-data: 4.0.1
+      decimal.js: 10.5.0
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -6455,19 +6454,19 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.36.0
 
-  vitest-environment-miniflare@2.14.4(vitest@3.0.8(@types/node@22.13.9)(happy-dom@17.3.0)(jsdom@26.0.0)(terser@5.36.0)):
+  vitest-environment-miniflare@2.14.4(vitest@3.0.8(@types/node@22.13.9)(happy-dom@17.3.0)(jsdom@26.1.0)(terser@5.36.0)):
     dependencies:
       '@miniflare/queues': 2.14.4
       '@miniflare/runner-vm': 2.14.4
       '@miniflare/shared': 2.14.4
       '@miniflare/shared-test-environment': 2.14.4
       undici: 5.28.4
-      vitest: 3.0.8(@types/node@22.13.9)(happy-dom@17.3.0)(jsdom@26.0.0)(terser@5.36.0)
+      vitest: 3.0.8(@types/node@22.13.9)(happy-dom@17.3.0)(jsdom@26.1.0)(terser@5.36.0)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  vitest@3.0.8(@types/node@22.13.9)(happy-dom@17.3.0)(jsdom@26.0.0)(terser@5.36.0):
+  vitest@3.0.8(@types/node@22.13.9)(happy-dom@17.3.0)(jsdom@26.1.0)(terser@5.36.0):
     dependencies:
       '@vitest/expect': 3.0.8
       '@vitest/mocker': 3.0.8(vite@5.4.11(@types/node@22.13.9)(terser@5.36.0))
@@ -6492,7 +6491,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.9
       happy-dom: 17.3.0
-      jsdom: 26.0.0
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
See https://github.com/mswjs/interceptors/pull/710#issuecomment-2805495148 for context.

From my local testing, the JSDOM dependency wasn't used at all. I ran the tests with both node v18 and node v22.

Note that my `pnpm-lock.yaml` has some more changes, probably coming from my version of pnpm (I just installed it). Tell me if you'd like me to use a specific version of pnpm. I also added `pnpm-workspace.yaml` to the `.gitignore` file because it appeared after installing packages. Happy to remove this change if you think it shouldn't be there.

Tell me what you think!
