### PR TITLE
fix(fetch): return headers in FetchResponse

### DIFF
--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -90,8 +90,9 @@ export class FetchResponse extends Response {
     const finalBody = FetchResponse.isResponseWithBody(status) ? body : null
 
     super(finalBody, {
-      ...init,
       status: safeStatus,
+      statusText: init.statusText,
+      headers: init.headers,
     })
 
     if (status !== safeStatus) {

--- a/test/modules/fetch/intercept/fetch.test.ts
+++ b/test/modules/fetch/intercept/fetch.test.ts
@@ -422,3 +422,13 @@ it('intercepts an HTTPS PATCH request', async () => {
 
   expect(requestId).toMatch(REQUEST_ID_REGEXP)
 })
+
+it('response should return headers', async () => {
+  interceptor.once('request', ({ controller }) => {
+    // controller.respondWith(new Response(null, { headers: { 'x-custom-header': 'yes' } }))
+    controller.respondWith(new Response('not-really-compressed', { headers: new Headers({ 'content-encoding': 'gzip', 'x-custom-header': 'yes' })}))
+  })
+
+  const response = await fetch('http://example.test')
+  expect(response.headers.get('x-custom-header')).toBe('yes')
+})


### PR DESCRIPTION
For some reason, the `Response` object drops the `headers` property when converting to an object. As a result, the super call to the input is missing the `headers` property."
![image](https://github.com/user-attachments/assets/290b66aa-7233-4426-aca6-f33f87bf9592)

Resolves https://github.com/nock/nock/issues/2832