### PR TITLE
fix(http): proper HTTP/2 negotiation for mocked and passthrough

### DIFF
--- a/src/interceptors/net/index.ts
+++ b/src/interceptors/net/index.ts
@@ -51,10 +51,7 @@ declare module 'node:http' {
      * @note An undocumented method backing every agent-driven request
      * (see "#stopReusingUnpatchedSockets").
      */
-    addRequest?: (
-      request: http.ClientRequest,
-      ...args: Array<unknown>
-    ) => void
+    addRequest?: (request: http.ClientRequest, ...args: Array<unknown>) => void
   }
 }
 
@@ -223,7 +220,7 @@ export class SocketInterceptor extends Interceptor<SocketEventMap> {
                 () => {
                   /**
                    * @note Create the passthrough connection via the original
-                   * "tls.connect()" with the original connection options
+                   * "tls.connect()" with the effective connection options
                    * (the real DNS lookup and the caller's certificate
                    * validation included). The latch exempts the transport
                    * connect of that connection from interception.
@@ -231,10 +228,7 @@ export class SocketInterceptor extends Interceptor<SocketEventMap> {
                   isCreatingPassthroughConnection = true
 
                   try {
-                    return tls.connect(
-                      (realTlsConnectionOptions ??
-                        tlsConnectionOptions) as tls.ConnectionOptions
-                    )
+                    return tls.connect(tlsConnectionOptions)
                   } finally {
                     isCreatingPassthroughConnection = false
                   }
@@ -288,9 +282,7 @@ export class SocketInterceptor extends Interceptor<SocketEventMap> {
                * listeners to claim the connection (or once every listener
                * declines it), the controller passes it through as-is.
                */
-              controller.awaitVerdicts(
-                interceptor.listenerCount('connection')
-              )
+              controller.awaitVerdicts(interceptor.listenerCount('connection'))
 
               interceptor.emitter.emit(
                 new SocketConnectionEvent({

--- a/src/interceptors/net/socket-controller.ts
+++ b/src/interceptors/net/socket-controller.ts
@@ -187,7 +187,10 @@ function toServerSocket<T extends net.Socket>(socket: T): T {
 
       // Deliver the final chunk passed to "end(chunk)", if any.
       if (finalEnd.chunk != null) {
-        socket.push(toBuffer(finalEnd.chunk, finalEnd.encoding), finalEnd.encoding)
+        socket.push(
+          toBuffer(finalEnd.chunk, finalEnd.encoding),
+          finalEnd.encoding
+        )
       }
 
       socket.push(null)
@@ -538,7 +541,11 @@ export class TcpSocketController extends SocketController {
           typeof args[0] === 'object' &&
           (args[0].localAddress != null || args[0].localPort != null)
         ) {
-          args[0] = { ...args[0], localAddress: undefined, localPort: undefined }
+          args[0] = {
+            ...args[0],
+            localAddress: undefined,
+            localPort: undefined,
+          }
         }
 
         return Reflect.apply(target, thisArg, args)
@@ -868,9 +875,7 @@ export class TcpSocketController extends SocketController {
     }
   }
 
-  #removeBufferedWrite(
-    args: Parameters<net.Socket['_writeGeneric']>
-  ): boolean {
+  #removeBufferedWrite(args: Parameters<net.Socket['_writeGeneric']>): boolean {
     const index = this.#bufferedWrites.indexOf(args)
 
     if (index === -1) {
@@ -1462,6 +1467,18 @@ export class TlsSocketController extends TcpSocketController {
   }
 
   protected emulateConnect(): void {
+    /**
+     * @note The client chooses its wire protocol when we emulate the
+     * handshake. A later passthrough handshake must preserve that choice
+     * instead of negotiating a different protocol for buffered writes.
+     */
+    if (this.#tlsConnectionOptions) {
+      const alpnProtocol = this.socket._handle.getALPNNegotiatedProtocol()
+      this.#tlsConnectionOptions.ALPNProtocols = alpnProtocol
+        ? [alpnProtocol]
+        : []
+    }
+
     super.emulateConnect()
 
     // For TLS sockets, also invoke the "secureConnect" callbacks since some consumers,

--- a/test/modules/http/regressions/https-alpn-passthrough.test.ts
+++ b/test/modules/http/regressions/https-alpn-passthrough.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+/**
+ * @see https://github.com/mswjs/interceptors/issues/819
+ */
+import http2 from 'node:http2'
+import { Agent, fetch } from 'undici'
+import { ClientRequestInterceptor } from '#/src/interceptors/ClientRequest'
+import { createRawTestServer } from '#/test/helpers'
+import {
+  TLS_CERTIFICATE,
+  TLS_PRIVATE_KEY,
+} from '#/test/modules/net/compliance/fixtures/tls'
+
+const interceptor = new ClientRequestInterceptor()
+const dispatcher = new Agent({
+  allowH2: true,
+  connect: { ca: TLS_CERTIFICATE },
+})
+
+beforeAll(() => {
+  interceptor.apply()
+})
+
+afterAll(async () => {
+  await dispatcher.destroy()
+  interceptor.dispose()
+})
+
+it('passes fetch requests through to a server offering HTTP/2', async () => {
+  await using server = await createRawTestServer(() => {
+    return http2.createSecureServer(
+      {
+        cert: TLS_CERTIFICATE,
+        key: TLS_PRIVATE_KEY,
+        allowHTTP1: true,
+      },
+      (_request, response) => {
+        response.end('original-response')
+      }
+    )
+  })
+
+  const response = await fetch(server.https.url('/'), { dispatcher })
+
+  expect(response.status).toBe(200)
+  await expect(response.text()).resolves.toBe('original-response')
+})

--- a/test/modules/net/compliance/tls-negotiation.test.ts
+++ b/test/modules/net/compliance/tls-negotiation.test.ts
@@ -97,6 +97,32 @@ it('reports no ALPN protocol if none was requested', async () => {
   socket.destroy()
 })
 
+it('negotiates HTTP/2 on a passthrough connection', async () => {
+  await using server = await createRawTestServer(() => {
+    return new tls.Server({
+      cert: TLS_CERTIFICATE,
+      key: TLS_PRIVATE_KEY,
+      ALPNProtocols: ['h2', 'http/1.1'],
+    })
+  })
+
+  const socket = tls.connect({
+    port: server.port,
+    host: server.hostname,
+    servername: 'localhost',
+    ca: [TLS_CERTIFICATE],
+    ALPNProtocols: ['http/1.1', 'h2'],
+  })
+  const secureConnectListener = vi.fn()
+  socket.on('secureConnect', secureConnectListener)
+
+  await expect.poll(() => secureConnectListener).toHaveBeenCalledOnce()
+
+  expect(socket.alpnProtocol).toBe('h2')
+
+  socket.destroy()
+})
+
 it('sends the SNI servername to the server', async () => {
   const serverSecureConnectionListener = vi.fn()
 


### PR DESCRIPTION
- Fixes #819 