### PR TITLE
fix(ClientRequest): avoid duplicate destroy error events

### DIFF
--- a/src/interceptors/ClientRequest/MockHttpSocket.ts
+++ b/src/interceptors/ClientRequest/MockHttpSocket.ts
@@ -171,10 +171,6 @@ export class MockHttpSocket extends MockSocket {
     // can be suppressed by using the "emitClose: false" option.
     freeParser(this.responseParser, this)
 
-    if (error) {
-      this.emit('error', error)
-    }
-
     return super.destroy(error)
   }
 

--- a/test/modules/http/regressions/http-client-request-destroy-error.test.ts
+++ b/test/modules/http/regressions/http-client-request-destroy-error.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @vitest-environment node
+ */
+import { it, expect, beforeAll, afterAll } from 'vitest'
+import http from 'node:http'
+import { ClientRequestInterceptor } from '../../../../src/interceptors/ClientRequest'
+import { sleep } from '../../../helpers'
+
+const interceptor = new ClientRequestInterceptor()
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+})
+
+it('emits a single error when ClientRequest is destroyed with an error', async () => {
+  const errors: Array<unknown> = []
+
+  interceptor.once('request', ({ controller }) => {
+    controller.respondWith(new Response('mocked'))
+  })
+
+  const request = http.request('http://example.com/resource')
+  request.on('error', (error) => {
+    errors.push(error)
+  })
+
+  request.end()
+  request.destroy(new Error('request aborted'))
+
+  await sleep(250)
+
+  expect(errors).toHaveLength(1)
+})


### PR DESCRIPTION
## Summary

`MockHttpSocket.destroy(error)` manually emitted the error and then delegated to `super.destroy(error)`, which can emit the same error again. That makes intercepted `ClientRequest.destroy(error)` behave differently from Node's native request and can surface as an uncaught second error for clients that expect one error event.

This lets the base socket destroy path handle error emission and adds a regression test that destroys an intercepted `ClientRequest` with an error and observes exactly one error event.

Fixes mswjs/msw#2617.

## Validation

- `corepack pnpm exec vitest -c test/vitest.config.js run test/modules/http/regressions/http-client-request-destroy-error.test.ts --reporter verbose`
- `corepack pnpm run build`