### PR TITLE
Fix: Correctly pass http version to the ServerResponse in node

### DIFF
--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -348,7 +348,7 @@ export class MockHttpSocket extends MockSocket {
     // This is critical for Node.js to correctly allow keep alive.
     // By default, nodejs sets keepalive to false if the HttpVersion is not at least
     // 1.1: https://github.com/nodejs/node/blob/70f6b58ac655234435a99d72b857dd7b316d34bf/lib/_http_server.js#L211C1-L211C34
-    // The version should normally already have been set by the onResponseStart method
+    // The version should normally already have been set by the onRequestStart method
     if(this.httpVersionMajor != null && this.httpVersionMinor != null) {
       incomingMessage.httpVersion = `${this.httpVersionMajor}.${this.httpVersionMinor}`
       incomingMessage.httpVersionMajor = this.httpVersionMajor

--- a/test/modules/http/response/http-response-connection-headers.test.ts
+++ b/test/modules/http/response/http-response-connection-headers.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @vitest-environment node
+ */
+import { it, expect, beforeAll, afterEach, afterAll } from 'vitest'
+import http from 'http'
+import https from 'https'
+import { HttpServer } from '@open-draft/test-server/http'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+import { waitForClientRequest } from '../../../helpers'
+
+const httpServer = new HttpServer((app) => {
+  app.get('/', (_req, res) => {
+    res.status(200).send('response with keep-alive')
+  })
+
+  app.get('/stream', (_req, res) => {
+    res.write('chunk1')
+    setTimeout(() => {
+      res.write('chunk2')
+      res.end()
+    }, 10)
+  })
+})
+
+const interceptor = new ClientRequestInterceptor()
+
+beforeAll(async () => {
+  interceptor.apply()
+  await httpServer.listen()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+  await httpServer.close()
+})
+
+it('responds to an HTTP request with connection: keep-alive header', async () => {
+  interceptor.on('request', ({ controller }) => {
+    controller.respondWith(
+      new Response('mock response', {
+        status: 200,
+        headers: {
+          Connection: 'keep-alive',
+          'Content-Type': 'text/plain',
+        },
+      })
+    )
+  })
+
+  const request = http.get('http://localhost/', {
+    headers: {
+      Connection: 'keep-alive',
+    },
+  })
+
+  const { res, text } = await waitForClientRequest(request)
+
+  expect(res.statusCode).toBe(200)
+  expect(res.headers.connection).toBe('keep-alive')
+  expect(await text()).toBe('mock response')
+})
+
+it('responds to an HTTP request with connection: close header', async () => {
+  interceptor.on('request', ({ controller }) => {
+    controller.respondWith(
+      new Response('mock response', {
+        status: 200,
+        headers: {
+          Connection: 'close',
+          'Content-Type': 'text/plain',
+        },
+      })
+    )
+  })
+
+  const request = http.get('http://localhost/', {
+    headers: {
+      Connection: 'close',
+    },
+  })
+
+  const { res, text } = await waitForClientRequest(request)
+
+  expect(res.statusCode).toBe(200)
+  expect(res.headers.connection).toBe('close')
+  expect(await text()).toBe('mock response')
+})
+
+it('responds to an HTTP request without connection header', async () => {
+  interceptor.on('request', ({ controller }) => {
+    controller.respondWith(
+      new Response('mock response', {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/plain',
+        },
+      })
+    )
+  })
+
+  const request = http.get('http://localhost/')
+
+  const { res, text } = await waitForClientRequest(request)
+
+  expect(res.statusCode).toBe(200)
+  expect(await text()).toBe('mock response')
+})
+
+it('responds to an HTTPS request with connection: keep-alive header', async () => {
+  interceptor.on('request', ({ controller }) => {
+    controller.respondWith(
+      new Response('mock response https', {
+        status: 200,
+        headers: {
+          Connection: 'keep-alive',
+          'Content-Type': 'text/plain',
+        },
+      })
+    )
+  })
+
+  const request = https.get('https://localhost/', {
+    headers: {
+      Connection: 'keep-alive',
+    },
+  })
+
+  const { res, text } = await waitForClientRequest(request)
+
+  expect(res.statusCode).toBe(200)
+  expect(res.headers.connection).toBe('keep-alive')
+  expect(await text()).toBe('mock response https')
+})
+
+it('responds to a streaming request with connection: keep-alive header', async () => {
+  interceptor.on('request', ({ controller }) => {
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream({
+      start(streamController) {
+        streamController.enqueue(encoder.encode('chunk1'))
+        setTimeout(() => {
+          streamController.enqueue(encoder.encode('chunk2'))
+          streamController.close()
+        }, 10)
+      },
+    })
+
+    controller.respondWith(
+      new Response(stream, {
+        status: 200,
+        headers: {
+          Connection: 'keep-alive',
+          'Content-Type': 'text/plain',
+        },
+      })
+    )
+  })
+
+  const request = http.get('http://localhost/', {
+    headers: {
+      Connection: 'keep-alive',
+    },
+  })
+
+  const { res, text } = await waitForClientRequest(request)
+
+  expect(res.statusCode).toBe(200)
+  expect(res.headers.connection).toBe('keep-alive')
+  expect(await text()).toBe('chunk1chunk2')
+})
+
+it('handles multiple sequential requests with keep-alive', async () => {
+  interceptor.on('request', ({ controller }) => {
+    controller.respondWith(
+      new Response('mock response sequential', {
+        status: 200,
+        headers: {
+          Connection: 'keep-alive',
+          'Content-Type': 'text/plain',
+        },
+      })
+    )
+  })
+
+  // First request
+  const request1 = http.get('http://localhost/', {
+    headers: {
+      Connection: 'keep-alive',
+    },
+  })
+
+  const { res: res1, text: text1 } = await waitForClientRequest(request1)
+
+  expect(res1.statusCode).toBe(200)
+  expect(res1.headers.connection).toBe('keep-alive')
+  expect(await text1()).toBe('mock response sequential')
+
+  // Second request
+  const request2 = http.get('http://localhost/', {
+    headers: {
+      Connection: 'keep-alive',
+    },
+  })
+
+  const { res: res2, text: text2 } = await waitForClientRequest(request2)
+
+  expect(res2.statusCode).toBe(200)
+  expect(res2.headers.connection).toBe('keep-alive')
+  expect(await text2()).toBe('mock response sequential')
+})


### PR DESCRIPTION
This PR updates the MockHttpSocket to correctly set the http version passed to ServerResponse. This fixes a bug where mocked responses with the Connection: keep-alive header never completed before. For that, I've added some regression tests.

I found it kinda hard to wrap my head around the architecture of mswjs/interceptors, so please let me know if I did something stupid.

This fixes a bug in nock: https://github.com/nock/nock/issues/2918