### PR TITLE
fix(ClientRequest): forward abort signal to intercepted request

### DIFF
--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -41,6 +41,7 @@ interface MockHttpSocketOptions {
   createConnection: () => net.Socket
   onRequest: MockHttpSocketRequestCallback
   onResponse: MockHttpSocketResponseCallback
+  signal?: AbortSignal
 }
 
 export const kRequestId = Symbol('kRequestId')
@@ -52,6 +53,7 @@ export class MockHttpSocket extends MockSocket {
 
   private onRequest: MockHttpSocketRequestCallback
   private onResponse: MockHttpSocketResponseCallback
+  private signal?: AbortSignal
   private responseListenersPromise?: Promise<void>
 
   private requestRawHeadersBuffer: Array<string> = []
@@ -110,6 +112,7 @@ export class MockHttpSocket extends MockSocket {
     this.createConnection = options.createConnection
     this.onRequest = options.onRequest
     this.onResponse = options.onResponse
+    this.signal = options.signal
 
     this.baseUrl = baseUrlFromConnectionOptions(this.connectionOptions)
 
@@ -580,7 +583,7 @@ export class MockHttpSocket extends MockSocket {
       method,
       headers,
       credentials: 'same-origin',
-      // @ts-expect-error Undocumented Fetch property.
+      signal: this.signal,
       duplex: canHaveBody ? 'half' : undefined,
       body: canHaveBody ? (Readable.toWeb(this.requestStream!) as any) : null,
     })

--- a/src/interceptors/ClientRequest/agents.ts
+++ b/src/interceptors/ClientRequest/agents.ts
@@ -25,18 +25,21 @@ interface MockAgentOptions {
   customAgent?: http.RequestOptions['agent']
   onRequest: MockHttpSocketRequestCallback
   onResponse: MockHttpSocketResponseCallback
+  signal?: AbortSignal
 }
 
 export class MockAgent extends http.Agent {
   private customAgent?: http.RequestOptions['agent']
   private onRequest: MockHttpSocketRequestCallback
   private onResponse: MockHttpSocketResponseCallback
+  private signal?: AbortSignal
 
   constructor(options: MockAgentOptions) {
     super()
     this.customAgent = options.customAgent
     this.onRequest = options.onRequest
     this.onResponse = options.onResponse
+    this.signal = options.signal
   }
 
   public createConnection(options: any, callback: any): net.Socket {
@@ -62,6 +65,7 @@ export class MockAgent extends http.Agent {
       ),
       onRequest: this.onRequest.bind(this),
       onResponse: this.onResponse.bind(this),
+      signal: this.signal,
     })
 
     return socket
@@ -72,12 +76,14 @@ export class MockHttpsAgent extends https.Agent {
   private customAgent?: https.RequestOptions['agent']
   private onRequest: MockHttpSocketRequestCallback
   private onResponse: MockHttpSocketResponseCallback
+  private signal?: AbortSignal
 
   constructor(options: MockAgentOptions) {
     super()
     this.customAgent = options.customAgent
     this.onRequest = options.onRequest
     this.onResponse = options.onResponse
+    this.signal = options.signal
   }
 
   public createConnection(options: any, callback: any): net.Socket {
@@ -103,6 +109,7 @@ export class MockHttpsAgent extends https.Agent {
       ),
       onRequest: this.onRequest.bind(this),
       onResponse: this.onResponse.bind(this),
+      signal: this.signal,
     })
 
     return socket

--- a/src/interceptors/ClientRequest/index.test.ts
+++ b/src/interceptors/ClientRequest/index.test.ts
@@ -54,6 +54,31 @@ it('abort the request if the abort signal is emitted', async () => {
   expect(request.destroyed).toBe(true)
 })
 
+it('forwards the abort signal to the intercepted request', async () => {
+  const requestUrl = httpServer.http.url('/')
+  const abortController = new AbortController()
+  const requestListenerPromise = new DeferredPromise<void>()
+  const signalAbortPromise = new DeferredPromise<unknown>()
+
+  interceptor.on('request', ({ request, controller }) => {
+    request.signal.addEventListener(
+      'abort',
+      () => signalAbortPromise.resolve(request.signal.reason),
+      { once: true }
+    )
+    requestListenerPromise.resolve()
+    controller.passthrough()
+  })
+
+  const request = http.get(requestUrl, { signal: abortController.signal })
+  request.on('error', () => {})
+  await requestListenerPromise
+
+  abortController.abort('abort reason')
+
+  await expect(signalAbortPromise).resolves.toBe('abort reason')
+})
+
 it('patch the Headers object correctly after dispose and reapply', async () => {
   interceptor.dispose()
   interceptor.apply()

--- a/src/interceptors/ClientRequest/index.ts
+++ b/src/interceptors/ClientRequest/index.ts
@@ -49,6 +49,7 @@ export class ClientRequestInterceptor extends Interceptor<HttpRequestEventMap> {
           customAgent: options.agent,
           onRequest,
           onResponse,
+          signal: options.signal,
         })
         options.agent = mockAgent
 
@@ -66,6 +67,7 @@ export class ClientRequestInterceptor extends Interceptor<HttpRequestEventMap> {
           customAgent: options.agent,
           onRequest,
           onResponse,
+          signal: options.signal,
         })
         options.agent = mockAgent
 
@@ -84,6 +86,7 @@ export class ClientRequestInterceptor extends Interceptor<HttpRequestEventMap> {
           customAgent: options.agent,
           onRequest,
           onResponse,
+          signal: options.signal,
         })
         options.agent = mockAgent
 
@@ -106,6 +109,7 @@ export class ClientRequestInterceptor extends Interceptor<HttpRequestEventMap> {
           customAgent: options.agent,
           onRequest,
           onResponse,
+          signal: options.signal,
         })
         options.agent = mockAgent
 
@@ -124,6 +128,7 @@ export class ClientRequestInterceptor extends Interceptor<HttpRequestEventMap> {
           customAgent: options.agent,
           onRequest,
           onResponse,
+          signal: options.signal,
         })
         options.agent = mockAgent
 

--- a/src/utils/handleRequest.ts
+++ b/src/utils/handleRequest.ts
@@ -130,7 +130,10 @@ export async function handleRequest(
 
   // Handle the request being aborted while waiting for the request listeners.
   if (requestAbortPromise.state === 'rejected') {
-    await options.controller.errorWith(requestAbortPromise.rejectionReason)
+    if (options.controller.readyState === RequestController.PENDING) {
+      await options.controller.errorWith(requestAbortPromise.rejectionReason)
+    }
+
     return
   }
 


### PR DESCRIPTION
## Summary

Fixes #768.

- Preserve the original `http.ClientRequest` abort signal when constructing the intercepted Fetch `Request`.
- Pass the signal through the mock HTTP/HTTPS agents into `MockHttpSocket`.
- Avoid re-handling a request controller when an abort arrives after the request has already been passed through.
- Add regression coverage that verifies `request.signal` observed in the interceptor receives the original abort reason.

## Validation

- `corepack pnpm exec vitest run src/interceptors/ClientRequest/index.test.ts`
- `corepack pnpm exec vitest run -c test/vitest.config.js test/modules/http/compliance/http-abort-controller.test.ts test/modules/http/compliance/http-timeout.test.ts test/modules/http/compliance/http.test.ts`
- `corepack pnpm build`
- `git diff --check`