### PR TITLE
fix(WebSocket): annotate `readyState` as `WebSocket['readyState']`

### DIFF
--- a/src/interceptors/WebSocket/WebSocketOverride.ts
+++ b/src/interceptors/WebSocket/WebSocketOverride.ts
@@ -30,7 +30,7 @@ export class WebSocketOverride extends EventTarget implements WebSocket {
   public protocol: string
   public extensions: string
   public binaryType: BinaryType
-  public readyState: number
+  public readyState: WebSocket['readyState']
   public bufferedAmount: number
 
   private _onopen: WebSocketEventListener | null = null


### PR DESCRIPTION
Fix #765 