### PR TITLE
fix(fetch): clone responses safely

### DIFF
--- a/src/RemoteHttpInterceptor.ts
+++ b/src/RemoteHttpInterceptor.ts
@@ -189,7 +189,7 @@ export class RemoteHttpResolver extends Interceptor<HttpRequestEventMap> {
 
           this.logger.info('received mocked response!', { response })
 
-          const responseClone = response.clone()
+          const responseClone = FetchResponse.clone(response)
           const responseText = await responseClone.text()
 
           // // Send the mocked response to the child process.

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -85,7 +85,7 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
           if (this.emitter.listenerCount('response') > 0) {
             this.logger.info('emitting the "response" event...')
 
-            const responseClone = originalResponse.clone()
+            const responseClone = FetchResponse.clone(originalResponse)
             await emitAsync(this.emitter, 'response', {
               response: responseClone,
               isMockedResponse: false,
@@ -156,7 +156,7 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
               // Clone the mocked response for the "response" event listener.
               // This way, the listener can read the response and not lock its body
               // for the actual fetch consumer.
-              response: response.clone(),
+              response: FetchResponse.clone(response),
               isMockedResponse: true,
               request,
               requestId,

--- a/src/utils/fetchUtils.test.ts
+++ b/src/utils/fetchUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { FetchRequest } from './fetchUtils'
+import { FetchRequest, FetchResponse } from './fetchUtils'
 
 describe('FetchRequest', () => {
   const URL = 'https://example.com/'
@@ -81,5 +81,29 @@ describe('FetchRequest', () => {
     expect
       .soft(new FetchRequest(URL, { method: 'POST', body: 'hello' }))
       .toHaveProperty('body', expect.any(ReadableStream))
+  })
+})
+
+describe('FetchResponse', () => {
+  it('clones a regular response', () => {
+    const response = new Response('hello world')
+    expect(FetchResponse.clone(response)).toMatchObject(response)
+  })
+
+  it('returns a mocked 500 response if cloning throws', async () => {
+    const response = new Response('hello world')
+    const error = new Error('Cannot clone!')
+    response.clone = function () {
+      throw error
+    }
+
+    const clone = FetchResponse.clone(response)
+    expect.soft(clone.status).toBe(500)
+    expect.soft(clone.statusText).toBe('Unclonable Response')
+    await expect.soft(clone.json()).resolves.toEqual({
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    })
   })
 })

--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -218,6 +218,34 @@ export class FetchResponse extends Response {
     return headers
   }
 
+  /**
+   * Safely clones the given `Response`.
+   * Coerces response clone exceptions into 500 mocked responses.
+   * Handy in the environments that introduce arbitrary response
+   * cloning restrictions, like "101 Switching Protocols" cloning
+   * in "miniflare".
+   */
+  static clone(response: Response): Response {
+    try {
+      const clone = response.clone()
+      return clone
+    } catch (error) {
+      return Response.json(
+        error instanceof Error
+          ? {
+              name: error.name,
+              message: error.message,
+              stack: error.stack,
+            }
+          : {},
+        {
+          status: 500,
+          statusText: 'Unclonable Response',
+        }
+      )
+    }
+  }
+
   constructor(body?: BodyInit | null, init: FetchResponseInit = {}) {
     const status = init.status ?? 200
     const safeStatus = FetchResponse.isConfigurableStatusCode(status)

--- a/test/features/events/response.test.ts
+++ b/test/features/events/response.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 import { vi, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
 import https from 'node:https'
-import waitForExpect from 'wait-for-expect'
 import { HttpServer } from '@open-draft/test-server/http'
 import { DeferredPromise } from '@open-draft/deferred-promise'
 import { HttpRequestEventMap } from '../../../src'
@@ -100,7 +99,7 @@ it('ClientRequest: emits the "response" event for a mocked response', async () =
   expect(res.statusCode).toBe(200)
   expect(res.statusMessage).toBe('OK')
 
-  expect(responseListener).toHaveBeenCalledTimes(1)
+  expect(responseListener).toHaveBeenCalledOnce()
 
   const [{ response, request, isMockedResponse }] =
     responseListener.mock.calls[0]
@@ -135,7 +134,7 @@ it('ClientRequest: emits the "response" event upon the original response', async
   req.end()
   await waitForClientRequest(req)
 
-  expect(responseListener).toHaveBeenCalledTimes(1)
+  expect(responseListener).toHaveBeenCalledOnce()
 
   const [{ response, request, isMockedResponse }] =
     responseListener.mock.calls[0]
@@ -166,7 +165,7 @@ it('XMLHttpRequest: emits the "response" event upon a mocked response', async ()
     req.send()
   })
 
-  expect(responseListener).toHaveBeenCalledTimes(1)
+  expect(responseListener).toHaveBeenCalledOnce()
 
   const [{ response, request, isMockedResponse }] =
     responseListener.mock.calls.find(([{ request }]) => {
@@ -323,9 +322,7 @@ it('supports reading the request and response bodies in the "response" listener'
     body: 'request-body',
   })
 
-  await waitForExpect(() => {
-    expect(responseListener).toHaveBeenCalledTimes(1)
-  })
+  await expect.poll(() => responseListener).toHaveBeenCalledOnce()
 
   expect(requestCallback).toHaveBeenCalledWith('request-body')
   expect(responseCallback).toHaveBeenCalledWith('mocked-response-text')


### PR DESCRIPTION
## Motivation

Some environments, like Miniflare, patch the `Response` prototype and introduce arbitrary restrictions for response cloning, like throwing on cloning attempts of responses that contain `this[kWebSocket]`. 

Those restrictions result in hard exceptions during the request interception (e.g. when cloning the response instance for logging purposes).

## Changes

- Implement `FetchResponse.clone()`, which attempts to clone a response, returns a successful clone, or returns a mocked 500 response with the clone error details if cloning fails.
- Use `FetchResponse.clone()` everywhere a fetch API response is being cloned. 