### PR TITLE
fix: mark XHR progress length as not computable on length failures

### DIFF
--- a/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
+++ b/src/interceptors/XMLHttpRequest/XMLHttpRequestController.ts
@@ -22,6 +22,29 @@ const kIsRequestHandled = Symbol('kIsRequestHandled')
 const IS_NODE = isNodeProcess()
 const kFetchRequest = Symbol('kFetchRequest')
 
+type BodyByteLengthResult = {
+  length: number
+  lengthComputable: boolean
+}
+
+async function getBodyByteLengthResult(
+  input: Request | Response | (() => Request | Response)
+): Promise<BodyByteLengthResult> {
+  try {
+    const body = typeof input === 'function' ? input() : input
+
+    return {
+      length: await getBodyByteLength(body),
+      lengthComputable: true,
+    }
+  } catch {
+    return {
+      length: 0,
+      lengthComputable: false,
+    }
+  }
+}
+
 /**
  * An `XMLHttpRequest` instance controller that allows us
  * to handle any given request instance (e.g. responding to it).
@@ -306,26 +329,30 @@ export class XMLHttpRequestController {
      * @see https://github.com/mswjs/interceptors/issues/573
      */
     if (this[kFetchRequest]) {
-      const totalRequestBodyLength = await getBodyByteLength(
+      const totalRequestBodyLength = await getBodyByteLengthResult(
         this[kFetchRequest]
       )
 
       this.trigger('loadstart', this.request.upload, {
         loaded: 0,
-        total: totalRequestBodyLength,
+        total: totalRequestBodyLength.length,
+        lengthComputable: totalRequestBodyLength.lengthComputable,
       })
       this.trigger('progress', this.request.upload, {
-        loaded: totalRequestBodyLength,
-        total: totalRequestBodyLength,
+        loaded: totalRequestBodyLength.length,
+        total: totalRequestBodyLength.length,
+        lengthComputable: totalRequestBodyLength.lengthComputable,
       })
       this.trigger('load', this.request.upload, {
-        loaded: totalRequestBodyLength,
-        total: totalRequestBodyLength,
+        loaded: totalRequestBodyLength.length,
+        total: totalRequestBodyLength.length,
+        lengthComputable: totalRequestBodyLength.lengthComputable,
       })
 
       this.trigger('loadend', this.request.upload, {
-        loaded: totalRequestBodyLength,
-        total: totalRequestBodyLength,
+        loaded: totalRequestBodyLength.length,
+        total: totalRequestBodyLength.length,
+        lengthComputable: totalRequestBodyLength.lengthComputable,
       })
     }
 
@@ -407,13 +434,16 @@ export class XMLHttpRequestController {
       },
     })
 
-    const totalResponseBodyLength = await getBodyByteLength(response.clone())
+    const totalResponseBodyLength = await getBodyByteLengthResult(() =>
+      response.clone()
+    )
 
     this.logger.info('calculated response body length', totalResponseBodyLength)
 
     this.trigger('loadstart', this.request, {
       loaded: 0,
-      total: totalResponseBodyLength,
+      total: totalResponseBodyLength.length,
+      lengthComputable: totalResponseBodyLength.lengthComputable,
     })
 
     this.setReadyState(this.request.HEADERS_RECEIVED)
@@ -426,12 +456,14 @@ export class XMLHttpRequestController {
 
       this.trigger('load', this.request, {
         loaded: this.responseBuffer.byteLength,
-        total: totalResponseBodyLength,
+        total: totalResponseBodyLength.length,
+        lengthComputable: totalResponseBodyLength.lengthComputable,
       })
 
       this.trigger('loadend', this.request, {
         loaded: this.responseBuffer.byteLength,
-        total: totalResponseBodyLength,
+        total: totalResponseBodyLength.length,
+        lengthComputable: totalResponseBodyLength.lengthComputable,
       })
     }
 
@@ -455,7 +487,8 @@ export class XMLHttpRequestController {
 
           this.trigger('progress', this.request, {
             loaded: this.responseBuffer.byteLength,
-            total: totalResponseBodyLength,
+            total: totalResponseBodyLength.length,
+            lengthComputable: totalResponseBodyLength.lengthComputable,
           })
         }
 

--- a/src/interceptors/XMLHttpRequest/utils/createEvent.test.ts
+++ b/src/interceptors/XMLHttpRequest/utils/createEvent.test.ts
@@ -23,4 +23,18 @@ it('returns the ProgressEvent instance', () => {
   expect(event).toBeInstanceOf(ProgressEvent)
   expect(event.loaded).toBe(100)
   expect(event.total).toBe(500)
+  expect(event.lengthComputable).toBe(true)
+})
+
+it('respects an explicit lengthComputable value', () => {
+  const event = createEvent(request, 'load', {
+    loaded: 100,
+    total: 0,
+    lengthComputable: false,
+  })
+
+  expect(event).toBeInstanceOf(ProgressEvent)
+  expect(event.loaded).toBe(100)
+  expect(event.total).toBe(0)
+  expect(event.lengthComputable).toBe(false)
 })

--- a/src/interceptors/XMLHttpRequest/utils/createEvent.ts
+++ b/src/interceptors/XMLHttpRequest/utils/createEvent.ts
@@ -28,7 +28,7 @@ export function createEvent(
 
   const event = progressEvents.includes(type)
     ? new ProgressEventClass(type, {
-        lengthComputable: true,
+        lengthComputable: init?.lengthComputable ?? true,
         loaded: init?.loaded || 0,
         total: init?.total || 0,
       })

--- a/test/modules/XMLHttpRequest/compliance/xhr-response-progress.browser.test.ts
+++ b/test/modules/XMLHttpRequest/compliance/xhr-response-progress.browser.test.ts
@@ -74,6 +74,62 @@ test('supports response progress for a mocked response', async ({
   ])
 })
 
+test('marks response progress length as not computable when total length fails', async ({
+  loadExample,
+  page,
+}) => {
+  await loadExample(require.resolve('./xhr-upload.browser.runtime.js'))
+
+  await page.evaluate(() => {
+    window.interceptor.on('request', ({ controller }) => {
+      const response = new Response(new Blob(['hello world']))
+
+      Object.defineProperty(response, 'clone', {
+        value: () => {
+          throw new Error('Failed to clone response')
+        },
+      })
+
+      controller.respondWith(response)
+    })
+  })
+
+  const events = await page.evaluate(() => {
+    const xhr = new XMLHttpRequest()
+    const events: Array<{
+      type: string
+      lengthComputable: boolean
+      loaded: number
+      total: number
+    }> = []
+
+    for (const eventType of ['loadstart', 'progress', 'load', 'loadend']) {
+      xhr.addEventListener(eventType, (event) => {
+        const progressEvent = event as ProgressEvent
+
+        events.push({
+          type: progressEvent.type,
+          lengthComputable: progressEvent.lengthComputable,
+          loaded: progressEvent.loaded,
+          total: progressEvent.total,
+        })
+      })
+    }
+
+    xhr.open('GET', '/does-not-matter')
+    xhr.send()
+
+    return window.waitForXMLHttpRequest(xhr).then(() => events)
+  })
+
+  expect(events).toEqual([
+    { type: 'loadstart', lengthComputable: false, loaded: 0, total: 0 },
+    { type: 'progress', lengthComputable: false, loaded: 11, total: 0 },
+    { type: 'load', lengthComputable: false, loaded: 11, total: 0 },
+    { type: 'loadend', lengthComputable: false, loaded: 11, total: 0 },
+  ])
+})
+
 test('supports response progress for a bypassed response', async ({
   loadExample,
   page,


### PR DESCRIPTION
## Summary

- preserve explicit `lengthComputable` values when creating XHR progress events
- keep request/response progress events at `lengthComputable: true` when body length is calculated successfully
- fall back to `lengthComputable: false` and `total: 0` when body length calculation fails, while continuing to stream the response body

Fixes #617.

## Validation

- `corepack pnpm exec vitest run src/interceptors/XMLHttpRequest/utils/createEvent.test.ts`
- `corepack pnpm build`
- `git diff --check`

Attempted browser coverage with `corepack pnpm exec playwright test -c test/playwright.config.ts test/modules/XMLHttpRequest/compliance/xhr-response-progress.browser.test.ts`, but local Chromium is missing. `corepack pnpm exec playwright install chromium` timed out in this Windows environment, so the browser regression test is included for CI to run.