### PR TITLE
fix(MockHttpSocket): handle response body streaming errors correctly

### DIFF
--- a/test/modules/http/compliance/http-res-destroy.test.ts
+++ b/test/modules/http/compliance/http-res-destroy.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment node
+import { setTimeout } from 'node:timers/promises'
 import { vi, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
 import http from 'node:http'
 import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
 import { HttpServer } from '@open-draft/test-server/lib/http'
 import { waitForClientRequest } from '../../../helpers'
+import { type Socket } from 'node:net'
 
 const httpServer = new HttpServer((app) => {
   app.get('/', (req, res) => res.sendStatus(200))
@@ -12,57 +14,158 @@ const httpServer = new HttpServer((app) => {
 const interceptor = new ClientRequestInterceptor()
 
 beforeAll(async () => {
-  interceptor.apply()
   await httpServer.listen()
 })
 
 afterEach(() => {
   interceptor.removeAllListeners()
+  interceptor.dispose()
 })
 
 afterAll(async () => {
-  interceptor.dispose()
   await httpServer.close()
 })
 
-it('emits the "error" event when a bypassed response is destroyed', async () => {
-  const socketErrorListener = vi.fn()
+const scenarios = [
+  {
+    condition: 'when the interceptor is not enabled [baseline test]',
+    setup: () => {},
+  },
+  {
+    condition: 'for a bypassed response',
+    setup: () => {
+      interceptor.apply()
+    },
+  },
+  {
+    condition: 'for a mocked response',
+    setup: () => {
+      interceptor.apply()
+      interceptor.on('request', ({ controller }) => {
+        controller.respondWith(new Response('hello world'))
+      })
+    },
+  },
+]
 
-  const request = http
-    .get(httpServer.http.url('/'))
-    .on('socket', (socket) => {
-      socket.on('error', socketErrorListener)
-    })
-    .on('response', (response) => {
-      response.destroy(new Error('reason'))
-    })
+scenarios.forEach(({ condition, setup }) => {
+  it(`emits the "error" event to the socket, response and request when the response is destroyed ${condition}`, async () => {
+    setup()
 
-  const { res } = await waitForClientRequest(request)
+    const socketErrorListener = vi.fn()
+    const responseErrorListener = vi.fn()
+    const requestErrorListener = vi.fn()
 
-  expect(res.destroyed).toBe(true)
-  expect(socketErrorListener).toHaveBeenCalledOnce()
-  expect(socketErrorListener).toHaveBeenCalledWith(new Error('reason'))
-})
+    let socket: Socket
+    const responseError = new Error('reason')
 
-it('emits the "error" event when a mocked response is destroyed', async () => {
-  interceptor.on('request', ({ controller }) => {
-    controller.respondWith(new Response('hello world'))
+    const request = http
+      .get(httpServer.http.url('/'))
+      .on('socket', (newSocket) => {
+        newSocket.on('error', socketErrorListener)
+        socket = newSocket
+      })
+      .on('response', (response) => {
+        response.on('error', responseErrorListener)
+        response.destroy(responseError)
+      })
+      .on('error', requestErrorListener)
+
+    const { res } = await waitForClientRequest(request)
+
+    await setTimeout(0)
+
+    expect(res.destroyed).toBe(true)
+    expect(responseErrorListener).toHaveBeenCalledOnce()
+    expect(responseErrorListener).toHaveBeenCalledWith(responseError)
+
+    // @ts-expect-error
+    expect(socket?.destroyed).toBe(true)
+    expect(socketErrorListener).toHaveBeenCalledOnce()
+    expect(socketErrorListener).toHaveBeenCalledWith(responseError)
+
+    expect(request.destroyed).toBe(true)
+    expect(requestErrorListener).toHaveBeenCalledOnce()
+    expect(requestErrorListener).toHaveBeenCalledWith(responseError)
   })
 
-  const socketErrorListener = vi.fn()
+  it(`emits the "error" event to the socket and request when the socket is destroyed ${condition}`, async () => {
+    setup()
 
-  const request = http
-    .get(httpServer.http.url('/'))
-    .on('socket', (socket) => {
-      socket.on('error', socketErrorListener)
-    })
-    .on('response', (response) => {
-      response.destroy(new Error('reason'))
-    })
+    const socketErrorListener = vi.fn()
+    const responseErrorListener = vi.fn()
+    const requestErrorListener = vi.fn()
 
-  const { res } = await waitForClientRequest(request)
+    let socket: Socket
 
-  expect(res.destroyed).toBe(true)
-  expect(socketErrorListener).toHaveBeenCalledOnce()
-  expect(socketErrorListener).toHaveBeenCalledWith(new Error('reason'))
+    const socketError = new Error('reason')
+
+    const request = http
+      .get(httpServer.http.url('/'))
+      .on('socket', (newSocket) => {
+        newSocket.on('error', socketErrorListener)
+        socket = newSocket
+      })
+      .on('response', (response) => {
+        response.on('error', responseErrorListener)
+        socket.destroy(socketError)
+      })
+      .on('error', requestErrorListener)
+
+    const { res } = await waitForClientRequest(request)
+
+    await setTimeout(0)
+
+    expect(res.destroyed).toBe(false)
+    expect(responseErrorListener).not.toHaveBeenCalled()
+
+    // @ts-expect-error
+    expect(socket?.destroyed).toBe(true)
+    expect(socketErrorListener).toHaveBeenCalledOnce()
+    expect(socketErrorListener).toHaveBeenCalledWith(socketError)
+
+    expect(request.destroyed).toBe(true)
+    expect(requestErrorListener).toHaveBeenCalledOnce()
+    expect(requestErrorListener).toHaveBeenCalledWith(socketError)
+  })
+
+  it(`emits the "error" event to the socket and request when the request is destroyed ${condition}`, async () => {
+    setup()
+
+    const socketErrorListener = vi.fn()
+    const responseErrorListener = vi.fn()
+    const requestErrorListener = vi.fn()
+
+    let socket: Socket
+
+    const requestError = new Error('reason')
+
+    const request = http
+      .get(httpServer.http.url('/'))
+      .on('socket', (newSocket) => {
+        newSocket.on('error', socketErrorListener)
+        socket = newSocket
+      })
+      .on('response', (response) => {
+        response.on('error', responseErrorListener)
+        request.destroy(requestError)
+      })
+      .on('error', requestErrorListener)
+
+    const { res } = await waitForClientRequest(request)
+
+    await setTimeout(0)
+
+    expect(res.destroyed).toBe(true)
+    expect(responseErrorListener).not.toHaveBeenCalled()
+
+    // @ts-expect-error
+    expect(socket?.destroyed).toBe(true)
+    expect(socketErrorListener).toHaveBeenCalledOnce()
+    expect(socketErrorListener).toHaveBeenCalledWith(requestError)
+
+    expect(request.destroyed).toBe(true)
+    expect(requestErrorListener).toHaveBeenCalledOnce()
+    expect(requestErrorListener).toHaveBeenCalledWith(requestError)
+  })
 })

--- a/test/modules/http/response/http-response-error.test.ts
+++ b/test/modules/http/response/http-response-error.test.ts
@@ -58,6 +58,7 @@ it('treats a thrown Response.error() as a network error', async () => {
       new TypeError('Network error')
     )
   })
-
+  
+  expect(requestErrorListener).toHaveBeenCalledOnce()
   expect(responseListener).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
# Problem

- Response body streaming errors are not handled correctly
- See #738 

# Solution

- Add a number of tests around stream destruction (socket / response body / request) including some baseline tests to verify the Node.js behaviour without any interception enabled
- Expand existing response readable stream tests to add more error scenarios
- Update `MockHttpSocket` so it:
  - Emits an `error` event if the response body stream errors after the headers have been returned (rather than attempting to return a 500 status error)
  - Only calls `error` event listeners once on error
  - Forwards response body streaming errors to the `IncomingRequest` that the client is interacting with
