### PR TITLE
feat(WebSocket): implement `WebSocketServerConnectionProtocol`

### DIFF
--- a/src/interceptors/WebSocket/WebSocketClientConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketClientConnection.ts
@@ -7,16 +7,32 @@ import { createRequestId } from '../../createRequestId'
 const kEmitter = Symbol('kEmitter')
 const kBoundListener = Symbol('kBoundListener')
 
-interface WebSocketClientEventMap {
+export interface WebSocketClientEventMap {
   message: MessageEvent<WebSocketData>
   close: CloseEvent
 }
 
-export interface WebSocketClientConnectionProtocol {
-  id: string
-  url: URL
-  send(data: WebSocketData): void
-  close(code?: number, reason?: string): void
+export abstract class WebSocketClientConnectionProtocol {
+  abstract id: string
+  abstract url: URL
+  public abstract send(data: WebSocketData): void
+  public abstract close(code?: number, reason?: string): void
+
+  public abstract addEventListener<
+    EventType extends keyof WebSocketClientEventMap
+  >(
+    type: EventType,
+    listener: WebSocketEventListener<WebSocketClientEventMap[EventType]>,
+    options?: AddEventListenerOptions | boolean
+  ): void
+
+  public abstract removeEventListener<
+    EventType extends keyof WebSocketClientEventMap
+  >(
+    event: EventType,
+    listener: WebSocketEventListener<WebSocketClientEventMap[EventType]>,
+    options?: EventListenerOptions | boolean
+  ): void
 }
 
 /**

--- a/src/interceptors/WebSocket/WebSocketServerConnection.ts
+++ b/src/interceptors/WebSocket/WebSocketServerConnection.ts
@@ -17,11 +17,33 @@ const kEmitter = Symbol('kEmitter')
 const kBoundListener = Symbol('kBoundListener')
 const kSend = Symbol('kSend')
 
-interface WebSocketServerEventMap {
+export interface WebSocketServerEventMap {
   open: Event
   message: MessageEvent<WebSocketData>
   error: Event
   close: CloseEvent
+}
+
+export abstract class WebSocketServerConnectionProtocol {
+  public abstract connect(): void
+  public abstract send(data: WebSocketData): void
+  public abstract close(): void
+
+  public abstract addEventListener<
+    EventType extends keyof WebSocketServerEventMap
+  >(
+    event: EventType,
+    listener: WebSocketEventListener<WebSocketServerEventMap[EventType]>,
+    options?: AddEventListenerOptions | boolean
+  ): void
+
+  public abstract removeEventListener<
+    EventType extends keyof WebSocketServerEventMap
+  >(
+    event: EventType,
+    listener: WebSocketEventListener<WebSocketServerEventMap[EventType]>,
+    options?: EventListenerOptions | boolean
+  ): void
 }
 
 /**
@@ -29,7 +51,9 @@ interface WebSocketServerEventMap {
  * WebSocket server connection. It's idle by default but you can
  * establish it by calling `server.connect()`.
  */
-export class WebSocketServerConnection {
+export class WebSocketServerConnection
+  implements WebSocketServerConnectionProtocol
+{
   /**
    * A WebSocket instance connected to the original server.
    */

--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -1,9 +1,14 @@
 import { Interceptor } from '../../Interceptor'
 import {
-  type WebSocketClientConnectionProtocol,
+  WebSocketClientConnectionProtocol,
   WebSocketClientConnection,
+  type WebSocketClientEventMap,
 } from './WebSocketClientConnection'
-import { WebSocketServerConnection } from './WebSocketServerConnection'
+import {
+  WebSocketServerConnectionProtocol,
+  WebSocketServerConnection,
+  type WebSocketServerEventMap,
+} from './WebSocketServerConnection'
 import { WebSocketClassTransport } from './WebSocketClassTransport'
 import {
   kClose,
@@ -15,8 +20,11 @@ import { hasConfigurableGlobal } from '../../utils/hasConfigurableGlobal'
 
 export { type WebSocketData, WebSocketTransport } from './WebSocketTransport'
 export {
-  WebSocketClientConnection,
+  WebSocketClientEventMap,
   WebSocketClientConnectionProtocol,
+  WebSocketClientConnection,
+  WebSocketServerEventMap,
+  WebSocketServerConnectionProtocol,
   WebSocketServerConnection,
 }
 
@@ -28,12 +36,12 @@ export type WebSocketConnectionData = {
   /**
    * The incoming WebSocket client connection.
    */
-  client: WebSocketClientConnection
+  client: WebSocketClientConnectionProtocol
 
   /**
    * The original WebSocket server connection.
    */
-  server: WebSocketServerConnection
+  server: WebSocketServerConnectionProtocol
 
   /**
    * The connection information.


### PR DESCRIPTION
## Motivation

Add the `WebSocketServerConnectionProtocol` type and annotate the `WebSocketConnectionData` `server` property using that type. This way, the consumer might implement the `server` property in any way they see fit (e.g. by using Playwright's `page.routeWebSocket()`) and still remain functional with the interceptor and the contract it introduces.

Also adds missing `addEventListener()` and `removeEventListener()` methods on both client and server protocols.

Also makes client and server protocols _abstract classes_.

Also exports previously missing event maps for client and server events so consumers can implement type-safe client and server protocols. 