### PR TITLE
fix: bundle `debug` in browser build

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -36,6 +36,11 @@ export default defineConfig([
       './src/interceptors/WebSocket/index.ts',
     ],
     outDir: './lib/browser',
+    /**
+     * @note Inline the "debug" package into the browser bundle.
+     * It only ships CommonJS, which browsers cannot load directly.
+     */
+    noExternal: ['debug'],
     platform: 'browser',
     target: 'chrome120',
     format: ['esm'],

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -36,11 +36,13 @@ export default defineConfig([
       './src/interceptors/WebSocket/index.ts',
     ],
     outDir: './lib/browser',
-    /**
-     * @note Inline the "debug" package into the browser bundle.
-     * It only ships CommonJS, which browsers cannot load directly.
-     */
-    noExternal: ['debug'],
+    deps: {
+      /**
+       * @note Inline the "debug" package into the browser bundle.
+       * It only ships CommonJS, which browsers cannot load directly.
+       */
+      alwaysBundle: ['debug'],
+    },
     platform: 'browser',
     target: 'chrome120',
     format: ['esm'],


### PR DESCRIPTION
`debug` is CJS-only and cannot run in the browser. Causes browser module compat tests to fail in MSW.
