### PR TITLE
Cancel unused fetch response event clones

### DIFF
--- a/src/interceptors/fetch/index.ts
+++ b/src/interceptors/fetch/index.ts
@@ -16,6 +16,16 @@ import { setRawRequest } from '../../getRawRequest'
 import { isResponseError } from '../../utils/responseUtils'
 import { patchesRegistry } from '../../utils/patchesRegistry'
 
+function cancelUnconsumedResponseClone(response: Response): void {
+  if (!response.body || response.bodyUsed) {
+    return
+  }
+
+  response.body.cancel().catch(() => {
+    // The response clone is internal and deliberately unused.
+  })
+}
+
 export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
   static symbol = Symbol.for('fetch-interceptor')
 
@@ -92,6 +102,7 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
               request: requestCloneForResponseEvent,
               requestId,
             })
+            cancelUnconsumedResponseClone(responseClone)
           }
 
           // Resolve the response promise with the original response
@@ -155,15 +166,18 @@ export class FetchInterceptor extends Interceptor<HttpRequestEventMap> {
             // Await the response listeners to finish before resolving
             // the response promise. This ensures all your logic finishes
             // before the interceptor resolves the pending response.
+            const responseClone = FetchResponse.clone(response)
+
             await emitAsync(this.emitter, 'response', {
               // Clone the mocked response for the "response" event listener.
               // This way, the listener can read the response and not lock its body
               // for the actual fetch consumer.
-              response: FetchResponse.clone(response),
+              response: responseClone,
               isMockedResponse: true,
               request,
               requestId,
             })
+            cancelUnconsumedResponseClone(responseClone)
           }
 
           responsePromise.resolve(response)

--- a/test/modules/fetch/response/fetch-await-response-event.test.ts
+++ b/test/modules/fetch/response/fetch-await-response-event.test.ts
@@ -66,3 +66,15 @@ it('awaits response listener promise before resolving the original response prom
   expect(markStep).toHaveBeenNthCalledWith(3, 3)
   expect(markStep).toHaveBeenNthCalledWith(4, 4)
 })
+
+it('cancels unconsumed original response event clones', async () => {
+  interceptor.on('response', () => {})
+
+  const response = await fetch(httpServer.http.url('/resource'))
+  const cancelResult = await Promise.race([
+    response.body!.cancel().then(() => 'cancelled'),
+    new Promise((resolve) => setTimeout(() => resolve('timeout'), 500)),
+  ])
+
+  expect(cancelResult).toBe('cancelled')
+})


### PR DESCRIPTION
## Summary
- Cancel internal response-event clones when listeners do not consume them.
- Keep existing response listener behavior for clones that are read during the event.
- Add regression coverage for cancelling the original passthrough response body after an unconsumed response event clone.

Fixes #712.

## Validation
- `corepack pnpm exec vitest -c test/vitest.config.js run test/modules/fetch/response/fetch-await-response-event.test.ts --reporter verbose`
- `corepack pnpm build`