### PR TITLE
fix: support detecting prototype-level globals

### DIFF
--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -1,7 +1,5 @@
 import type { RequestController } from './RequestController'
 
-export const IS_PATCHED_MODULE: unique symbol = Symbol('isPatchedModule')
-
 /**
  * @note Export `RequestController` as a type only.
  * It's never meant to be created in the userland.
@@ -16,7 +14,7 @@ export type HttpRequestEventMap = {
       request: Request
       requestId: string
       controller: RequestController
-    }
+    },
   ]
   response: [
     args: {
@@ -24,7 +22,7 @@ export type HttpRequestEventMap = {
       isMockedResponse: boolean
       request: Request
       requestId: string
-    }
+    },
   ]
   unhandledException: [
     args: {
@@ -32,6 +30,6 @@ export type HttpRequestEventMap = {
       request: Request
       requestId: string
       controller: RequestController
-    }
+    },
   ]
 }

--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -18,6 +18,7 @@ import {
 import { bindEvent } from './utils/bindEvent'
 import { hasConfigurableGlobal } from '../../utils/hasConfigurableGlobal'
 import { emitAsync } from '../../utils/emitAsync'
+import { globalsRegistry } from '../../utils/globalsRegistry'
 
 export {
   type WebSocketData,
@@ -80,10 +81,7 @@ export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
   }
 
   protected setup(): void {
-    const originalWebSocketDescriptor = Object.getOwnPropertyDescriptor(
-      globalThis,
-      'WebSocket'
-    )
+    const logger = this.logger.extend('setup')
 
     const WebSocketProxy = new Proxy(globalThis.WebSocket, {
       construct: (
@@ -175,17 +173,12 @@ export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
       },
     })
 
-    Object.defineProperty(globalThis, 'WebSocket', {
-      value: WebSocketProxy,
-      configurable: true,
-    })
+    logger.info('patching global WebSocket...')
 
-    this.subscriptions.push(() => {
-      Object.defineProperty(
-        globalThis,
-        'WebSocket',
-        originalWebSocketDescriptor!
-      )
-    })
+    this.subscriptions.push(
+      globalsRegistry.replaceGlobal('WebSocket', WebSocketProxy)
+    )
+
+    logger.info('global WebSocket patched!', globalThis.WebSocket.name)
   }
 }

--- a/src/interceptors/XMLHttpRequest/index.ts
+++ b/src/interceptors/XMLHttpRequest/index.ts
@@ -1,9 +1,9 @@
-import { invariant } from 'outvariant'
 import { Emitter } from 'strict-event-emitter'
-import { HttpRequestEventMap, IS_PATCHED_MODULE } from '../../glossary'
+import { HttpRequestEventMap } from '../../glossary'
 import { Interceptor } from '../../Interceptor'
 import { createXMLHttpRequestProxy } from './XMLHttpRequestProxy'
 import { hasConfigurableGlobal } from '../../utils/hasConfigurableGlobal'
+import { globalsRegistry } from '../../utils/globalsRegistry'
 
 export type XMLHttpRequestEmitter = Emitter<HttpRequestEventMap>
 
@@ -21,41 +21,21 @@ export class XMLHttpRequestInterceptor extends Interceptor<HttpRequestEventMap> 
   protected setup() {
     const logger = this.logger.extend('setup')
 
-    logger.info('patching "XMLHttpRequest" module...')
+    logger.info('patching global XMLHttpRequest...')
 
-    const PureXMLHttpRequest = globalThis.XMLHttpRequest
-
-    invariant(
-      !(PureXMLHttpRequest as any)[IS_PATCHED_MODULE],
-      'Failed to patch the "XMLHttpRequest" module: already patched.'
+    this.subscriptions.push(
+      globalsRegistry.replaceGlobal(
+        'XMLHttpRequest',
+        createXMLHttpRequestProxy({
+          emitter: this.emitter,
+          logger: this.logger,
+        })
+      )
     )
-
-    globalThis.XMLHttpRequest = createXMLHttpRequestProxy({
-      emitter: this.emitter,
-      logger: this.logger,
-    })
 
     logger.info(
-      'native "XMLHttpRequest" module patched!',
+      'global XMLHttpRequest patched!',
       globalThis.XMLHttpRequest.name
     )
-
-    Object.defineProperty(globalThis.XMLHttpRequest, IS_PATCHED_MODULE, {
-      enumerable: true,
-      configurable: true,
-      value: true,
-    })
-
-    this.subscriptions.push(() => {
-      Object.defineProperty(globalThis.XMLHttpRequest, IS_PATCHED_MODULE, {
-        value: undefined,
-      })
-
-      globalThis.XMLHttpRequest = PureXMLHttpRequest
-      logger.info(
-        'native "XMLHttpRequest" module restored!',
-        globalThis.XMLHttpRequest.name
-      )
-    })
   }
 }

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -1,7 +1,6 @@
-import { invariant } from 'outvariant'
 import { until } from '@open-draft/until'
 import { DeferredPromise } from '@open-draft/deferred-promise'
-import { HttpRequestEventMap, IS_PATCHED_MODULE } from '../../glossary'
+import { HttpRequestEventMap } from '../../glossary'
 import { Interceptor } from '../../Interceptor'
 import { RequestController } from '../../RequestController'
 import { emitAsync } from '../../utils/emitAsync'
@@ -15,6 +14,7 @@ import { hasConfigurableGlobal } from '../../utils/hasConfigurableGlobal'
 import { FetchRequest, FetchResponse } from '../../utils/fetchUtils'
 import { setRawRequest } from '../../getRawRequest'
 import { isResponseError } from '../../utils/responseUtils'
+import { globalsRegistry } from '../../utils/globalsRegistry'
 
 export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
   static symbol = Symbol('fetch')
@@ -28,14 +28,11 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
   }
 
   protected async setup() {
+    const logger = this.logger.extend('setup')
+
     const pureFetch = globalThis.fetch
 
-    invariant(
-      !(pureFetch as any)[IS_PATCHED_MODULE],
-      'Failed to patch the "fetch" module: already patched.'
-    )
-
-    globalThis.fetch = async (input, init) => {
+    const fetchProxy: typeof fetch = async (input, init) => {
       const requestId = createRequestId()
 
       /**
@@ -192,23 +189,10 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
       return responsePromise
     }
 
-    Object.defineProperty(globalThis.fetch, IS_PATCHED_MODULE, {
-      enumerable: true,
-      configurable: true,
-      value: true,
-    })
+    logger.info('patching global fetch...')
 
-    this.subscriptions.push(() => {
-      Object.defineProperty(globalThis.fetch, IS_PATCHED_MODULE, {
-        value: undefined,
-      })
+    this.subscriptions.push(globalsRegistry.replaceGlobal('fetch', fetchProxy))
 
-      globalThis.fetch = pureFetch
-
-      this.logger.info(
-        'restored native "globalThis.fetch"!',
-        globalThis.fetch.name
-      )
-    })
+    logger.info('global fetch patched!', globalThis.fetch.name)
   }
 }

--- a/src/utils/globalUtils.test.ts
+++ b/src/utils/globalUtils.test.ts
@@ -1,0 +1,144 @@
+import { it, beforeEach, afterEach, expect, vi } from 'vitest'
+import { globalsRegistry } from './globalsRegistry'
+
+declare global {
+  var foo: { original: boolean }
+}
+
+const realGlobalPrototype = Object.getPrototypeOf(global)
+
+beforeEach(() => {
+  global.foo = { original: true }
+})
+
+afterEach(() => {
+  Object.setPrototypeOf(global, realGlobalPrototype)
+  globalsRegistry.restoreAllGlobals()
+})
+
+it('replaces the global', () => {
+  globalsRegistry.replaceGlobal('foo', { original: false })
+  expect(global.foo).toEqual({ original: false })
+})
+
+it('replaces the global set on the prototype', () => {
+  function FakeGlobalScope() {}
+  FakeGlobalScope.prototype.foo = { prototype: true }
+  Object.setPrototypeOf(global, FakeGlobalScope.prototype)
+  Reflect.deleteProperty(global, 'foo')
+
+  expect(global.foo).toEqual({ prototype: true })
+  expect(FakeGlobalScope.prototype.foo).toEqual({ prototype: true })
+
+  globalsRegistry.replaceGlobal('foo', { original: false })
+
+  expect(global.foo).toEqual({ original: false })
+  expect(FakeGlobalScope.prototype.foo, 'Preserves prototype value').toEqual({
+    prototype: true,
+  })
+})
+
+it('replaces the global after it was restored', () => {
+  const restoreGlobal = globalsRegistry.replaceGlobal('foo', {
+    original: false,
+  })
+  expect(global.foo).toEqual({ original: false })
+
+  restoreGlobal()
+  expect(global.foo).toEqual({ original: true })
+
+  globalsRegistry.replaceGlobal('foo', { original: false })
+  expect(global.foo).toEqual({ original: false })
+})
+
+it('warns on replacing a non-existing global', () => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  globalsRegistry.replaceGlobal(
+    // @ts-expect-error Intentionally invalid value.
+    'NON-EXISTING',
+    { original: false }
+  )
+  expect(console.warn).toHaveBeenCalledExactlyOnceWith(
+    'Failed to replace a global value at "NON-EXISTING": not a global value.'
+  )
+})
+
+it('throws if replacing an already replaced global', () => {
+  globalsRegistry.replaceGlobal('foo', { original: false })
+  expect(global.foo).toEqual({ original: false })
+
+  expect(() =>
+    globalsRegistry.replaceGlobal('foo', { original: false })
+  ).toThrow('Failed to replace a global value at "foo": already replaced.')
+})
+
+it('does nothing if restoring an already restored global', () => {
+  const restoreGlobal = globalsRegistry.replaceGlobal('foo', {
+    original: false,
+  })
+
+  expect(global.foo).toEqual({ original: false })
+
+  restoreGlobal()
+  expect(global.foo).toEqual({ original: true })
+
+  restoreGlobal()
+  expect(global.foo).toEqual({ original: true })
+})
+
+it('restores the global', () => {
+  const restoreGlobal = globalsRegistry.replaceGlobal('foo', {
+    original: false,
+  })
+  expect(global.foo).toEqual({ original: false })
+
+  restoreGlobal()
+  expect(global.foo).toEqual({ original: true })
+})
+
+it('restores the global set on the prototype', () => {
+  function FakeGlobalScope() {}
+  FakeGlobalScope.prototype.foo = { prototype: true }
+  Object.setPrototypeOf(global, FakeGlobalScope.prototype)
+  Reflect.deleteProperty(global, 'foo')
+
+  expect(global.foo).toEqual({ prototype: true })
+
+  const restoreGlobal = globalsRegistry.replaceGlobal('foo', {
+    original: false,
+  })
+
+  expect(global.foo).toEqual({ original: false })
+
+  restoreGlobal()
+  expect(global.foo).toEqual({ prototype: true })
+})
+
+it('restores global to the original property descriptor', () => {
+  const descriptor: PropertyDescriptor = {
+    value: { original: true },
+    enumerable: false,
+    configurable: true,
+    writable: false,
+  }
+  Object.defineProperty(global, 'foo', descriptor)
+  expect(Object.getOwnPropertyDescriptor(global, 'foo')).toEqual(descriptor)
+
+  const restoreGlobal = globalsRegistry.replaceGlobal('foo', {
+    original: false,
+  })
+
+  expect(global.foo).toEqual({ original: false })
+  expect(Object.getOwnPropertyDescriptor(global, 'foo')).toEqual({
+    value: { original: false },
+    enumerable: true,
+    configurable: true,
+    writable: false,
+  })
+
+  restoreGlobal()
+
+  expect(global.foo).toEqual({ original: true })
+  expect(Object.getOwnPropertyDescriptor(global, 'foo')).toEqual(descriptor)
+})

--- a/src/utils/globalsRegistry.ts
+++ b/src/utils/globalsRegistry.ts
@@ -1,0 +1,107 @@
+import { invariant } from 'outvariant'
+
+class GlobalsRegistry {
+  #globals = new Map<keyof typeof globalThis, () => void>()
+
+  public replaceGlobal<K extends keyof typeof globalThis>(
+    key: K,
+    nextValue: (typeof globalThis)[K]
+  ): () => void {
+    invariant(
+      !this.#globals.has(key),
+      `Failed to replace a global value at "${key}": already replaced.`
+    )
+
+    const match = getDeepPropertyDescriptor(globalThis, key)
+
+    if (typeof match === 'undefined') {
+      console.warn(
+        `Failed to replace a global value at "${key}": not a global value.`
+      )
+      return () => {}
+    }
+
+    Object.defineProperty(globalThis, key, {
+      value: nextValue,
+      enumerable: true,
+      configurable: true,
+    })
+
+    const restoreGlobal = () => {
+      if (!this.#globals.has(key)) {
+        return
+      }
+
+      if (match.owner === globalThis) {
+        Object.defineProperty(match.owner, key, match.descriptor)
+      } else {
+        /**
+         * @todo Delete the proxy property set by the registry.
+         * If the owner isn't `globalThis`, the property is likely nested in the prototype.
+         * The registry does not meddle with those, they are left intact.
+         */
+        Reflect.deleteProperty(globalThis, key)
+      }
+
+      this.#globals.delete(key)
+    }
+
+    this.#globals.set(key, restoreGlobal)
+
+    return restoreGlobal
+  }
+
+  public restoreAllGlobals(): void {
+    const errors: Array<Error> = []
+
+    for (const [, restoreGlobal] of this.#globals) {
+      try {
+        restoreGlobal()
+      } catch (error) {
+        if (error instanceof Error) {
+          errors.push(error)
+        } else {
+          throw error
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new AggregateError(errors, 'FOO!')
+    }
+  }
+}
+
+export const globalsRegistry = new GlobalsRegistry()
+
+interface DeepDescriptorMatch {
+  owner: object
+  descriptor: PropertyDescriptor
+}
+
+/**
+ * Returns a property descriptor for the given property on the owner.
+ * Walks down the prototype chain if the property does not exist on the owner.
+ * Handy for getting a global property descriptor where `globalThis` is
+ * replaced with a controlled class (e.g. ServiceWorkerGlobalScope).
+ */
+export function getDeepPropertyDescriptor<Owner extends object>(
+  owner: Owner,
+  key: keyof Owner
+): DeepDescriptorMatch | undefined {
+  let currentOwner: Owner | null = owner
+  let descriptor: PropertyDescriptor | undefined
+
+  while (currentOwner) {
+    descriptor = Object.getOwnPropertyDescriptor(currentOwner, key)
+
+    if (descriptor) {
+      return {
+        owner: currentOwner,
+        descriptor,
+      }
+    }
+
+    currentOwner = Object.getPrototypeOf(currentOwner)
+  }
+}

--- a/src/utils/hasConfigurableGlobal.test.ts
+++ b/src/utils/hasConfigurableGlobal.test.ts
@@ -1,12 +1,15 @@
 import { vi, beforeAll, afterEach, afterAll, it, expect } from 'vitest'
 import { hasConfigurableGlobal } from './hasConfigurableGlobal'
 
+let originalGlobalPrototype = Object.getPrototypeOf(globalThis)
+
 beforeAll(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {})
 })
 
 afterEach(() => {
   vi.clearAllMocks()
+  Object.setPrototypeOf(globalThis, originalGlobalPrototype)
 })
 
 afterAll(() => {
@@ -80,4 +83,12 @@ it('returns false and prints an error for global property that only has a getter
   expect(console.error).toHaveBeenCalledWith(
     '[MSW] Failed to apply interceptor: the global `_onlyGetter` property is non-configurable. This is likely an issue with your environment. If you are using a framework, please open an issue about this in their repository.'
   )
+})
+
+it('returns true for a property on a global prototype', () => {
+  function FakeGlobalScope() {}
+  FakeGlobalScope.prototype._prototypeGlobal = 123
+  Object.setPrototypeOf(globalThis, FakeGlobalScope.prototype)
+
+  expect(hasConfigurableGlobal('_prototypeGlobal')).toBe(true)
 })

--- a/src/utils/hasConfigurableGlobal.ts
+++ b/src/utils/hasConfigurableGlobal.ts
@@ -2,8 +2,10 @@
  * Returns a boolean indicating whether the given global property
  * is defined and is configurable.
  */
-export function hasConfigurableGlobal(propertyName: string): boolean {
-  const descriptor = Object.getOwnPropertyDescriptor(globalThis, propertyName)
+export function hasConfigurableGlobal(
+  propertyName: keyof typeof globalThis
+): boolean {
+  const descriptor = getDeepPropertyDescriptor(globalThis, propertyName)
 
   // The property is not set at all.
   if (typeof descriptor === 'undefined') {
@@ -31,4 +33,28 @@ export function hasConfigurableGlobal(propertyName: string): boolean {
   }
 
   return true
+}
+
+/**
+ * Returns a property descriptor for the given property on the owner.
+ * Walks down the prototype chain if the property does not exist on the owner.
+ * Handy for getting a global property descriptor where `globalThis` is
+ * replaced with a controlled class (e.g. ServiceWorkerGlobalScope).
+ */
+function getDeepPropertyDescriptor<Owner extends object>(
+  owner: Owner,
+  key: keyof Owner
+): PropertyDescriptor | undefined {
+  let currentOwner: Owner | null = owner
+  let descriptor: PropertyDescriptor | undefined
+
+  while (currentOwner) {
+    descriptor = Object.getOwnPropertyDescriptor(currentOwner, key)
+
+    if (descriptor) {
+      return descriptor
+    }
+
+    currentOwner = Object.getPrototypeOf(currentOwner)
+  }
 }

--- a/src/utils/hasConfigurableGlobal.ts
+++ b/src/utils/hasConfigurableGlobal.ts
@@ -1,3 +1,5 @@
+import { getDeepPropertyDescriptor } from './globalsRegistry'
+
 /**
  * Returns a boolean indicating whether the given global property
  * is defined and is configurable.
@@ -5,12 +7,14 @@
 export function hasConfigurableGlobal(
   propertyName: keyof typeof globalThis
 ): boolean {
-  const descriptor = getDeepPropertyDescriptor(globalThis, propertyName)
+  const match = getDeepPropertyDescriptor(globalThis, propertyName)
 
   // The property is not set at all.
-  if (typeof descriptor === 'undefined') {
+  if (typeof match === 'undefined') {
     return false
   }
+
+  const { descriptor } = match
 
   // The property is set to a getter that returns undefined.
   if (
@@ -33,28 +37,4 @@ export function hasConfigurableGlobal(
   }
 
   return true
-}
-
-/**
- * Returns a property descriptor for the given property on the owner.
- * Walks down the prototype chain if the property does not exist on the owner.
- * Handy for getting a global property descriptor where `globalThis` is
- * replaced with a controlled class (e.g. ServiceWorkerGlobalScope).
- */
-function getDeepPropertyDescriptor<Owner extends object>(
-  owner: Owner,
-  key: keyof Owner
-): PropertyDescriptor | undefined {
-  let currentOwner: Owner | null = owner
-  let descriptor: PropertyDescriptor | undefined
-
-  while (currentOwner) {
-    descriptor = Object.getOwnPropertyDescriptor(currentOwner, key)
-
-    if (descriptor) {
-      return descriptor
-    }
-
-    currentOwner = Object.getPrototypeOf(currentOwner)
-  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "removeComments": false,
     "esModuleInterop": true,
     "downlevelIteration": true,
-    "lib": ["dom", "dom.iterable", "ES2018.AsyncGenerator"],
+    "lib": ["dom", "dom.iterable", "ES2018.AsyncGenerator", "es2021"],
     "types": ["@types/node"],
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Motivation

Right now, the `hasConfigurableGlobal` check only checks property descriptors on `global`. There are cases when global property arrives via the prototype chain, e.g. in Cloudflare's workerd environment `global` is a `ServiceWorkerGlobalScope`. 

```ts
global.WebSocket // WebSocket
Object.getOwnPropertyDescriptor(global, 'WebSocket') // undefined
Object.getOwnPropertyDescriptor(globalThis.constructor.prototype, 'WebSocket') // { ... }
```

## Changes

- Supports prototype-level globals in `hasConfigurableGlobal` checks.
- Introduces a `GlobalsRegistry` singleton to manage globals patches correctly and consistently across all interceptors.
- Removes the internal `IS_PATCHED_MODULE` since it's replaced by `GlobalsRegistry`.