### PR TITLE
chore: various typos across codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ class XMLHttpRequestProxy extends XMLHttpRequest {
 }
 ```
 
-> The request interception algorithms differ dramatically based on the request API. Interceptors acommodate for them all, bringing the intercepted requests to a common ground—the Fetch API `Request` instance. The same applies for responses, where a Fetch API `Response` instance is translated to the appropriate response format.
+> The request interception algorithms differ dramatically based on the request API. Interceptors accommodate for them all, bringing the intercepted requests to a common ground—the Fetch API `Request` instance. The same applies for responses, where a Fetch API `Response` instance is translated to the appropriate response format.
 
 This library aims to provide _full specification compliance_ with the APIs and protocols it extends.
 
@@ -532,7 +532,7 @@ client.addEventListener('message', (event) => {
 
 #### `.close()`
 
-Closes the connection with the original WebSocket server. Unlike `client.close()`, closing the server connection does not accept any arguments and always asumes a graceful closure. Sending data via `server.send()` after the connection has been closed will have no effect.
+Closes the connection with the original WebSocket server. Unlike `client.close()`, closing the server connection does not accept any arguments and always assumes a graceful closure. Sending data via `server.send()` after the connection has been closed will have no effect.
 
 ## API
 

--- a/src/Interceptor.test.ts
+++ b/src/Interceptor.test.ts
@@ -100,7 +100,7 @@ describe('readyState', () => {
     expect(interceptor.readyState).toBe(InterceptorReadyState.INACTIVE)
   })
 
-  it('perfroms state transition when the interceptor is applying', async () => {
+  it('performs state transition when the interceptor is applying', async () => {
     const interceptor = new Interceptor(symbol)
     interceptor.apply()
 
@@ -109,7 +109,7 @@ describe('readyState', () => {
     expect(interceptor.readyState).toBe(InterceptorReadyState.APPLIED)
   })
 
-  it('perfroms state transition when disposing of the interceptor', async () => {
+  it('performs state transition when disposing of the interceptor', async () => {
     const interceptor = new Interceptor(symbol)
     interceptor.apply()
     interceptor.dispose()

--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -162,7 +162,7 @@ export class MockHttpSocket extends MockSocket {
 
   public destroy(error?: Error | undefined): this {
     // Destroy the response parser when the socket gets destroyed.
-    // Normally, we shoud listen to the "close" event but it
+    // Normally, we should listen to the "close" event but it
     // can be suppressed by using the "emitClose: false" option.
     this.responseParser.free()
 

--- a/src/interceptors/ClientRequest/utils/getIncomingMessageBody.test.ts
+++ b/src/interceptors/ClientRequest/utils/getIncomingMessageBody.test.ts
@@ -29,7 +29,7 @@ it('returns utf8 string given a gzipped response body', async () => {
   expect(await pendingResponseBody).toEqual('two')
 })
 
-it('returns utf8 string given a gzipped response body with incorrect "content-lenght"', async () => {
+it('returns utf8 string given a gzipped response body with incorrect "content-length"', async () => {
   const utfBuffer = zlib.gzipSync(Buffer.from('three'))
   const message = new IncomingMessage(new Socket())
   message.headers = {

--- a/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
+++ b/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts
@@ -174,7 +174,7 @@ export function normalizeClientRequestArgs(
     if (legacyUrl.hostname === null) {
       /**
        * We are dealing with a relative url, so use the path as an "option" and
-       * merge in any existing options, giving priority to exising options -- i.e. a path in any
+       * merge in any existing options, giving priority to existing options -- i.e. a path in any
        * existing options will take precedence over the one contained in the url. This is consistent
        * with the behaviour in ClientRequest.
        * @see https://github.com/nodejs/node/blob/d84f1312915fe45fe0febe888db692c74894c382/lib/_http_client.js#L122

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
@@ -118,7 +118,7 @@ it('records raw headers (Request / Headers as init)', () => {
   expect(getRawFetchHeaders(request.headers)).toEqual([['X-My-Header', '1']])
 })
 
-it('records raw headers (Reqest / Request as init)', () => {
+it('records raw headers (Request / Request as init)', () => {
   recordRawFetchHeaders()
   const init = new Request(url, { headers: [['X-My-Header', '1']] })
   const request = new Request(init)

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
@@ -251,7 +251,7 @@ export function getRawFetchHeaders(headers: Headers): RawHeaders {
  * That means the headers were created standalone and already have
  * the raw headers stored.
  * If the `init.headers` is a HeadersInit, create a new Headers
- * instace out of it.
+ * instance out of it.
  */
 function inferRawHeaders(headers: HeadersInit): RawHeaders {
   if (headers instanceof Headers) {

--- a/src/interceptors/WebSocket/WebSocketOverride.ts
+++ b/src/interceptors/WebSocket/WebSocketOverride.ts
@@ -175,7 +175,7 @@ export class WebSocketOverride extends EventTarget implements WebSocket {
     wasClean = true
   ): void {
     /**
-     * @note Move this check here so that even internall closures,
+     * @note Move this check here so that even internal closures,
      * like those triggered by the `server` connection, are not
      * performed twice.
      */

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -602,7 +602,7 @@ export class XMLHttpRequestController {
     this.logger.info('set readyState to: %d', nextReadyState)
 
     if (nextReadyState !== this.request.UNSENT) {
-      this.logger.info('triggerring "readystatechange" event...')
+      this.logger.info('triggering "readystatechange" event...')
 
       this.trigger('readystatechange', this.request)
     }

--- a/src/interceptors/XMLHttpRequest/utils/createResponse.ts
+++ b/src/interceptors/XMLHttpRequest/utils/createResponse.ts
@@ -24,13 +24,13 @@ export function createResponse(
     url: request.responseURL,
     status: request.status,
     statusText: request.statusText,
-    headers: createHeadersFromXMLHttpReqestHeaders(
+    headers: createHeadersFromXMLHttpRequestHeaders(
       request.getAllResponseHeaders()
     ),
   })
 }
 
-function createHeadersFromXMLHttpReqestHeaders(headersString: string): Headers {
+function createHeadersFromXMLHttpRequestHeaders(headersString: string): Headers {
   const headers = new Headers()
 
   const lines = headersString.split(/[\r\n]+/)

--- a/src/utils/emitAsync.ts
+++ b/src/utils/emitAsync.ts
@@ -13,13 +13,13 @@ export async function emitAsync<
   eventName: EventName,
   ...data: Events[EventName]
 ): Promise<void> {
-  const listners = emitter.listeners(eventName)
+  const listeners = emitter.listeners(eventName)
 
-  if (listners.length === 0) {
+  if (listeners.length === 0) {
     return
   }
 
-  for (const listener of listners) {
+  for (const listener of listeners) {
     await listener.apply(emitter, data)
   }
 }

--- a/test/modules/WebSocket/compliance/websocket.reuse-listeners.test.ts
+++ b/test/modules/WebSocket/compliance/websocket.reuse-listeners.test.ts
@@ -50,7 +50,7 @@ it('allows reusing the same function for multiple client listeners', async () =>
   await waitForWebSocketEvent('close', socket)
 
   /**
-   * @note The same event listner for the same event is deduped.
+   * @note The same event listener for the same event is deduped.
    * It will only be called once. That is correct.
    */
   expect(clientMessageListener).toHaveBeenCalledTimes(1)
@@ -76,7 +76,7 @@ it('allows reusing the same function for multiple server listeners', async () =>
   await waitForWebSocketEvent('close', socket)
 
   /**
-   * @note The same event listner for the same event is deduped.
+   * @note The same event listener for the same event is deduped.
    * It will only be called once. That is correct.
    */
   expect(serverMessageListener).toHaveBeenCalledTimes(1)

--- a/test/modules/WebSocket/intercept/websocket.send.test.ts
+++ b/test/modules/WebSocket/intercept/websocket.send.test.ts
@@ -85,7 +85,7 @@ it('intercepts ArrayBuffer sent over websocket', async () => {
   expect(await messageReceivedPromise).toEqual(buffer)
 })
 
-it('increases "bufferAmmount" before data is sent', async () => {
+it('increases "bufferAmount" before data is sent', async () => {
   interceptor.once('connection', () => {})
 
   const bufferAmountPromise = new DeferredPromise<{

--- a/test/modules/XMLHttpRequest/response/xhr.test.ts
+++ b/test/modules/XMLHttpRequest/response/xhr.test.ts
@@ -40,7 +40,7 @@ interceptor.on('request', ({ request, controller }) => {
     return controller.respondWith(
       new Response('foo', {
         status: 301,
-        statusText: 'Moved Permantently',
+        statusText: 'Moved Permanently',
         headers: {
           'Content-Type': 'application/hal+json',
         },

--- a/test/modules/fetch/compliance/fetch-response-non-configurable.test.ts
+++ b/test/modules/fetch/compliance/fetch-response-non-configurable.test.ts
@@ -39,7 +39,7 @@ it('handles non-configurable responses from the actual server', async () => {
     'fetch failed'
   )
 
-  // Must not call the response listner. Fetch failed.
+  // Must not call the response listener. Fetch failed.
   expect(responseListener).not.toHaveBeenCalled()
 })
 

--- a/test/modules/http/compliance/http-errors.test.ts
+++ b/test/modules/http/compliance/http-errors.test.ts
@@ -63,7 +63,7 @@ it('forwards ECONNREFUSED error given a bypassed request', async () => {
 
   /**
    * @note Don't assert exact error address/port
-   * because Node.js v20 will aggreggate connection errors
+   * because Node.js v20 will aggregate connection errors
    * into a single "AggregateError" instance that doesn't have those.
    */
   expect(requestError.code).toBe('ECONNREFUSED')

--- a/test/modules/http/compliance/http-max-header-fields-count.test.ts
+++ b/test/modules/http/compliance/http-max-header-fields-count.test.ts
@@ -19,7 +19,7 @@ afterAll(() => {
   interceptor.dispose()
 })
 
-it('supports requests with more than default maxiumum header fields count', async () => {
+it('supports requests with more than default maximum header fields count', async () => {
   const requestHeadersPromise = new DeferredPromise<Headers>()
 
   interceptor.on('request', ({ request, controller }) => {

--- a/test/modules/http/compliance/http-request-without-options.test.ts
+++ b/test/modules/http/compliance/http-request-without-options.test.ts
@@ -46,7 +46,7 @@ it('supports "http.request()" without any arguments', async () => {
   expect(await text()).toBe('Mocked')
 })
 
-it('supports "http.get()" without any argumenst', async () => {
+it('supports "http.get()" without any arguments', async () => {
   const responseListener = vi.fn()
   const errorListener = vi.fn()
 


### PR DESCRIPTION
## Summary

Apply typo corrections across the codebase

Chores:
- Fix misspelled identifiers and function names (e.g., listners→listeners, createHeadersFromXMLHttpReqestHeaders→createHeadersFromXMLHttpRequestHeaders)
- Correct typos in comments and documentation (e.g., acommodate→accommodate, triggerring→triggering, internal, should)
- Fix spelling errors in test descriptions and identifiers across WebSocket, HTTP, fetch, and XHR tests