### PR TITLE
fix(WebSocket): await `connection` event listeners

### DIFF
--- a/test/modules/WebSocket/utils/getWsUrl.ts
+++ b/test/modules/WebSocket/utils/getWsUrl.ts
@@ -1,7 +1,11 @@
+import { invariant } from 'outvariant'
 import type { WebSocketServer } from 'ws'
 
 export function getWsUrl(ws: WebSocketServer): string {
   const address = ws.address()
+
+  invariant(address != null, 'Failed to get WebSocket address: address is null')
+
   if (typeof address === 'string') {
     return address
   }


### PR DESCRIPTION
## Changes

- WebSocket interceptor now awaits all the `connection` event listeners before concluding whether to passthrough the connection. This allows the users to error the connection in asynchronous connection listeners (previously impossible, the connection would be established as-is despite async listener throwing eventually).