### PR TITLE
Handle absolute-form proxy request paths

### DIFF
--- a/src/utils/getUrlByRequestOptions.test.ts
+++ b/src/utils/getUrlByRequestOptions.test.ts
@@ -87,6 +87,16 @@ it('respects explicitly provided port', () => {
   ).toBe('http://127.0.0.1:4002/')
 })
 
+it('resolves absolute-form paths as the request target URL', () => {
+  expect(
+    getUrlByRequestOptions({
+      protocol: 'http:',
+      host: '127.0.0.1:3000',
+      path: 'https://google.com/search?q=msw',
+    }).href
+  ).toBe('https://google.com/search?q=msw')
+})
+
 it('inherits "username" and "password"', () => {
   const url = getUrlByRequestOptions({
     protocol: 'https:',
@@ -149,7 +159,6 @@ it('parses "host" in IPv6', () => {
       path: '/resource',
     }).href
   ).toBe('http://[::1]/resource')
-
 })
 
 it('parses "host" and "port" in IPv6', () => {

--- a/src/utils/getUrlByRequestOptions.ts
+++ b/src/utils/getUrlByRequestOptions.ts
@@ -94,7 +94,7 @@ function getHostname(options: ResolvedRequestOptions): string | undefined {
 
   if (host) {
     if (isRawIPv6Address(host)) {
-       host = `[${host}]`
+      host = `[${host}]`
     }
 
     // Check the presence of the port, and if it's present,
@@ -103,6 +103,15 @@ function getHostname(options: ResolvedRequestOptions): string | undefined {
   }
 
   return DEFAULT_HOSTNAME
+}
+
+function isAbsoluteUrl(path: string): boolean {
+  try {
+    new URL(path)
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**
@@ -121,6 +130,14 @@ export function getUrlByRequestOptions(options: ResolvedRequestOptions): URL {
 
   logger.info('figuring out url from request options...')
 
+  const path = options.path || DEFAULT_PATH
+  logger.info('path', path)
+
+  if (isAbsoluteUrl(path)) {
+    logger.info('using absolute-form request path as url: %s', path)
+    return new URL(path)
+  }
+
   const protocol = getProtocolByRequestOptions(options)
   logger.info('protocol', protocol)
 
@@ -129,9 +146,6 @@ export function getUrlByRequestOptions(options: ResolvedRequestOptions): URL {
 
   const hostname = getHostname(options)
   logger.info('hostname', hostname)
-
-  const path = options.path || DEFAULT_PATH
-  logger.info('path', path)
 
   const credentials = getAuthByRequestOptions(options)
   logger.info('credentials', credentials)


### PR DESCRIPTION
## Summary
- Treat absolute-form `RequestOptions.path` values as the request target URL.
- Preserve proxied HTTPS targets instead of concatenating them with the proxy host.
- Add regression coverage for proxy-style absolute-form paths.

Fixes #570.

## Validation
- `corepack pnpm exec vitest run src/utils/getUrlByRequestOptions.test.ts`
- `corepack pnpm build`