### PR TITLE
fix(FetchResponse): preserve custom `status` and `url` after cloning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node: [20, 22]
+        node: [20, 22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node: [20, 22, 24]
+        node: [22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -112,12 +112,15 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
 
           // Decompress the mocked response body, if applicable.
           const decompressedStream = decompressResponse(rawResponse)
-          const response =
-            decompressedStream === null
-              ? rawResponse
-              : new FetchResponse(decompressedStream, rawResponse)
-
-          FetchResponse.setUrl(request.url, response)
+          const response = new FetchResponse(
+            decompressedStream || rawResponse.body,
+            {
+              url: request.url,
+              status: rawResponse.status,
+              statusText: rawResponse.statusText,
+              headers: rawResponse.headers,
+            }
+          )
 
           /**
            * Undici's handling of following redirect responses.

--- a/src/utils/fetchUtils.test.ts
+++ b/src/utils/fetchUtils.test.ts
@@ -109,23 +109,23 @@ describe('FetchResponse', () => {
 
   it('sets the response URL', () => {
     const response = new Response('hello world')
-    FetchResponse.setUrl('https://example.com', response)
+    FetchResponse.setUrl('https://example.com/', response)
 
-    expect(response.url).toBe('https://example.com')
+    expect(response.url).toBe('https://example.com/')
   })
 
   it('preserves a custom response URL after cloning Response', () => {
     const response = new FetchResponse('hello world')
-    FetchResponse.setUrl('https://example.com', response)
+    FetchResponse.setUrl('https://example.com/', response)
 
-    expect(response.clone().url).toBe('https://example.com')
+    expect(response.clone().url).toBe('https://example.com/')
   })
 
   it('preserves a custom response URL after cloning FetchResponse', () => {
     const response = new FetchResponse('hello world', {
-      url: 'https://example.com',
+      url: 'https://example.com/',
     })
 
-    expect(response.clone().url).toBe('https://example.com')
+    expect(response.clone().url).toBe('https://example.com/')
   })
 })

--- a/src/utils/fetchUtils.test.ts
+++ b/src/utils/fetchUtils.test.ts
@@ -106,4 +106,26 @@ describe('FetchResponse', () => {
       stack: error.stack,
     })
   })
+
+  it('sets the response URL', () => {
+    const response = new Response('hello world')
+    FetchResponse.setUrl('https://example.com', response)
+
+    expect(response.url).toBe('https://example.com')
+  })
+
+  it('preserves a custom response URL after cloning Response', () => {
+    const response = new FetchResponse('hello world')
+    FetchResponse.setUrl('https://example.com', response)
+
+    expect(response.clone().url).toBe('https://example.com')
+  })
+
+  it('preserves a custom response URL after cloning FetchResponse', () => {
+    const response = new FetchResponse('hello world', {
+      url: 'https://example.com',
+    })
+
+    expect(response.clone().url).toBe('https://example.com')
+  })
 })

--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -160,6 +160,9 @@ interface UndiciResponseState {
   }
 }
 
+const kStatus = Symbol('kStatus')
+const kUrl = Symbol('kUrl')
+
 export class FetchResponse extends Response {
   /**
    * Response status codes for responses that cannot have body.
@@ -185,6 +188,33 @@ export class FetchResponse extends Response {
     return !FetchResponse.STATUS_CODES_WITHOUT_BODY.includes(status)
   }
 
+  static setStatus(status: number, response: Response): void {
+    /**
+     * @note Undici keeps an internal "Symbol(state)" that holds
+     * the actual value of response status. Update that in Node.js.
+     */
+    const internalState = getValueBySymbol<UndiciResponseState>(
+      'state',
+      response
+    )
+
+    if (internalState) {
+      internalState.status = status
+    } else {
+      Object.defineProperty(response, 'status', {
+        value: status,
+        enumerable: true,
+        configurable: true,
+        writable: false,
+      })
+    }
+
+    Object.defineProperty(response, kStatus, {
+      value: status,
+      enumerable: false,
+    })
+  }
+
   static setUrl(url: string | undefined, response: Response): void {
     if (!url || url === 'about:' || !canParseUrl(url)) {
       return
@@ -205,6 +235,11 @@ export class FetchResponse extends Response {
         writable: false,
       })
     }
+
+    Object.defineProperty(response, kUrl, {
+      value: url,
+      enumerable: false,
+    })
   }
 
   /**
@@ -212,9 +247,11 @@ export class FetchResponse extends Response {
    */
   static parseRawHeaders(rawHeaders: Array<string>): Headers {
     const headers = new Headers()
+
     for (let line = 0; line < rawHeaders.length; line += 2) {
       headers.append(rawHeaders[line], rawHeaders[line + 1])
     }
+
     return headers
   }
 
@@ -259,25 +296,33 @@ export class FetchResponse extends Response {
       headers: init.headers,
     })
 
+    /**
+     * Since Node.js v24, Undici stores the Response state in an inaccessible field "#state".
+     * Forward the modified status/URL to the cloned response manually.
+     * @see https://github.com/nodejs/undici/blob/f734c87280e626c75f59aad55b65eb6a89cef392/lib/web/fetch/response.js#L242
+     */
     if (status !== safeStatus) {
-      /**
-       * @note Undici keeps an internal "Symbol(state)" that holds
-       * the actual value of response status. Update that in Node.js.
-       */
-      const state = getValueBySymbol<UndiciResponseState>('state', this)
-
-      if (state) {
-        state.status = status
-      } else {
-        Object.defineProperty(this, 'status', {
-          value: status,
-          enumerable: true,
-          configurable: true,
-          writable: false,
-        })
-      }
+      FetchResponse.setStatus(status, this)
     }
 
     FetchResponse.setUrl(init.url, this)
+  }
+
+  public clone() {
+    const clonedResponse = super.clone()
+
+    const customStatus = Reflect.get(this, kStatus) as number | undefined
+
+    if (customStatus) {
+      FetchResponse.setStatus(customStatus, clonedResponse)
+    }
+
+    const customUrl = Reflect.get(this, kUrl) as string | undefined
+
+    if (customUrl) {
+      FetchResponse.setUrl(customUrl, clonedResponse)
+    }
+
+    return clonedResponse
   }
 }


### PR DESCRIPTION
- Related to https://github.com/mswjs/msw/pull/2729
- Extracted from #770