### PR TITLE
fix(ClientRequest): support mocking responses with a lot of headers

### DIFF
--- a/_http_common.d.ts
+++ b/_http_common.d.ts
@@ -19,7 +19,7 @@ export interface HTTPParser<ParserType extends number> {
   new (): HTTPParser<ParserType>
 
   [HTTPParser.kOnMessageBegin]: () => void
-  [HTTPParser.kOnHeaders]: RequestHeadersCallback
+  [HTTPParser.kOnHeaders]: HeadersCallback
   [HTTPParser.kOnHeadersComplete]: ParserType extends 0
     ? RequestHeadersCompleteCallback
     : ResponseHeadersCompleteCallback
@@ -34,7 +34,7 @@ export interface HTTPParser<ParserType extends number> {
   free(): void
 }
 
-export type RequestHeadersCallback = (
+export type HeadersCallback = (
   rawHeaders: Array<string>,
   url: string
 ) => void

--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -54,7 +54,8 @@ export class MockHttpSocket extends MockSocket {
   private onResponse: MockHttpSocketResponseCallback
   private responseListenersPromise?: Promise<void>
 
-  private rawHeadersBuffer: Array<string> = []
+  private requestRawHeadersBuffer: Array<string> = []
+  private responseRawHeadersBuffer: Array<string> = []
   private writeBuffer: Array<NormalizedSocketWriteArgs> = []
   private request?: Request
   private requestParser: HTTPParser<0>
@@ -484,7 +485,7 @@ export class MockHttpSocket extends MockSocket {
    * @note This is called before request start.
    */
   private onRequestHeaders: HeadersCallback = (rawHeaders) => {
-    this.rawHeadersBuffer.push(...rawHeaders)
+    this.requestRawHeadersBuffer.push(...rawHeaders)
   }
 
   private onRequestStart: RequestHeadersCompleteCallback = (
@@ -503,10 +504,10 @@ export class MockHttpSocket extends MockSocket {
     const url = new URL(path || '', this.baseUrl)
     const method = this.connectionOptions.method?.toUpperCase() || 'GET'
     const headers = FetchResponse.parseRawHeaders([
-      ...this.rawHeadersBuffer,
+      ...this.requestRawHeadersBuffer,
       ...(rawHeaders || []),
     ])
-    this.rawHeadersBuffer.length = 0
+    this.requestRawHeadersBuffer.length = 0
 
     const canHaveBody = method !== 'GET' && method !== 'HEAD'
 
@@ -606,7 +607,7 @@ export class MockHttpSocket extends MockSocket {
    * @note This is called before response start.
    */
   private onResponseHeaders: HeadersCallback = (rawHeaders) => {
-    this.rawHeadersBuffer.push(...rawHeaders)
+    this.responseRawHeadersBuffer.push(...rawHeaders)
   }
 
   private onResponseStart: ResponseHeadersCompleteCallback = (
@@ -619,10 +620,10 @@ export class MockHttpSocket extends MockSocket {
     statusText
   ) => {
     const headers = FetchResponse.parseRawHeaders([
-      ...this.rawHeadersBuffer,
+      ...this.responseRawHeadersBuffer,
       ...(rawHeaders || []),
     ])
-    this.rawHeadersBuffer.length = 0
+    this.responseRawHeadersBuffer.length = 0
 
     const response = new FetchResponse(
       /**

--- a/test/modules/http/compliance/http-max-header-fields-count.test.ts
+++ b/test/modules/http/compliance/http-max-header-fields-count.test.ts
@@ -91,13 +91,13 @@ it('supports multiple parallel "slow" requests', async () => {
 it('supports responses with more than default maximum header fields count', async () => {
   const responseHeadersPromise = new DeferredPromise<Headers>()
 
-  interceptor.on('request', ({ request, controller }) => {
-    const responseHeadersPairs = Array.from({ length: 60 })
-      .map<[string, string]>((_, index) => {
-        return [`x-response-header-${index}`, index.toString()]
-      })
-      .sort()
-    
+  const responseHeadersPairs = Array.from({ length: 60 })
+    .map<[string, string]>((_, index) => {
+      return [`x-response-header-${index}`, index.toString()]
+    })
+    .sort()
+
+  interceptor.on('request', ({ controller }) => {
     const response = new Response(null, {
       status: 200,
       headers: new Headers(responseHeadersPairs)
@@ -110,17 +110,11 @@ it('supports responses with more than default maximum header fields count', asyn
     responseHeadersPromise.resolve(response.headers)
   })
 
-  const request = http.request('http://localhost/response-headers')
+  const request = http.get('http://localhost/irrelevant')
   request.end()
 
   await waitForClientRequest(request)
   const responseHeaders = await responseHeadersPromise
 
-  const expectedHeadersPairs = Array.from({ length: 60 })
-    .map<[string, string]>((_, index) => {
-      return [`x-response-header-${index}`, index.toString()]
-    })
-    .sort()
-
-  expect(Array.from(responseHeaders)).toEqual(expectedHeadersPairs)
+  expect(Array.from(responseHeaders)).toEqual(responseHeadersPairs)
 })


### PR DESCRIPTION
Fixes #729

### Changes

This is a follow-up to the previous PR #734 that addressed request header buffering for "slow" requests. While that PR focused on ensuring request headers are buffered correctly, this change extends the same validation to response headers to maintain consistency in header handling throughout the interceptor.