### PR TITLE
fix: use `Symbol.for` for internal symbols

### DIFF
--- a/src/BatchInterceptor.ts
+++ b/src/BatchInterceptor.ts
@@ -2,19 +2,20 @@ import { EventMap, Listener } from 'strict-event-emitter'
 import { Interceptor, ExtractEventNames } from './Interceptor'
 
 export interface BatchInterceptorOptions<
-  InterceptorList extends ReadonlyArray<Interceptor<any>>
+  InterceptorList extends ReadonlyArray<Interceptor<any>>,
 > {
   name: string
   interceptors: InterceptorList
 }
 
 export type ExtractEventMapType<
-  InterceptorList extends ReadonlyArray<Interceptor<any>>
-> = InterceptorList extends ReadonlyArray<infer InterceptorType>
-  ? InterceptorType extends Interceptor<infer EventMap>
-    ? EventMap
+  InterceptorList extends ReadonlyArray<Interceptor<any>>,
+> =
+  InterceptorList extends ReadonlyArray<infer InterceptorType>
+    ? InterceptorType extends Interceptor<infer EventMap>
+      ? EventMap
+      : never
     : never
-  : never
 
 /**
  * A batch interceptor that exposes a single interface
@@ -22,14 +23,14 @@ export type ExtractEventMapType<
  */
 export class BatchInterceptor<
   InterceptorList extends ReadonlyArray<Interceptor<any>>,
-  Events extends EventMap = ExtractEventMapType<InterceptorList>
+  Events extends EventMap = ExtractEventMapType<InterceptorList>,
 > extends Interceptor<Events> {
   static symbol: symbol
 
   private interceptors: InterceptorList
 
   constructor(options: BatchInterceptorOptions<InterceptorList>) {
-    BatchInterceptor.symbol = Symbol(options.name)
+    BatchInterceptor.symbol = Symbol.for(options.name)
     super(BatchInterceptor.symbol)
     this.interceptors = options.interceptors
   }

--- a/src/RemoteHttpInterceptor.ts
+++ b/src/RemoteHttpInterceptor.ts
@@ -141,7 +141,7 @@ export interface RemoveResolverOptions {
 }
 
 export class RemoteHttpResolver extends Interceptor<HttpRequestEventMap> {
-  static symbol = Symbol('remote-resolver')
+  static symbol = Symbol.for('remote-resolver')
   private process: ChildProcess
 
   constructor(options: RemoveResolverOptions) {

--- a/src/interceptors/ClientRequest/index.ts
+++ b/src/interceptors/ClientRequest/index.ts
@@ -18,7 +18,7 @@ import {
 } from './utils/recordRawHeaders'
 
 export class ClientRequestInterceptor extends Interceptor<HttpRequestEventMap> {
-  static symbol = Symbol('client-request-interceptor')
+  static symbol = Symbol.for('client-request-interceptor')
 
   constructor() {
     super(ClientRequestInterceptor.symbol)

--- a/src/interceptors/WebSocket/index.ts
+++ b/src/interceptors/WebSocket/index.ts
@@ -70,7 +70,7 @@ export type WebSocketConnectionData = {
  * the global `WebSocket` class.
  */
 export class WebSocketInterceptor extends Interceptor<WebSocketEventMap> {
-  static symbol = Symbol('websocket')
+  static symbol = Symbol.for('websocket-interceptor')
 
   constructor() {
     super(WebSocketInterceptor.symbol)

--- a/src/interceptors/XMLHttpRequest/index.ts
+++ b/src/interceptors/XMLHttpRequest/index.ts
@@ -8,10 +8,10 @@ import { patchesRegistry } from '../../utils/patchesRegistry'
 export type XMLHttpRequestEmitter = Emitter<HttpRequestEventMap>
 
 export class XMLHttpRequestInterceptor extends Interceptor<HttpRequestEventMap> {
-  static interceptorSymbol = Symbol('xhr')
+  static symbol = Symbol.for('xhr-interceptor')
 
   constructor() {
-    super(XMLHttpRequestInterceptor.interceptorSymbol)
+    super(XMLHttpRequestInterceptor.symbol)
   }
 
   protected checkEnvironment() {

--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -17,7 +17,7 @@ import { isResponseError } from '../../utils/responseUtils'
 import { patchesRegistry } from '../../utils/patchesRegistry'
 
 export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
-  static symbol = Symbol('fetch')
+  static symbol = Symbol.for('fetch-interceptor')
 
   constructor() {
     super(FetchInterceptor.symbol)


### PR DESCRIPTION
- Closes #788 
- Fixes #771 