### PR TITLE
fix: use stable global symbol for XHR interceptor

### DIFF
--- a/src/interceptors/XMLHttpRequest/index.test.ts
+++ b/src/interceptors/XMLHttpRequest/index.test.ts
@@ -1,0 +1,13 @@
+import { afterEach, expect, it } from 'vitest'
+import { deleteGlobalSymbol } from '../../Interceptor'
+import { XMLHttpRequestInterceptor } from './index'
+
+afterEach(() => {
+  deleteGlobalSymbol(XMLHttpRequestInterceptor.interceptorSymbol)
+})
+
+it('uses a stable global symbol to detect existing XHR interceptors', () => {
+  expect(XMLHttpRequestInterceptor.interceptorSymbol).toBe(
+    Symbol.for('mswjs.interceptors.XMLHttpRequest')
+  )
+})

--- a/src/interceptors/XMLHttpRequest/index.ts
+++ b/src/interceptors/XMLHttpRequest/index.ts
@@ -8,7 +8,7 @@ import { patchesRegistry } from '../../utils/patchesRegistry'
 export type XMLHttpRequestEmitter = Emitter<HttpRequestEventMap>
 
 export class XMLHttpRequestInterceptor extends Interceptor<HttpRequestEventMap> {
-  static interceptorSymbol = Symbol('xhr')
+  static interceptorSymbol = Symbol.for('mswjs.interceptors.XMLHttpRequest')
 
   constructor() {
     super(XMLHttpRequestInterceptor.interceptorSymbol)


### PR DESCRIPTION
## Summary

- use a `Symbol.for(...)` registry symbol for `XMLHttpRequestInterceptor`
- keep duplicate bundled copies from treating the same global `XMLHttpRequest` as unpatched
- add a regression test for the stable symbol identity

Fixes #771.

## Validation

- `corepack pnpm exec vitest run src/interceptors/XMLHttpRequest/index.test.ts`
- `corepack pnpm build`
- `git diff --check`