### PR TITLE
fix(fetch): sanitize header tuples to fix Node.js 24 compatibility

### DIFF
--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
@@ -256,3 +256,42 @@ it('isolates headers between different headers instances', async () => {
   expect(firstClone.get('Content-Type')).toBe('application/json')
   expect(secondClone.get('Content-Type')).toBeNull()
 })
+
+/**
+ * Node.js 24+ may pass additional internal arguments to Headers.prototype.set
+ * and Headers.prototype.append. This test ensures we only record the first
+ * two arguments (name, value) and ignore any additional internal arguments.
+ * @see https://github.com/mswjs/interceptors/issues/762
+ */
+it('ignores extra internal arguments passed to .set() and .append()', () => {
+  recordRawFetchHeaders()
+  const headers = new Headers()
+
+    // Simulate Node.js 24+ behavior where internal calls may pass extra arguments
+    // by calling the prototype methods directly with additional arguments.
+    ; (Headers.prototype.set as Function).call(
+      headers,
+      'X-Set-Header',
+      'set-value',
+      true // extra internal argument
+    )
+    ; (Headers.prototype.append as Function).call(
+      headers,
+      'X-Append-Header',
+      'append-value',
+      true // extra internal argument
+    )
+
+  const rawHeaders = getRawFetchHeaders(headers)
+
+  // Verify that raw headers only contain [name, value] tuples
+  expect(rawHeaders).toEqual([
+    ['X-Set-Header', 'set-value'],
+    ['X-Append-Header', 'append-value'],
+  ])
+
+  // Ensure no extra elements in each tuple
+  for (const tuple of rawHeaders) {
+    expect(tuple).toHaveLength(2)
+  }
+})

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.test.ts
@@ -267,31 +267,25 @@ it('ignores extra internal arguments passed to .set() and .append()', () => {
   recordRawFetchHeaders()
   const headers = new Headers()
 
-    // Simulate Node.js 24+ behavior where internal calls may pass extra arguments
-    // by calling the prototype methods directly with additional arguments.
-    ; (Headers.prototype.set as Function).call(
-      headers,
-      'X-Set-Header',
-      'set-value',
-      true // extra internal argument
-    )
-    ; (Headers.prototype.append as Function).call(
-      headers,
-      'X-Append-Header',
-      'append-value',
-      true // extra internal argument
-    )
+  // Simulate Node.js 24+ behavior where internal calls may pass extra arguments
+  // by calling the prototype methods directly with additional arguments.
+  Headers.prototype.set.call(
+    headers,
+    'X-Set-Header',
+    'set-value',
+    // @ts-expect-error Internal argument
+    true
+  )
+  Headers.prototype.append.call(
+    headers,
+    'X-Append-Header',
+    'append-value',
+    // @ts-expect-error Internal argument
+    true
+  )
 
-  const rawHeaders = getRawFetchHeaders(headers)
-
-  // Verify that raw headers only contain [name, value] tuples
-  expect(rawHeaders).toEqual([
+  expect(getRawFetchHeaders(headers)).toEqual([
     ['X-Set-Header', 'set-value'],
     ['X-Append-Header', 'append-value'],
   ])
-
-  // Ensure no extra elements in each tuple
-  for (const tuple of rawHeaders) {
-    expect(tuple).toHaveLength(2)
-  }
 })

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
@@ -122,7 +122,10 @@ export function recordRawFetchHeaders() {
         ) {
           // Ensure each header tuple has exactly 2 elements (name, value).
           // Node.js 24+ may have stored tuples with extra internal arguments.
-          const rawHeadersFromInit = Reflect.get(headersInit, kRawHeaders) as RawHeaders
+          const rawHeadersFromInit = Reflect.get(
+            headersInit,
+            kRawHeaders
+          ) as RawHeaders
           const sanitizedHeaders = rawHeadersFromInit.map(
             (tuple): HeaderTuple => [tuple[0], tuple[1]]
           )

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
@@ -113,9 +113,15 @@ export function recordRawFetchHeaders() {
           headersInit instanceof Headers &&
           Reflect.has(headersInit, kRawHeaders)
         ) {
+          // Ensure each header tuple has exactly 2 elements (name, value).
+          // Node.js 24+ may have stored tuples with extra internal arguments.
+          const rawHeadersFromInit = Reflect.get(headersInit, kRawHeaders) as RawHeaders
+          const sanitizedHeaders = rawHeadersFromInit.map(
+            (tuple): HeaderTuple => [tuple[0], tuple[1]]
+          )
           const headers = Reflect.construct(
             target,
-            [Reflect.get(headersInit, kRawHeaders)],
+            [sanitizedHeaders],
             newTarget
           )
           ensureRawHeadersSymbol(headers, [
@@ -124,7 +130,7 @@ export function recordRawFetchHeaders() {
              * This prevents multiple Headers instances from pointing
              * at the same internal "rawHeaders" array.
              */
-            ...Reflect.get(headersInit, kRawHeaders),
+            ...sanitizedHeaders,
           ])
           return headers
         }
@@ -149,14 +155,20 @@ export function recordRawFetchHeaders() {
 
   Headers.prototype.set = new Proxy(Headers.prototype.set, {
     apply(target, thisArg, args: HeaderTuple) {
-      recordRawHeader(thisArg, args, 'set')
+      // Use only the first two arguments (name, value) to record raw headers.
+      // Node.js 24+ may pass additional internal arguments that should not
+      // be included in the raw headers array.
+      recordRawHeader(thisArg, [args[0], args[1]], 'set')
       return Reflect.apply(target, thisArg, args)
     },
   })
 
   Headers.prototype.append = new Proxy(Headers.prototype.append, {
     apply(target, thisArg, args: HeaderTuple) {
-      recordRawHeader(thisArg, args, 'append')
+      // Use only the first two arguments (name, value) to record raw headers.
+      // Node.js 24+ may pass additional internal arguments that should not
+      // be included in the raw headers array.
+      recordRawHeader(thisArg, [args[0], args[1]], 'append')
       return Reflect.apply(target, thisArg, args)
     },
   })


### PR DESCRIPTION
Node.js 24 internally passes a third boolean argument to Headers.prototype.set() and .append(). This extra argument was being recorded in raw header tuples, causing "Headers constructor: expected name/value pair to be length 2, found 3" errors when those tuples were later passed to the Headers constructor.

- Only record [name, value] in set/append proxies, ignoring extra args
- Sanitize header tuples when cloning Headers instances

Fixes #762