### PR TITLE
fix: set `redirected` property on redirect responses

### DIFF
--- a/src/interceptors/fetch/utils/followRedirect.ts
+++ b/src/interceptors/fetch/utils/followRedirect.ts
@@ -85,7 +85,13 @@ export async function followFetchRedirect(
    */
 
   requestInit.headers = request.headers
-  return fetch(new Request(locationUrl, requestInit))
+  const finalResponse = await fetch(new Request(locationUrl, requestInit))
+  Object.defineProperty(finalResponse, 'redirected', {
+    value: true,
+    configurable: true,
+  })
+
+  return finalResponse
 }
 
 /**

--- a/test/modules/fetch/compliance/fetch-follow-redirects.test.ts
+++ b/test/modules/fetch/compliance/fetch-follow-redirects.test.ts
@@ -30,6 +30,7 @@ it('follows a bypassed redirect response', async () => {
   const response = await fetch(httpServer.http.url('/original'))
 
   expect(response.status).toBe(200)
+  expect(response.redirected).toBe(true)
   await expect(response.text()).resolves.toBe('redirected')
 })
 
@@ -45,6 +46,7 @@ it('follows a mocked redirect to the original server', async () => {
   const response = await fetch(httpServer.http.url('/original'))
 
   expect(response.status).toBe(200)
+  expect(response.redirected).toBe(true)
   await expect(response.text()).resolves.toBe('redirected')
 })
 
@@ -60,6 +62,7 @@ it('follows a mocked relative redirect to the original server', async () => {
   const response = await fetch(httpServer.http.url('/original'))
 
   expect(response.status).toBe(200)
+  expect(response.redirected).toBe(true)
   await expect(response.text()).resolves.toBe('redirected')
 })
 
@@ -79,6 +82,7 @@ it('follows a mocked redirect to a mocked response', async () => {
   const response = await fetch(httpServer.http.url('/original'))
 
   expect(response.status).toBe(200)
+  expect(response.redirected).toBe(true)
   await expect(response.text()).resolves.toBe('mocked response')
 })
 
@@ -96,6 +100,7 @@ it('returns the redirect response as-is for a request with "manual" redirect mod
   })
 
   expect(response.status).toBe(301)
+  expect(response.redirected).toBe(false)
   expect(response.headers.get('location')).toBe(
     httpServer.http.url('/redirected')
   )


### PR DESCRIPTION
## Description

Sets the `.redirected` property on redirected requests to comply with the `Fetch` spec. 

Failing scenario using `msw`: 

```ts
it.only('sets the .redirected property', async () => {
  server.use(
    http.get(
      'https://fakesite.org/redirect/10',
      () => new HttpResponse(null, { status: 301, headers: { location: '/redirect/11' }, })
    ),
    http.get('https://fakesite.org/redirect/11', () => HttpResponse.json({ redirected: true }))
  );
  const response = await fetch('https://fakesite.org/redirect/10', { method: 'GET' });
  const json = await response.json();
  expect(json).toEqual({ redirected: true });
  expect(response.redirected).toBe(true);
});
```