### PR TITLE
fix(WebSocket): use non-protocol types for `client` and `server`

### DIFF
--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -36,12 +36,12 @@ export type WebSocketConnectionData = {
   /**
    * The incoming WebSocket client connection.
    */
-  client: WebSocketClientConnectionProtocol
+  client: WebSocketClientConnection
 
   /**
    * The original WebSocket server connection.
    */
-  server: WebSocketServerConnectionProtocol
+  server: WebSocketServerConnection
 
   /**
    * The connection information.


### PR DESCRIPTION
- #726 introduced a regression where the `client` and `server` properties of the `connection` event were not implemented correctly. Despite internal client and server implementing their respective protocols, those objects _contain additional properties_, and the consumer must know about them, too. 