### PR TITLE
Fix abort errors on large passthrough responses

### DIFF
--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -286,6 +286,17 @@ export class MockHttpSocket extends MockSocket {
       })
     }
 
+    let passthroughReadableEnded = false
+    let passthroughCloseEmitted = false
+    const emitPassthroughCloseOnce = (hadError: boolean) => {
+      if (passthroughCloseEmitted) {
+        return
+      }
+
+      passthroughCloseEmitted = true
+      this.emit('close', hadError)
+    }
+
     socket
       .on('lookup', (...args) => this.emit('lookup', ...args))
       .on('connect', () => {
@@ -311,8 +322,21 @@ export class MockHttpSocket extends MockSocket {
       .on('timeout', () => this.emit('timeout'))
       .on('prefinish', () => this.emit('prefinish'))
       .on('finish', () => this.emit('finish'))
-      .on('close', (hadError) => this.emit('close', hadError))
-      .on('end', () => this.emit('end'))
+      .on('close', (hadError) => {
+        if (hadError || !passthroughReadableEnded || this.readableEnded) {
+          emitPassthroughCloseOnce(hadError)
+          return
+        }
+
+        // Node's HTTP client expects the response readable side to end before
+        // the socket closes. The original socket can close before the pushed
+        // EOF surfaces on this socket, so defer "close" to avoid an abort.
+        this.once('end', () => emitPassthroughCloseOnce(hadError))
+      })
+      .on('end', () => {
+        passthroughReadableEnded = true
+        this.push(null)
+      })
   }
 
   /**

--- a/test/modules/http/regressions/http-passthrough-large-response-delayed-consumer.test.ts
+++ b/test/modules/http/regressions/http-passthrough-large-response-delayed-consumer.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment node
+ */
+import { afterAll, afterEach, beforeAll, expect, it } from 'vitest'
+import http from 'node:http'
+import net, { AddressInfo } from 'node:net'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+
+const largeResponseBody = Buffer.alloc(1024 * 1024, 'a')
+const interceptor = new ClientRequestInterceptor()
+
+const rawHttpServer = net.createServer((socket) => {
+  socket.once('data', () => {
+    socket.write('HTTP/1.1 200 OK\r\n')
+    socket.write('Connection: close\r\n')
+    // Use conventional response framing. The regression is caused by the
+    // large response body and delayed consumption, not by this header.
+    socket.write(`Content-Length: ${largeResponseBody.byteLength}\r\n`)
+    socket.write('Content-Type: text/plain\r\n')
+    socket.write('\r\n')
+    socket.end(largeResponseBody)
+  })
+})
+
+beforeAll(async () => {
+  interceptor.apply()
+  await new Promise<void>((resolve) => {
+    rawHttpServer.listen(0, '127.0.0.1', resolve)
+  })
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(async () => {
+  interceptor.dispose()
+  await new Promise<void>((resolve, reject) => {
+    rawHttpServer.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+  })
+})
+
+it('delivers a large passthrough response to a delayed consumer before closing', async () => {
+  expect.assertions(2)
+
+  const address = rawHttpServer.address() as AddressInfo
+  const result = await new Promise<{
+    receivedBodySize: number
+    isComplete: boolean
+  }>((resolve, reject) => {
+    const request = http.get(
+      `http://127.0.0.1:${address.port}/resource`,
+      (response) => {
+        let bytesRead = 0
+
+        response.on('error', reject)
+
+        // Delay response consumption by one tick so the original socket close
+        // can race with this passthrough socket's readable completion.
+        response.pause()
+
+        setImmediate(() => {
+          response.on('data', (chunk: Buffer) => {
+            bytesRead += chunk.byteLength
+          })
+          response.on('end', () => {
+            resolve({
+              receivedBodySize: bytesRead,
+              isComplete: response.complete,
+            })
+          })
+          response.resume()
+        })
+      }
+    )
+
+    request.on('error', reject)
+  })
+
+  expect(result.receivedBodySize).toBe(largeResponseBody.byteLength)
+  expect(result.isComplete).toBe(true)
+})


### PR DESCRIPTION
In passthrough mode, `MockHttpSocket` forwards data from the real socket into the mock socket that Node’s HTTP client observes. For large responses, the real socket can emit `close` before the mock socket has surfaced the pushed EOF as `end` to Node. Forwarding `close` immediately violates the ordering Node expects: the response readable side must finish before the socket is considered closed. Node then reports the otherwise valid response as `Error: aborted`

This PR tracks when the passthrough readable side has ended and defers forwarding close until the mock socket emits end. Error closes and closes before the upstream readable side ends are still forwarded immediately, so legitimate abort/error semantics are preserved.