### PR TITLE
Abort mocked fetch response bodies

### DIFF
--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -16,6 +16,27 @@ import { setRawRequest } from '../../getRawRequest'
 import { isResponseError } from '../../utils/responseUtils'
 import { patchesRegistry } from '../../utils/patchesRegistry'
 
+function createAbortableResponse(
+  response: Response,
+  signal: AbortSignal
+): Response {
+  if (!response.body) {
+    return response
+  }
+
+  const stream = new TransformStream()
+  response.body.pipeTo(stream.writable, { signal }).catch(() => {
+    // The consumer observes aborts and stream failures through `stream.readable`.
+  })
+
+  return new FetchResponse(stream.readable, {
+    url: response.url,
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  })
+}
+
 export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
   static symbol = Symbol.for('fetch-interceptor')
 
@@ -149,6 +170,11 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
             }
           }
 
+          const mockedResponse = createAbortableResponse(
+            response,
+            request.signal
+          )
+
           if (this.emitter.listenerCount('response') > 0) {
             this.logger.info('emitting the "response" event...')
 
@@ -159,14 +185,14 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
               // Clone the mocked response for the "response" event listener.
               // This way, the listener can read the response and not lock its body
               // for the actual fetch consumer.
-              response: FetchResponse.clone(response),
+              response: FetchResponse.clone(mockedResponse),
               isMockedResponse: true,
               request,
               requestId,
             })
           }
 
-          responsePromise.resolve(response)
+          responsePromise.resolve(mockedResponse)
         },
         errorWith: (reason) => {
           this.logger.info('request has been aborted!', { reason })

--- a/test/modules/fetch/compliance/abort-conrtoller.test.ts
+++ b/test/modules/fetch/compliance/abort-conrtoller.test.ts
@@ -162,3 +162,39 @@ it('aborts the pending request via "AbortSignal.timeout"', async () => {
     message: 'The operation was aborted due to timeout',
   })
 })
+
+it('aborts the mocked response body when the request is aborted after response', async () => {
+  const sourceCancelled = new DeferredPromise<unknown>()
+
+  interceptor.on('request', ({ controller }) => {
+    let interval: NodeJS.Timeout
+    const body = new ReadableStream({
+      start(controller) {
+        interval = globalThis.setInterval(() => {
+          controller.enqueue(new TextEncoder().encode('hello'))
+        }, 10)
+      },
+      cancel(reason) {
+        clearInterval(interval)
+        sourceCancelled.resolve(reason)
+      },
+    })
+
+    controller.respondWith(new Response(body))
+  })
+
+  const controller = new AbortController()
+  const response = await fetch(httpServer.http.url('/'), {
+    signal: controller.signal,
+  })
+  const bodyErrorPromise = response.text().then<unknown>(
+    () => expect.fail('must not finish reading the response body'),
+    (error) => error
+  )
+  const abortReason = new DOMException('Body aborted', 'AbortError')
+
+  controller.abort(abortReason)
+
+  await expect(bodyErrorPromise).resolves.toBe(abortReason)
+  await expect(sourceCancelled).resolves.toBe(abortReason)
+})


### PR DESCRIPTION
## Summary
- Wrap mocked fetch response bodies in an abort-aware stream tied to the original request signal.
- Cancel the underlying mocked body and error the response body when the request aborts after `fetch()` has resolved.
- Add regression coverage for aborting an infinite mocked response body.

Fixes #693.

## Validation
- `corepack pnpm exec vitest -c test/vitest.config.js run test/modules/fetch/compliance/abort-conrtoller.test.ts --reporter verbose`
- `corepack pnpm build`