### PR TITLE
fix(ClientRequest): improve IPv6 handling in connection options and tests

### DIFF
--- a/src/interceptors/net/utils/address-info.ts
+++ b/src/interceptors/net/utils/address-info.ts
@@ -9,14 +9,9 @@ export function getAddressInfoByConnectionOptions(
   }
 
   const isIPv6 = options.family === 6 || net.isIPv6(options.host || '')
-  const ipAddress = options.host
-    ? net.isIP(options.host) !== 0
-      ? options.host
-      : null
-    : null
 
   return {
-    address: ipAddress || isIPv6 ? '::1' : '127.0.0.1',
+    address: isIPv6 ? '::1' : '127.0.0.1',
     port: options.port || (options.protocol === 'https:' ? 443 : 80),
     family: isIPv6 ? 'IPv6' : 'IPv4',
   }

--- a/src/interceptors/net/utils/connection-options-to-url.ts
+++ b/src/interceptors/net/utils/connection-options-to-url.ts
@@ -10,7 +10,7 @@ export function connectionOptionsToUrl(
   options: NetworkConnectionOptions,
   socket: net.Socket
 ): URL {
-  const isIPv6 = options.family === 6 || net.isIPv6(options.host || '')
+  const isIPv6 = net.isIPv6(options.host || '')
   const protocol =
     socket instanceof tls.TLSSocket
       ? 'https:'

--- a/src/interceptors/net/utils/normalize-net-connect-args.ts
+++ b/src/interceptors/net/utils/normalize-net-connect-args.ts
@@ -70,6 +70,7 @@ export function normalizeNetConnectArgs(
           port: +args[0].port,
           host: options.hostname,
           auth: options.auth,
+          family: args[0].family,
         },
         callback,
       ]

--- a/test/modules/http/compliance/http-request-ipv6.test.ts
+++ b/test/modules/http/compliance/http-request-ipv6.test.ts
@@ -30,3 +30,20 @@ it('supports requests with IPv6 request url', async () => {
   expect.soft(requestUrl).toBe(url)
   await expect.soft(response.text()).resolves.toBe('test')
 })
+
+it('supports requests with family 6', async () => {
+  const url = 'http://example.test/'
+  const listenerUrlPromise = new DeferredPromise<string>()
+
+  interceptor.on('request', ({ request, controller }) => {
+    listenerUrlPromise.resolve(request.url)
+    controller.respondWith(new Response('test'))
+  })
+
+  const request = http.get(url, { family: 6 })
+  const [response] = await toWebResponse(request)
+
+  const requestUrl = await listenerUrlPromise
+  expect.soft(requestUrl).toBe(url)
+  await expect.soft(response.text()).resolves.toBe('test')
+})

--- a/test/modules/http/compliance/http.test.ts
+++ b/test/modules/http/compliance/http.test.ts
@@ -229,6 +229,26 @@ it('returns socket address for a mocked request with IPv6 hostname', async () =>
   })
 })
 
+it('returns socket address for a mocked request with family 6', async () => {
+  interceptor.on('request', async ({ controller }) => {
+    controller.respondWith(new Response())
+  })
+
+  const addressPromise = new DeferredPromise<object>()
+  const request = http.get('http://example.test', { family: 6 })
+  request.on('socket', (socket) => {
+    socket.on('connect', () => {
+      addressPromise.resolve(socket.address())
+    })
+  })
+
+  await expect(addressPromise).resolves.toEqual({
+    address: '::1',
+    family: 'IPv6',
+    port: 80,
+  })
+})
+
 it('returns socket address for a bypassed request', async () => {
   const addressPromise = new DeferredPromise<object>()
   const request = http.get(httpServer.http.url('/user'))


### PR DESCRIPTION
Fixes incorrect IPv6 detection/address resolution when a request is made with the `family: 6` option (rather than an explicit IPv6 host).

**Changes:**
- **`address-info.ts`**: simplified `getAddressInfoByConnectionOptions` to derive the mocked socket address purely from `isIPv6` (`family === 6 || net.isIPv6(host)`), removing the flawed fallback that used any parsable IP host as the address.
- **`connection-options-to-url.ts`**: reverted URL construction to rely only on `net.isIPv6(host)` (not `family`), since `family` should affect the socket's address but not the constructed request URL.