### PR TITLE
fix(fetch): detach abort listener from request.signal after settle

### DIFF
--- a/src/utils/handleRequest.ts
+++ b/src/utils/handleRequest.ts
@@ -90,6 +90,9 @@ export async function handleRequest(
   // })
 
   const requestAbortPromise = new DeferredPromise<void, unknown>()
+  const onAbort = () => {
+    requestAbortPromise.reject(options.request.signal?.reason)
+  }
 
   /**
    * @note `signal` is not always defined in React Native.
@@ -100,106 +103,104 @@ export async function handleRequest(
       return
     }
 
-    options.request.signal.addEventListener(
-      'abort',
-      () => {
-        requestAbortPromise.reject(options.request.signal.reason)
-      },
-      { once: true }
-    )
+    options.request.signal.addEventListener('abort', onAbort, { once: true })
   }
 
-  const result = await until(async () => {
-    // Emit the "request" event and wait until all the listeners
-    // for that event are finished (e.g. async listeners awaited).
-    // By the end of this promise, the developer cannot affect the
-    // request anymore.
-    const requestListenersPromise = emitAsync(options.emitter, 'request', {
-      requestId: options.requestId,
-      request: options.request,
-      controller: options.controller,
+  try {
+    const result = await until(async () => {
+      // Emit the "request" event and wait until all the listeners
+      // for that event are finished (e.g. async listeners awaited).
+      // By the end of this promise, the developer cannot affect the
+      // request anymore.
+      const requestListenersPromise = emitAsync(options.emitter, 'request', {
+        requestId: options.requestId,
+        request: options.request,
+        controller: options.controller,
+      })
+
+      await Promise.race([
+        // Short-circuit the request handling promise if the request gets aborted.
+        requestAbortPromise,
+        requestListenersPromise,
+        options.controller.handled,
+      ])
     })
 
-    await Promise.race([
-      // Short-circuit the request handling promise if the request gets aborted.
-      requestAbortPromise,
-      requestListenersPromise,
-      options.controller.handled,
-    ])
-  })
-
-  // Handle the request being aborted while waiting for the request listeners.
-  if (requestAbortPromise.state === 'rejected') {
-    await options.controller.errorWith(requestAbortPromise.rejectionReason)
-    return
-  }
-
-  if (result.error) {
-    // Handle the error during the request listener execution.
-    // These can be thrown responses or request errors.
-    if (await handleResponseError(result.error)) {
+    // Handle the request being aborted while waiting for the request listeners.
+    if (requestAbortPromise.state === 'rejected') {
+      await options.controller.errorWith(requestAbortPromise.rejectionReason)
       return
     }
 
-    // If the developer has added "unhandledException" listeners,
-    // allow them to handle the error. They can translate it to a
-    // mocked response, network error, or forward it as-is.
-    if (options.emitter.listenerCount('unhandledException') > 0) {
-      // Create a new request controller just for the unhandled exception case.
-      // This is needed because the original controller might have been already
-      // interacted with (e.g. "respondWith" or "errorWith" called on it).
-      const unhandledExceptionController = new RequestController(
-        options.request,
-        {
-          /**
-           * @note Intentionally empty passthrough handle.
-           * This controller is created within another controller and we only need
-           * to know if `unhandledException` listeners handled the request.
-           */
-          passthrough() {},
-          async respondWith(response) {
-            await handleResponse(response)
-          },
-          async errorWith(reason) {
-            /**
-             * @note Handle the result of the unhandled controller
-             * in the same way as the original request controller.
-             * The exception here is that thrown errors within the
-             * "unhandledException" event do NOT result in another
-             * emit of the same event. They are forwarded as-is.
-             */
-            await options.controller.errorWith(reason)
-          },
-        }
-      )
-
-      await emitAsync(options.emitter, 'unhandledException', {
-        error: result.error,
-        request: options.request,
-        requestId: options.requestId,
-        controller: unhandledExceptionController,
-      })
-
-      // If all the "unhandledException" listeners have finished
-      // but have not handled the request in any way, passthrough.
-      if (
-        unhandledExceptionController.readyState !== RequestController.PENDING
-      ) {
+    if (result.error) {
+      // Handle the error during the request listener execution.
+      // These can be thrown responses or request errors.
+      if (await handleResponseError(result.error)) {
         return
       }
+
+      // If the developer has added "unhandledException" listeners,
+      // allow them to handle the error. They can translate it to a
+      // mocked response, network error, or forward it as-is.
+      if (options.emitter.listenerCount('unhandledException') > 0) {
+        // Create a new request controller just for the unhandled exception case.
+        // This is needed because the original controller might have been already
+        // interacted with (e.g. "respondWith" or "errorWith" called on it).
+        const unhandledExceptionController = new RequestController(
+          options.request,
+          {
+            /**
+             * @note Intentionally empty passthrough handle.
+             * This controller is created within another controller and we only need
+             * to know if `unhandledException` listeners handled the request.
+             */
+            passthrough() {},
+            async respondWith(response) {
+              await handleResponse(response)
+            },
+            async errorWith(reason) {
+              /**
+               * @note Handle the result of the unhandled controller
+               * in the same way as the original request controller.
+               * The exception here is that thrown errors within the
+               * "unhandledException" event do NOT result in another
+               * emit of the same event. They are forwarded as-is.
+               */
+              await options.controller.errorWith(reason)
+            },
+          }
+        )
+
+        await emitAsync(options.emitter, 'unhandledException', {
+          error: result.error,
+          request: options.request,
+          requestId: options.requestId,
+          controller: unhandledExceptionController,
+        })
+
+        // If all the "unhandledException" listeners have finished
+        // but have not handled the request in any way, passthrough.
+        if (
+          unhandledExceptionController.readyState !== RequestController.PENDING
+        ) {
+          return
+        }
+      }
+
+      // Otherwise, coerce unhandled exceptions to a 500 Internal Server Error response.
+      await options.controller.respondWith(
+        createServerErrorResponse(result.error)
+      )
+      return
     }
 
-    // Otherwise, coerce unhandled exceptions to a 500 Internal Server Error response.
-    await options.controller.respondWith(
-      createServerErrorResponse(result.error)
-    )
-    return
-  }
+    // If the request hasn't been handled by this point, passthrough.
+    if (options.controller.readyState === RequestController.PENDING) {
+      return await options.controller.passthrough()
+    }
 
-  // If the request hasn't been handled by this point, passthrough.
-  if (options.controller.readyState === RequestController.PENDING) {
-    return await options.controller.passthrough()
+    return options.controller.handled
+  } finally {
+    options.request.signal?.removeEventListener('abort', onAbort)
   }
-
-  return options.controller.handled
 }

--- a/test/modules/fetch/fetch-memory-worker.js
+++ b/test/modules/fetch/fetch-memory-worker.js
@@ -1,0 +1,43 @@
+const v8 = require('node:v8')
+const vm = require('node:vm')
+const { workerData, parentPort } = require('node:worker_threads')
+const {
+  FetchInterceptor,
+} = require('../../../lib/node/interceptors/fetch/index.cjs')
+
+// Workers don't accept --expose-gc via execArgv; toggle the flag at runtime.
+v8.setFlagsFromString('--expose_gc')
+const gc = vm.runInNewContext('gc')
+
+const interceptor = new FetchInterceptor()
+interceptor.apply()
+
+// No listeners attached — this is the regression surface.
+;(async () => {
+  const concurrency = 20
+  let done = 0
+  async function workerLoop() {
+    while (done < workerData.requestCount) {
+      const i = done++
+      if (i >= workerData.requestCount) break
+      const response = await fetch(`${workerData.serverUrl}?i=${i}`)
+      await response.text()
+    }
+  }
+  await Promise.all(Array.from({ length: concurrency }, () => workerLoop()))
+
+  // Interleave GCs with setImmediate so FinalizationRegistry callbacks
+  // (which run on the next microtask tick) get a chance to release native
+  // handles before we snapshot.
+  const tick = () => new Promise((r) => setImmediate(r))
+  for (let i = 0; i < 5; i++) {
+    gc()
+    await tick()
+  }
+
+  v8.writeHeapSnapshot(workerData.snapshotPath)
+
+  parentPort.postMessage('complete')
+})().catch((error) => {
+  parentPort.postMessage({ error: error?.message ?? String(error) })
+})

--- a/test/modules/fetch/fetch-memory.test.ts
+++ b/test/modules/fetch/fetch-memory.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+import fs from 'node:fs'
+import path from 'node:path'
+import { Worker } from 'node:worker_threads'
+import { HttpServer } from '@open-draft/test-server/http'
+import { it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { DeferredPromise } from '@open-draft/deferred-promise'
+import { FetchInterceptor } from '../../../src/interceptors/fetch'
+
+const server = new HttpServer((app) => {
+  app.get('/', (_req, res) => res.status(200).end())
+})
+
+const interceptor = new FetchInterceptor()
+
+beforeAll(async () => {
+  await server.listen()
+  interceptor.apply()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+  await server.close()
+})
+
+it('detaches the abort listener from request.signal after the request resolves', async () => {
+  // Under sustained traffic, undici-side state can transitively keep the
+  // request's AbortSignal reachable after fetch returns. If the abort
+  // listener is left attached, its closure pins per-request scope and
+  // eventually compounds into hundreds of MB of native memory growth.
+  // See https://github.com/PatrikBird/mswjs-interceptors-leak-repro
+  // Capture the abort listener that handleRequest attaches and verify it is
+  // detached again before the request resolves. We can't assert "all abort
+  // listeners on the signal are removed" because undici attaches its own
+  // listeners that it manages independently.
+  const addedAbortListeners = new Set<EventListenerOrEventListenerObject>()
+  const removedAbortListeners = new Set<EventListenerOrEventListenerObject>()
+  const originalAdd = AbortSignal.prototype.addEventListener
+  const originalRemove = AbortSignal.prototype.removeEventListener
+  AbortSignal.prototype.addEventListener = function (type, listener, opts) {
+    if (type === 'abort' && listener) addedAbortListeners.add(listener)
+    return originalAdd.call(this, type, listener, opts)
+  }
+  AbortSignal.prototype.removeEventListener = function (type, listener, opts) {
+    if (type === 'abort' && listener) removedAbortListeners.add(listener)
+    return originalRemove.call(this, type, listener, opts)
+  }
+
+  try {
+    const response = await fetch(server.http.url('/'))
+    await response.text()
+
+    expect(addedAbortListeners.size).toBeGreaterThan(0)
+    // At least one of the abort listeners that was added during the request
+    // must also have been removed — the interceptor's own listener.
+    const detached = [...addedAbortListeners].filter((l) =>
+      removedAbortListeners.has(l)
+    )
+    expect(detached.length).toBeGreaterThan(0)
+  } finally {
+    AbortSignal.prototype.addEventListener = originalAdd
+    AbortSignal.prototype.removeEventListener = originalRemove
+  }
+})
+
+it(
+  'does not retain Request instances after passthrough without listeners',
+  async () => {
+    const snapshotPath = path.resolve(__dirname, 'fetch-memory.heapsnapshot')
+
+    const worker = new Worker(
+      path.resolve(__dirname, './fetch-memory-worker.js'),
+      {
+        workerData: {
+          requestCount: 5_000,
+          serverUrl: server.http.url('/'),
+          snapshotPath,
+        },
+        stderr: true,
+        stdout: true,
+      }
+    )
+
+    const completePromise = new DeferredPromise<void>()
+    worker.once('message', () => completePromise.resolve())
+    worker.on('error', (error) => completePromise.reject(error))
+
+    await completePromise
+
+    // Scan the heap snapshot for retained Request / FetchRequest instances.
+    const snap = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'))
+    const types = snap.snapshot.meta.node_types[0]
+    const fields = snap.snapshot.meta.node_fields
+    const FC = fields.length
+    const TYPE_IDX = fields.indexOf('type')
+    const NAME_IDX = fields.indexOf('name')
+    const nodes = snap.nodes
+    const strings = snap.strings
+
+    let requestLikeCount = 0
+    for (let n = 0; n < nodes.length / FC; n++) {
+      const type = types[nodes[n * FC + TYPE_IDX]]
+      const name = strings[nodes[n * FC + NAME_IDX]] ?? ''
+      if (
+        type === 'object' &&
+        (name === 'Request' || name === 'FetchRequest')
+      ) {
+        requestLikeCount++
+      }
+    }
+
+    fs.rmSync(snapshotPath, { force: true })
+
+    // After 5,000 fetches with no listeners, only a small number of in-flight
+    // / FinalizationRegistry-pending Request instances should remain. The
+    // regression retains thousands.
+    expect(requestLikeCount).toBeLessThan(100)
+  },
+  { timeout: 30_000 }
+)


### PR DESCRIPTION
> [!NOTE]
> This PR was drafted with the help of an AI assistant. The fix, tests, and numbers have been verified locally before opening.

Closes #783.

## Problem

`FetchInterceptor` (and any interceptor sharing `handleRequest`) leaks **native** memory under sustained traffic. JS heap snapshots stay clean, but RSS climbs hundreds of MB because undici-side state (sockets, zlib contexts, response buffers) is transitively pinned. The leak is amplified by `redirect: 'follow'` traffic and was the cause of unbounded RSS growth on a Nuxt 4 SSR server using `@artmizu/nuxt-prometheus`.

## Root cause

`handleRequest` attaches an `'abort'` listener to `request.signal` with `{ once: true }`, so the listener self-removes only when an abort fires. For requests that complete normally — the overwhelming majority — the listener stays attached forever.

Undici keeps internal references to a `Request` after `fetch` returns (keepalive socket metadata, etc.), keeping its `AbortSignal` reachable. The still-attached listener pins its closure (`requestAbortPromise` and the surrounding scope), which transitively pins per-request undici state.

The same listener pattern exists in `0.36.10`, which is why it also leaks (just less amplified — the closure captured a smaller scope before the `0.40.0` rewrite to `RequestController`-with-callbacks).

## Fix

Wrap the body of `handleRequest` in `try { ... } finally { ... }` and detach the abort listener in `finally`. Also `await controller.handled` before the trailing return so the `finally` block runs after the request is fully resolved (rather than synchronously, which would detach the listener while the fetch was still in flight).

## Numbers

Reproduction at 50,000 requests, `redirect: 'follow'`, concurrency 20, post-pumped-GC, on Node 24:

| Run                          | RSS Δ      | over baseline |
| ---------------------------- | ---------- | ------------- |
| baseline (no interceptor)    | 227 MB     | —             |
| 0.36.10                      | 408 MB     | +181 MB       |
| **0.41.8 unpatched**         | **684 MB** | **+457 MB**   |
| **0.41.8 patched (this PR)** | **239 MB** | **+12 MB**    |

\~97 % reduction; patched 0.41.8 is also cleaner than 0.36.10.

Repro: <https://github.com/PatrikBird/mswjs-interceptors-leak-repro>

## Tests

`test/modules/fetch/fetch-memory.test.ts` adds two tests:

1. **Behavioral, deterministic** — spies on `AbortSignal.prototype.{add,remove}EventListener` and verifies that the abort listener attached during a fetch is also detached before the fetch resolves.
2. **Worker-isolated heap snapshot** — spawns a worker that runs 5,000 fetches with no listeners, forces pumped GC, writes a heap snapshot, and asserts retained `Request` / `FetchRequest` instances < 100. Mirrors the pattern from the existing (separate) `MockHttpSocket` memory test.

All 76 fetch integration tests pass. Broader integration suite passes apart from `test/modules/http/compliance/http-errors.test.ts > forwards EHOSTUNREACH error for a bypassed request`, which was already failing on `main` before this PR (network-dependent, unrelated).

## Compatibility

No public API change. Behavior is identical except that the abort listener is detached when the request settles instead of remaining attached until GC. Aborts that arrive after the request settles were already no-ops because `requestAbortPromise` is no longer awaited at that point.
