### PR TITLE
fix(ClientRequest): support more than 32 headers

### DIFF
--- a/_http_common.d.ts
+++ b/_http_common.d.ts
@@ -2,6 +2,7 @@ declare var HTTPParser: {
   new (): HTTPParser<number>
   REQUEST: 0
   RESPONSE: 1
+  readonly kOnHeaders: unique symbol
   readonly kOnHeadersComplete: unique symbol
   readonly kOnBody: unique symbol
   readonly kOnMessageComplete: unique symbol
@@ -10,6 +11,7 @@ declare var HTTPParser: {
 export interface HTTPParser<ParserType extends number> {
   new (): HTTPParser<ParserType>
 
+  [HTTPParser.kOnHeaders]: (rawHeaders: Array<string>, url: string) => void
   [HTTPParser.kOnHeadersComplete]: ParserType extends 0
     ? RequestHeadersCompleteCallback
     : ResponseHeadersCompleteCallback

--- a/test/modules/http/compliance/http-res-headers-32.test.ts
+++ b/test/modules/http/compliance/http-res-headers-32.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import http from 'node:http'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+import { waitForClientRequest } from '../../../helpers'
+import { HttpServer } from '@open-draft/test-server/lib/http'
+import { DeferredPromise } from '@open-draft/deferred-promise'
+
+const interceptor = new ClientRequestInterceptor()
+
+const httpServer = new HttpServer((app) => {
+  app.disable('x-powered-by')
+  app.get('/', (req, res) => {
+    const headers: Record<string, string> = {}
+    for (let i = 1; i <= 32; i++) {
+      headers[`x-header-${i}`] = `value${i}`
+    }
+    res.set(headers)
+    res.end()
+  })
+})
+
+beforeAll(async () => {
+  interceptor.apply()
+  await httpServer.listen()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+  await httpServer.close()
+})
+
+it('support more than 32 headers', async () => {
+  const requestUrl = httpServer.http.url('/')
+  const request = http.get(requestUrl)
+
+  const { res } = await waitForClientRequest(request)
+  expect(Object.keys(res.headers).length).toBe(35) // 32 custom headers + 3 default headers
+})
+
+it('support more than 32 headers', async () => {
+  const requestUrl = httpServer.http.url('/')
+  const responsePromise = new DeferredPromise<Response>()
+  interceptor.on('response', ({ response }) => {
+    responsePromise.resolve(response)
+  })
+  http.get(requestUrl)
+
+  const response = await responsePromise
+  expect(Object.keys(Object.fromEntries(response.headers.entries())).length).toBe(35) // 32 custom headers + 3 default headers
+})


### PR DESCRIPTION
TL;DR: Node call `kOnHeaders` if there are more than 32 headers.

https://github.com/nock/nock/discussions/2878

@kettanaito Need to tidy up this PR, but want to make sure you think this is the right direction first.