### PR TITLE
fix(HttpRequestInterceptor): prevent double `connection` listeners

### DIFF
--- a/src/interceptors/http/index.ts
+++ b/src/interceptors/http/index.ts
@@ -28,7 +28,7 @@ import {
 import { unwrapPendingData } from '../net/utils/flush-writes'
 import { FetchResponse } from '../../utils/fetchUtils'
 import { requestContext } from '../../request-context'
-import { Interceptor } from '#/src/interceptor'
+import { Interceptor, InterceptorReadyState } from '#/src/interceptor'
 
 const log = createLogger('HttpRequestInterceptor')
 
@@ -45,6 +45,7 @@ export class HttpRequestInterceptor extends Interceptor<HttpRequestEventMap> {
 
   protected setup(): void {
     const socketInterceptor = Interceptor.singleton(SocketInterceptor)
+    if (socketInterceptor.readyState === InterceptorReadyState.ACTIVE) return
     socketInterceptor.apply()
     this.subscriptions.push(() => socketInterceptor.dispose())
 

--- a/src/interceptors/http/index.ts
+++ b/src/interceptors/http/index.ts
@@ -45,7 +45,11 @@ export class HttpRequestInterceptor extends Interceptor<HttpRequestEventMap> {
 
   protected setup(): void {
     const socketInterceptor = Interceptor.singleton(SocketInterceptor)
-    if (socketInterceptor.readyState === InterceptorReadyState.ACTIVE) return
+
+    if (socketInterceptor.readyState === InterceptorReadyState.ACTIVE) {
+      return
+    }
+
     socketInterceptor.apply()
     this.subscriptions.push(() => socketInterceptor.dispose())
 

--- a/test/modules/http/regressions/http-batch-interceptor-double-connection.test.ts
+++ b/test/modules/http/regressions/http-batch-interceptor-double-connection.test.ts
@@ -25,7 +25,7 @@ afterAll(() => {
   interceptor.dispose()
 })
 
-it('does not throw "CANNOT HANDLE ALREADY HANDLED REQUEST" when using BatchInterceptor with HttpRequestInterceptor and FetchInterceptor', async () => {
+it('does not attach multiple "connection" listeners for nested interceptors', async () => {
   interceptor.on('request', ({ controller }) => {
     controller.respondWith(new Response('mocked'))
   })

--- a/test/modules/http/regressions/http-batch-interceptor-double-connection.test.ts
+++ b/test/modules/http/regressions/http-batch-interceptor-double-connection.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+/**
+ * Using BatchInterceptor with both HttpRequestInterceptor and FetchInterceptor
+ * causes the "connection" event listener to be added twice, resulting in
+ * "Invariant Violation: CANNOT HANDLE ALREADY HANDLED REQUEST".
+ */
+import { BatchInterceptor } from '#/src/BatchInterceptor'
+import { HttpRequestInterceptor } from '#/src/interceptors/http'
+import { FetchInterceptor } from '#/src/interceptors/fetch/node'
+
+const interceptor = new BatchInterceptor({
+  name: 'batch-test',
+  interceptors: [new HttpRequestInterceptor(), new FetchInterceptor()],
+})
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterEach(() => {
+  interceptor.removeAllListeners()
+})
+
+afterAll(() => {
+  interceptor.dispose()
+})
+
+it('does not throw "CANNOT HANDLE ALREADY HANDLED REQUEST" when using BatchInterceptor with HttpRequestInterceptor and FetchInterceptor', async () => {
+  interceptor.on('request', ({ controller }) => {
+    controller.respondWith(new Response('mocked'))
+  })
+
+  const response = await fetch('http://localhost/resource')
+  expect(response.status).toBe(200)
+  await expect(response.text()).resolves.toBe('mocked')
+})


### PR DESCRIPTION
## Why

The FetchInterceptor -> HttpRequestInterceptor chain resulted in _two_ `connection` event listeners being added to the underlying SocketInterceptor singleton. Because of that, handling the same request resulted in this error:

```
Invariant Violation: CANNOT HANDLE ALREADY HANDLED REQUEST
```