### PR TITLE
fix(ClientRequest): support `http.Agent` instances as agents for `https` requests

### DIFF
--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -126,7 +126,8 @@ export class MockHttpSocket extends MockSocket {
     // Response parser.
     this.responseParser = new HTTPParser()
     this.responseParser.initialize(HTTPParser.RESPONSE, {})
-    this.responseParser[HTTPParser.kOnHeaders] = this.onResponseHeaders.bind(this)
+    this.responseParser[HTTPParser.kOnHeaders] =
+      this.onResponseHeaders.bind(this)
     this.responseParser[HTTPParser.kOnHeadersComplete] =
       this.onResponseStart.bind(this)
     this.responseParser[HTTPParser.kOnBody] = this.onResponseBody.bind(this)

--- a/src/interceptors/ClientRequest/agents.ts
+++ b/src/interceptors/ClientRequest/agents.ts
@@ -75,12 +75,12 @@ export class MockHttpsAgent extends https.Agent {
 
   public createConnection(options: any, callback: any): net.Socket {
     const createConnection =
-      this.customAgent instanceof https.Agent
+      this.customAgent instanceof http.Agent
         ? this.customAgent.createConnection
         : super.createConnection
 
     const createConnectionOptions =
-      this.customAgent instanceof https.Agent
+      this.customAgent instanceof http.Agent
         ? {
             ...options,
             ...this.customAgent.options,


### PR DESCRIPTION
- Fixes #675

## Changes

`MockHttpsAgent` now performs an instance check for `http.Agent` since HTTP agents are valid agents for `https.request()`. 