### PR TITLE
Forward arbitrary ClientRequest error reasons

### DIFF
--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -454,8 +454,8 @@ export class MockHttpSocket extends MockSocket {
   /**
    * Close this socket connection with the given error.
    */
-  public errorWith(error?: Error): void {
-    this.destroy(error)
+  public errorWith(error?: unknown): void {
+    this.destroy(error as Error)
   }
 
   private mockConnect(): void {

--- a/src/interceptors/ClientRequest/index.test.ts
+++ b/src/interceptors/ClientRequest/index.test.ts
@@ -73,3 +73,25 @@ it('patch the Headers object correctly after dispose and reapply', async () => {
   )
   expect(res.headers['x-custom-header']).toEqual('Yes')
 })
+
+it('errors the request with an arbitrary error reason', async () => {
+  const reason = { message: 'custom error', code: 'test' }
+
+  interceptor.on('request', ({ controller }) => {
+    controller.errorWith(reason)
+  })
+
+  const errorPromise = new DeferredPromise<unknown>()
+  const request = http.request(httpServer.http.url('/'))
+
+  request.on('response', () => {
+    errorPromise.reject(new Error('Expected request error, got response'))
+  })
+  request.on('error', (error) => {
+    errorPromise.resolve(error)
+  })
+
+  request.end()
+
+  await expect(errorPromise).resolves.toBe(reason)
+})

--- a/src/interceptors/ClientRequest/index.ts
+++ b/src/interceptors/ClientRequest/index.ts
@@ -161,9 +161,7 @@ export class ClientRequestInterceptor extends Interceptor<HttpRequestEventMap> {
         await socket.respondWith(response)
       },
       errorWith(reason) {
-        if (reason instanceof Error) {
-          socket.errorWith(reason)
-        }
+        socket.errorWith(reason)
       },
     })
 


### PR DESCRIPTION
## Summary
- Forward all `controller.errorWith()` reasons through the ClientRequest adapter instead of dropping non-`Error` values.
- Allow the mock HTTP socket error path to receive arbitrary error reasons.
- Add regression coverage that an object reason reaches the request `error` event instead of the response path.

Fixes #625.

## Validation
- `corepack pnpm exec vitest run src/interceptors/ClientRequest/index.test.ts`
- `corepack pnpm build`