### PR TITLE
fix: add `FetchRequest` utility

### DIFF
--- a/src/RemoteHttpInterceptor.ts
+++ b/src/RemoteHttpInterceptor.ts
@@ -7,7 +7,7 @@ import { XMLHttpRequestInterceptor } from './interceptors/XMLHttpRequest'
 import { FetchInterceptor } from './interceptors/fetch'
 import { handleRequest } from './utils/handleRequest'
 import { RequestController } from './RequestController'
-import { FetchResponse } from './utils/fetchUtils'
+import { FetchRequest, FetchResponse } from './utils/fetchUtils'
 import { isResponseError } from './utils/responseUtils'
 
 export interface SerializedRequest {
@@ -172,7 +172,7 @@ export class RemoteHttpResolver extends Interceptor<HttpRequestEventMap> {
 
       logger.info('parsed intercepted request', requestJson)
 
-      const request = new Request(requestJson.url, {
+      const request = new FetchRequest(requestJson.url, {
         method: requestJson.method,
         headers: new Headers(requestJson.headers),
         credentials: requestJson.credentials,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,6 @@ export {
 export { createRequestId } from './createRequestId'
 export { getCleanUrl } from './utils/getCleanUrl'
 export { encodeBuffer, decodeBuffer } from './utils/bufferUtils'
-export { FetchResponse } from './utils/fetchUtils'
+export { FetchRequest, FetchResponse } from './utils/fetchUtils'
 export { getRawRequest } from './getRawRequest'
 export { resolveWebSocketUrl } from './utils/resolveWebSocketUrl'

--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -15,7 +15,7 @@ import { isPropertyAccessible } from '../../utils/isPropertyAccessible'
 import { baseUrlFromConnectionOptions } from '../Socket/utils/baseUrlFromConnectionOptions'
 import { createRequestId } from '../../createRequestId'
 import { getRawFetchHeaders } from './utils/recordRawHeaders'
-import { FetchResponse } from '../../utils/fetchUtils'
+import { FetchRequest, FetchResponse } from '../../utils/fetchUtils'
 import { setRawRequest } from '../../getRawRequest'
 import { setRawRequestBodyStream } from '../../utils/node'
 import { freeParser } from './utils/parserUtils'
@@ -576,7 +576,7 @@ export class MockHttpSocket extends MockSocket {
     })
 
     const requestId = createRequestId()
-    this.request = new Request(url, {
+    this.request = new FetchRequest(url, {
       method,
       headers,
       credentials: 'same-origin',

--- a/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
+++ b/src/interceptors/ClientRequest/utils/recordRawHeaders.ts
@@ -1,3 +1,5 @@
+import { FetchRequest, FetchResponse } from '../../../utils/fetchUtils'
+
 type HeaderTuple = [string, string]
 type RawHeaders = Array<HeaderTuple>
 type SetHeaderBehavior = 'set' | 'append'
@@ -91,6 +93,11 @@ export function recordRawFetchHeaders() {
 
       globalThis.Request = OriginalRequest
       globalThis.Response = OriginalResponse
+
+      Object.setPrototypeOf(FetchRequest, OriginalRequest)
+      Object.setPrototypeOf(FetchRequest.prototype, OriginalRequest.prototype)
+      Object.setPrototypeOf(FetchResponse, OriginalResponse)
+      Object.setPrototypeOf(FetchResponse.prototype, OriginalResponse.prototype)
 
       Reflect.deleteProperty(Headers, kRestorePatches)
     },
@@ -222,6 +229,17 @@ export function recordRawFetchHeaders() {
       },
     }),
   })
+
+  /**
+   * Re-parent FetchRequest/FetchResponse so their `super()` calls go
+   * through the proxied globalThis.Request/Response above. Without this,
+   * FetchRequest extends the statically-captured (original) Request,
+   * bypassing the construct proxy that records raw headers.
+   */
+  Object.setPrototypeOf(FetchRequest, globalThis.Request)
+  Object.setPrototypeOf(FetchRequest.prototype, globalThis.Request.prototype)
+  Object.setPrototypeOf(FetchResponse, globalThis.Response)
+  Object.setPrototypeOf(FetchResponse.prototype, globalThis.Response.prototype)
 }
 
 export function restoreHeadersPrototype() {

--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -16,6 +16,7 @@ import { INTERNAL_REQUEST_ID_HEADER_NAME } from '../../Interceptor'
 import { createRequestId } from '../../createRequestId'
 import { getBodyByteLength } from './utils/getBodyByteLength'
 import { setRawRequest } from '../../getRawRequest'
+import { FetchRequest } from '../../utils/fetchUtils'
 
 const kIsRequestHandled = Symbol('kIsRequestHandled')
 const IS_NODE = isNodeProcess()
@@ -671,7 +672,7 @@ export class XMLHttpRequestController {
     const resolvedBody =
       body instanceof Document ? body.documentElement.innerText : body
 
-    const fetchRequest = new Request(this.url.href, {
+    const fetchRequest = new FetchRequest(this.url.href, {
       method: this.method,
       headers: this.requestHeaders,
       /**

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -12,7 +12,7 @@ import { createNetworkError } from './utils/createNetworkError'
 import { followFetchRedirect } from './utils/followRedirect'
 import { decompressResponse } from './utils/decompression'
 import { hasConfigurableGlobal } from '../../utils/hasConfigurableGlobal'
-import { FetchResponse } from '../../utils/fetchUtils'
+import { FetchRequest, FetchResponse } from '../../utils/fetchUtils'
 import { setRawRequest } from '../../getRawRequest'
 import { isResponseError } from '../../utils/responseUtils'
 
@@ -51,7 +51,7 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
           ? new URL(input, location.href)
           : input
 
-      const request = new Request(resolvedInput, init)
+      const request = new FetchRequest(resolvedInput, init)
 
       /**
        * @note Set the raw request only if a Request instance was provided to fetch.

--- a/src/utils/fetchUtils.test.ts
+++ b/src/utils/fetchUtils.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { FetchRequest } from './fetchUtils'
+
+describe('FetchRequest', () => {
+  const URL = 'https://example.com/'
+
+  it('creates a request with a non-configurable mode', () => {
+    expect
+      .soft(new FetchRequest(URL, { mode: 'navigate' }))
+      .toHaveProperty('mode', 'navigate')
+    expect
+      .soft(new FetchRequest(URL, { mode: 'websocket' }))
+      .toHaveProperty('mode', 'websocket')
+    expect
+      .soft(new FetchRequest(URL, { mode: 'webtransport' }))
+      .toHaveProperty('mode', 'webtransport')
+  })
+})

--- a/src/utils/fetchUtils.test.ts
+++ b/src/utils/fetchUtils.test.ts
@@ -4,15 +4,27 @@ import { FetchRequest } from './fetchUtils'
 describe('FetchRequest', () => {
   const URL = 'https://example.com/'
 
+  it('passes instanceof check with the regular Request', () => {
+    expect(new FetchRequest(URL)).toBeInstanceOf(Request)
+  })
+
   it('creates a request with a non-configurable method', () => {
     expect
       .soft(new FetchRequest(URL, { method: 'CONNECT' }))
       .toHaveProperty('method', 'CONNECT')
+
     expect
       .soft(new FetchRequest(URL, { method: 'TRACE' }))
       .toHaveProperty('method', 'TRACE')
     expect
+      .soft(new FetchRequest(new FetchRequest(URL, { method: 'TRACE' })))
+      .toHaveProperty('method', 'TRACE')
+
+    expect
       .soft(new FetchRequest(URL, { method: 'TRACK' }))
+      .toHaveProperty('method', 'TRACK')
+    expect
+      .soft(new FetchRequest(new FetchRequest(URL, { method: 'TRACK' })))
       .toHaveProperty('method', 'TRACK')
   })
 
@@ -21,10 +33,21 @@ describe('FetchRequest', () => {
       .soft(new FetchRequest(URL, { mode: 'navigate' }))
       .toHaveProperty('mode', 'navigate')
     expect
+      .soft(new FetchRequest(new FetchRequest(URL, { mode: 'navigate' })))
+      .toHaveProperty('mode', 'navigate')
+
+    expect
       .soft(new FetchRequest(URL, { mode: 'websocket' }))
       .toHaveProperty('mode', 'websocket')
     expect
+      .soft(new FetchRequest(new FetchRequest(URL, { mode: 'websocket' })))
+      .toHaveProperty('mode', 'websocket')
+
+    expect
       .soft(new FetchRequest(URL, { mode: 'webtransport' }))
+      .toHaveProperty('mode', 'webtransport')
+    expect
+      .soft(new FetchRequest(new FetchRequest(URL, { mode: 'webtransport' })))
       .toHaveProperty('mode', 'webtransport')
   })
 

--- a/src/utils/fetchUtils.test.ts
+++ b/src/utils/fetchUtils.test.ts
@@ -27,4 +27,36 @@ describe('FetchRequest', () => {
       .soft(new FetchRequest(URL, { mode: 'webtransport' }))
       .toHaveProperty('mode', 'webtransport')
   })
+
+  it('ignores body for the requests without a body', () => {
+    expect
+      .soft(new FetchRequest(URL, { body: null }))
+      .toHaveProperty('body', null)
+    expect
+      .soft(new FetchRequest(URL, { body: undefined }))
+      .toHaveProperty('body', null)
+    expect
+      .soft(new FetchRequest(URL, { body: 'hello' }))
+      .toHaveProperty('body', null)
+
+    expect
+      .soft(new FetchRequest(URL, { method: 'GET', body: 'hello' }))
+      .toHaveProperty('body', null)
+    expect
+      .soft(new FetchRequest(URL, { method: 'HEAD', body: 'hello' }))
+      .toHaveProperty('body', null)
+    expect
+      .soft(new FetchRequest(URL, { method: 'CONNECT', body: 'hello' }))
+      .toHaveProperty('body', null)
+    expect
+      .soft(new FetchRequest(URL, { method: 'TRACE', body: 'hello' }))
+      .toHaveProperty('body', null)
+    expect
+      .soft(new FetchRequest(URL, { method: 'TRACK', body: 'hello' }))
+      .toHaveProperty('body', null)
+
+    expect
+      .soft(new FetchRequest(URL, { method: 'POST', body: 'hello' }))
+      .toHaveProperty('body', expect.any(ReadableStream))
+  })
 })

--- a/src/utils/fetchUtils.test.ts
+++ b/src/utils/fetchUtils.test.ts
@@ -4,6 +4,18 @@ import { FetchRequest } from './fetchUtils'
 describe('FetchRequest', () => {
   const URL = 'https://example.com/'
 
+  it('creates a request with a non-configurable method', () => {
+    expect
+      .soft(new FetchRequest(URL, { method: 'CONNECT' }))
+      .toHaveProperty('method', 'CONNECT')
+    expect
+      .soft(new FetchRequest(URL, { method: 'TRACE' }))
+      .toHaveProperty('method', 'TRACE')
+    expect
+      .soft(new FetchRequest(URL, { method: 'TRACK' }))
+      .toHaveProperty('method', 'TRACK')
+  })
+
   it('creates a request with a non-configurable mode', () => {
     expect
       .soft(new FetchRequest(URL, { mode: 'navigate' }))

--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -53,6 +53,34 @@ export class FetchRequest extends Request {
       this.#setInternalProperty('method', method)
     }
 
+    if (method === 'CONNECT') {
+      const url = new URL(input instanceof Request ? input.url : input)
+
+      let authority: string
+
+      /**
+       * @note Node.js has a bug parsing raw CONNECT requests URLs like
+       * "http://127.0.0.1:1337/localhost:80". It would treat "localhost:" as a protocol.
+       */
+      if (url.protocol === 'localhost:') {
+        authority = url.href
+      } else {
+        authority = url.pathname.replace(/^\/+/, '')
+      }
+
+      /**
+       * @note Define "url" as a getter because Undici uses their own
+       * logic to resolve the "request.url" property. Simply reassigning
+       * its value doesn't do anything. This is a destructive action
+       * but it's safe because "CONNECT" requests are forbidden per fetch.
+       */
+      Object.defineProperty(this, 'url', {
+        get: () => authority,
+        enumerable: true,
+        configurable: true,
+      })
+    }
+
     if (mode != null && mode !== safeMode) {
       this.#setInternalProperty('mode', mode)
     }

--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -5,6 +5,7 @@ interface UndiciRequestState extends RequestInit {}
 
 interface FetchRequestInit extends Omit<RequestInit, 'mode'> {
   mode?: RequestMode | 'websocket' | 'webtransport'
+  duplex?: 'half' | 'full'
 }
 
 export class FetchRequest extends Request {
@@ -39,6 +40,9 @@ export class FetchRequest extends Request {
     const safeMethod = FetchRequest.isConfigurableMethod(method)
       ? method
       : 'GET'
+    const safeBody = FetchRequest.isMethodWithBody(method)
+      ? init?.body
+      : undefined
 
     const mode = (init?.mode as RequestMode) ?? undefined
     const safeMode = FetchRequest.isConfigurableMode(mode) ? mode : undefined
@@ -47,6 +51,10 @@ export class FetchRequest extends Request {
       ...(init || {}),
       method: safeMethod,
       mode: safeMode,
+      // @ts-expect-error Untyped Node.js property.
+      duplex:
+        init?.duplex != null ? init.duplex : safeBody ? 'half' : undefined,
+      body: safeBody,
     })
 
     if (method !== safeMethod) {

--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -1,11 +1,58 @@
 import { canParseUrl } from './canParseUrl'
 import { getValueBySymbol } from './getValueBySymbol'
 
+interface UndiciRequestState extends RequestInit {}
+
+interface FetchRequestInit extends Omit<RequestInit, 'mode'> {
+  mode?: RequestMode | 'websocket' | 'webtransport'
+}
+
+export class FetchRequest extends Request {
+  static isMethodWithBody(method: string): boolean {
+    return method !== 'HEAD' && method !== 'GET'
+  }
+
+  /**
+   * Check if the given request `mode` is configurable.
+   * @see https://fetch.spec.whatwg.org/#concept-request-mode
+   */
+  static isConfigurableMode(mode: string): boolean {
+    return (
+      mode !== 'navigate' && mode !== 'websocket' && mode !== 'webtransport'
+    )
+  }
+
+  constructor(input: RequestInfo, init?: FetchRequestInit) {
+    const mode = (init?.mode as RequestMode) ?? undefined
+    const safeMode = FetchRequest.isConfigurableMode(mode) ? mode : undefined
+
+    super(input, {
+      ...(init || {}),
+      mode: safeMode,
+    })
+
+    if (init?.mode != null && init?.mode !== safeMode) {
+      const state = getValueBySymbol<UndiciRequestState>('state', this)
+
+      if (state) {
+        state.mode = mode
+      } else {
+        Object.defineProperty(this, 'mode', {
+          value: mode,
+          enumerable: true,
+          configurable: true,
+          writable: false,
+        })
+      }
+    }
+  }
+}
+
 export interface FetchResponseInit extends ResponseInit {
   url?: string
 }
 
-interface UndiciFetchInternalState {
+interface UndiciResponseState {
   aborted: boolean
   rangeRequested: boolean
   timingAllowPassed: boolean
@@ -54,7 +101,7 @@ export class FetchResponse extends Response {
       return
     }
 
-    const state = getValueBySymbol<UndiciFetchInternalState>('state', response)
+    const state = getValueBySymbol<UndiciResponseState>('state', response)
 
     if (state) {
       // In Undici, push the URL to the internal list of URLs.
@@ -100,7 +147,7 @@ export class FetchResponse extends Response {
        * @note Undici keeps an internal "Symbol(state)" that holds
        * the actual value of response status. Update that in Node.js.
        */
-      const state = getValueBySymbol<UndiciFetchInternalState>('state', this)
+      const state = getValueBySymbol<UndiciResponseState>('state', this)
 
       if (state) {
         state.status = status

--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -9,6 +9,14 @@ interface FetchRequestInit extends Omit<RequestInit, 'mode'> {
 }
 
 export class FetchRequest extends Request {
+  static #resolveProperty<T extends keyof FetchRequestInit & keyof Request>(
+    input: RequestInfo | URL,
+    init: FetchRequestInit = {},
+    key: T
+  ): FetchRequestInit[T] {
+    return init[key] ?? (input instanceof Request ? input[key] : undefined)
+  }
+
   /**
    * Check if the given request method is configurable.
    * @see https://fetch.spec.whatwg.org/#methods
@@ -35,16 +43,18 @@ export class FetchRequest extends Request {
     )
   }
 
-  constructor(input: RequestInfo, init?: FetchRequestInit) {
-    const method = init?.method || 'GET'
+  constructor(input: URL | RequestInfo, init?: FetchRequestInit) {
+    const method = FetchRequest.#resolveProperty(input, init, 'method') || 'GET'
     const safeMethod = FetchRequest.isConfigurableMethod(method)
       ? method
       : 'GET'
     const safeBody = FetchRequest.isMethodWithBody(method)
-      ? init?.body
+      ? FetchRequest.#resolveProperty(input, init, 'body')
       : undefined
 
-    const mode = (init?.mode as RequestMode) ?? undefined
+    const mode =
+      (FetchRequest.#resolveProperty(input, init, 'mode') as RequestMode) ??
+      undefined
     const safeMode = FetchRequest.isConfigurableMode(mode) ? mode : undefined
 
     super(input, {
@@ -53,7 +63,11 @@ export class FetchRequest extends Request {
       mode: safeMode,
       // @ts-expect-error Untyped Node.js property.
       duplex:
-        init?.duplex != null ? init.duplex : safeBody ? 'half' : undefined,
+        init?.duplex != null
+          ? init.duplex
+          : FetchRequest.isMethodWithBody(method)
+            ? 'half'
+            : undefined,
       body: safeBody,
     })
 

--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -48,9 +48,22 @@ export class FetchRequest extends Request {
     const safeMethod = FetchRequest.isConfigurableMethod(method)
       ? method
       : 'GET'
-    const safeBody = FetchRequest.isMethodWithBody(method)
-      ? FetchRequest.#resolveProperty(input, init, 'body')
-      : undefined
+
+    const hasExplicitBody = init != null && 'body' in init
+
+    /**
+     * Only include `body` in the super init when it needs to be overridden.
+     * When `input` is a Request and no explicit body is in `init`, let the
+     * Request constructor handle body transfer naturally so it properly
+     * marks the original request's body as consumed (bodyUsed = true).
+     */
+    const bodyInit: { body?: BodyInit | null } = !FetchRequest.isMethodWithBody(
+      method
+    )
+      ? { body: undefined }
+      : hasExplicitBody
+        ? { body: init.body }
+        : {}
 
     const mode =
       (FetchRequest.#resolveProperty(input, init, 'mode') as RequestMode) ??
@@ -63,12 +76,9 @@ export class FetchRequest extends Request {
       mode: safeMode,
       // @ts-expect-error Untyped Node.js property.
       duplex:
-        init?.duplex != null
-          ? init.duplex
-          : FetchRequest.isMethodWithBody(method)
-            ? 'half'
-            : undefined,
-      body: safeBody,
+        init?.duplex ??
+        (FetchRequest.isMethodWithBody(method) ? 'half' : undefined),
+      ...bodyInit,
     })
 
     if (method !== safeMethod) {

--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -8,8 +8,20 @@ interface FetchRequestInit extends Omit<RequestInit, 'mode'> {
 }
 
 export class FetchRequest extends Request {
+  /**
+   * Check if the given request method is configurable.
+   * @see https://fetch.spec.whatwg.org/#methods
+   */
+  static isConfigurableMethod(method: string): boolean {
+    return method !== 'CONNECT' && method !== 'TRACE' && method !== 'TRACK'
+  }
+
   static isMethodWithBody(method: string): boolean {
-    return method !== 'HEAD' && method !== 'GET'
+    return (
+      method !== 'HEAD' &&
+      method !== 'GET' &&
+      FetchRequest.isConfigurableMethod(method)
+    )
   }
 
   /**
@@ -23,27 +35,44 @@ export class FetchRequest extends Request {
   }
 
   constructor(input: RequestInfo, init?: FetchRequestInit) {
+    const method = init?.method || 'GET'
+    const safeMethod = FetchRequest.isConfigurableMethod(method)
+      ? method
+      : 'GET'
+
     const mode = (init?.mode as RequestMode) ?? undefined
     const safeMode = FetchRequest.isConfigurableMode(mode) ? mode : undefined
 
     super(input, {
       ...(init || {}),
+      method: safeMethod,
       mode: safeMode,
     })
 
-    if (init?.mode != null && init?.mode !== safeMode) {
-      const state = getValueBySymbol<UndiciRequestState>('state', this)
+    if (method !== safeMethod) {
+      this.#setInternalProperty('method', method)
+    }
 
-      if (state) {
-        state.mode = mode
-      } else {
-        Object.defineProperty(this, 'mode', {
-          value: mode,
-          enumerable: true,
-          configurable: true,
-          writable: false,
-        })
-      }
+    if (mode != null && mode !== safeMode) {
+      this.#setInternalProperty('mode', mode)
+    }
+  }
+
+  #setInternalProperty<T extends keyof Request>(
+    key: T,
+    value: Request[T]
+  ): void {
+    const internalState = getValueBySymbol<UndiciRequestState>('state', this)
+
+    if (internalState) {
+      Reflect.set(internalState, key, value)
+    } else {
+      Object.defineProperty(this, key, {
+        value,
+        enumerable: true,
+        configurable: true,
+        writable: false,
+      })
     }
   }
 }


### PR DESCRIPTION
- Related to and used in #770 
- Needed for https://github.com/mswjs/msw/pull/2721 (representing `navigate` requests)

## Motivation

Since we are using Fetch API to represent the network request across the board, we are hitting the limitations of the API for certain requests. For example, there's no way to construct a `CONNECT` request as it's a forbidden method. There's no way to construct a request with a `navigate` as its `mode`. 

> This is yet another of countless examples of how the Fetch API is great for working with request/response instances that someone (e.g. the browser) has already created for you but rather bad for describing same requests/responses yourself. 

The `FetchRequest` subclass of `Request` aims to fill in those gaps. From the developer's perspective, they are interacting with a representation of an intercepted request. Such a representation poses no security risks as it lives in an entirely separate universe from the one those spec limitations operate in. 