### PR TITLE
fix(ClientRequest): support intercepting "slow" requests

### DIFF
--- a/_http_common.d.ts
+++ b/_http_common.d.ts
@@ -2,6 +2,7 @@ declare var HTTPParser: {
   new (): HTTPParser<number>
   REQUEST: 0
   RESPONSE: 1
+  readonly kOnHeaders: unique symbol
   readonly kOnHeadersComplete: unique symbol
   readonly kOnBody: unique symbol
   readonly kOnMessageComplete: unique symbol
@@ -10,6 +11,7 @@ declare var HTTPParser: {
 export interface HTTPParser<ParserType extends number> {
   new (): HTTPParser<ParserType>
 
+  [HTTPParser.kOnHeaders]: RequestHeadersCallback
   [HTTPParser.kOnHeadersComplete]: ParserType extends 0
     ? RequestHeadersCompleteCallback
     : ResponseHeadersCompleteCallback
@@ -22,10 +24,15 @@ export interface HTTPParser<ParserType extends number> {
   free(): void
 }
 
+export type RequestHeadersCallback = (
+  rawHeaders: Array<string>,
+  url: string
+) => void
+
 export type RequestHeadersCompleteCallback = (
   versionMajor: number,
   versionMinor: number,
-  headers: Array<string>,
+  rawHeaders: Array<string>,
   idk: number,
   path: string,
   idk2: unknown,

--- a/_http_common.d.ts
+++ b/_http_common.d.ts
@@ -2,21 +2,31 @@ declare var HTTPParser: {
   new (): HTTPParser<number>
   REQUEST: 0
   RESPONSE: 1
+
+  /**
+   * @see https://github.com/nodejs/node/blob/229cc3be28eab3153c16bc55bc67d1e81c4a7067/src/node_http_parser.cc#L76
+   */
+  readonly kOnMessageBegin: unique symbol
   readonly kOnHeaders: unique symbol
   readonly kOnHeadersComplete: unique symbol
   readonly kOnBody: unique symbol
   readonly kOnMessageComplete: unique symbol
+  readonly kOnExecute: unique symbol
+  readonly kOnTimeout: unique symbol
 }
 
 export interface HTTPParser<ParserType extends number> {
   new (): HTTPParser<ParserType>
 
+  [HTTPParser.kOnMessageBegin]: () => void
   [HTTPParser.kOnHeaders]: RequestHeadersCallback
   [HTTPParser.kOnHeadersComplete]: ParserType extends 0
     ? RequestHeadersCompleteCallback
     : ResponseHeadersCompleteCallback
   [HTTPParser.kOnBody]: (chunk: Buffer) => void
   [HTTPParser.kOnMessageComplete]: () => void
+  [HTTPParser.kOnExecute]: () => void
+  [HTTPParser.kOnTimeout]: () => void
 
   initialize(type: ParserType, asyncResource: object): void
   execute(buffer: Buffer): void

--- a/test/modules/http/compliance/http-custom-agent.test.ts
+++ b/test/modules/http/compliance/http-custom-agent.test.ts
@@ -3,7 +3,7 @@ import { vi, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
 import http from 'node:http'
 import https from 'node:https'
 import { HttpServer } from '@open-draft/test-server/http'
-import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest/index'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
 import { waitForClientRequest } from '../../../../test/helpers'
 
 const interceptor = new ClientRequestInterceptor()

--- a/test/modules/http/compliance/http-max-header-fields-count.test.ts
+++ b/test/modules/http/compliance/http-max-header-fields-count.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+import http from 'node:http'
+import { afterAll, afterEach, beforeAll, it, expect } from 'vitest'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+import { waitForClientRequest } from '../../../helpers'
+import { DeferredPromise } from '@open-draft/deferred-promise'
+
+const interceptor = new ClientRequestInterceptor()
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+})
+
+it('supports requests with more than default maxiumum header fields count', async () => {
+  const requestHeadersPromise = new DeferredPromise<Headers>()
+
+  interceptor.on('request', ({ request, controller }) => {
+    requestHeadersPromise.resolve(request.headers)
+    controller.respondWith(new Response())
+  })
+
+  const request = http.request('http://localhost/irrelevant')
+
+  /**
+   * By default, Node.js HTTP parser defines 32 as the maximum header fields count.
+   * Each request also has "connection" and "host" headers added automatically.
+   * @see https://github.com/nodejs/node/blob/229cc3be28eab3153c16bc55bc67d1e81c4a7067/src/node_http_parser.cc#L83-L84
+   */
+  const headersPairs = Array.from({ length: 60 })
+    .map<[string, string]>((_, index) => {
+      return [`x-header-${index}`, index.toString()]
+    })
+    .sort()
+  request.setHeaders(new Headers(headersPairs))
+  request.end()
+
+  await waitForClientRequest(request)
+  const requestHeaders = await requestHeadersPromise
+
+  expect(Array.from(requestHeaders)).toEqual([
+    ['connection', 'close'],
+    ['host', 'localhost'],
+    ...headersPairs,
+  ])
+})
+
+it('supports multiple parallel "slow" requests', async () => {
+  // Perform multiple slow requests to ensure their buffered headers don't overlap.
+  for (let requestIndex = 0; requestIndex < 5; requestIndex++) {
+    const requestHeadersPromise = new DeferredPromise<Headers>()
+
+    interceptor.on('request', ({ request, controller }) => {
+      if (request.url === `http://localhost/${requestIndex}`) {
+        requestHeadersPromise.resolve(request.headers)
+        controller.respondWith(new Response())
+      }
+    })
+
+    const request = http.request(`http://localhost/${requestIndex}`)
+
+    const headersPairs = Array.from({ length: 60 })
+      .map<[string, string]>((_, index) => {
+        return [
+          `x-request-${requestIndex}-header-${index}`,
+          requestIndex.toString() + index.toString(),
+        ]
+      })
+      .sort()
+    request.setHeaders(new Headers(headersPairs))
+    request.end()
+
+    await waitForClientRequest(request)
+    const requestHeaders = await requestHeadersPromise
+
+    expect(Array.from(requestHeaders)).toEqual([
+      ['connection', 'close'],
+      ['host', 'localhost'],
+      ...headersPairs,
+    ])
+  }
+})


### PR DESCRIPTION
- Fixes #729
- Closes #730

## Changes

Adds the `kOnHeaders` internal callback to make sure we're buffering the request headers for "slow" requests correctly. 

> [!IMPORTANT]
> In the test case for multiple slow requests, I've somehow reproduced socket's `path` being `undefined`. That produces `/undefined` in the URL path so I'm adding a fallback to an empty string if that ever happens. This is not reproducible in isolation. 