### PR TITLE
fix(net): preserve passthrough writes until the client consumes EOF

### DIFF
--- a/src/interceptors/http/source.ts
+++ b/src/interceptors/http/source.ts
@@ -402,11 +402,11 @@ export class NodeHttpRequestSource extends Interceptor<HttpRequestEventMap> {
                         }
                       }
 
-                      const onResponseClose = () => {
+                      const onResponseEnd = () => {
                         disposeResponseParser()
 
-                        // Without a response, no response listener will release
-                        // the buffered EOF/close that rejects the client request.
+                        // Without a final response, release EOF now. A half-open
+                        // socket cannot close until the client consumes it.
                         if (!hasFinalResponse) {
                           socketController.uncorkReads()
                         }
@@ -415,13 +415,15 @@ export class NodeHttpRequestSource extends Interceptor<HttpRequestEventMap> {
                       const disposeResponseParser = (error?: Error) => {
                         responseParserDisposed = true
                         realSocket.removeListener('data', onResponseData)
-                        realSocket.removeListener('close', onResponseClose)
+                        realSocket.removeListener('end', onResponseEnd)
+                        realSocket.removeListener('close', onResponseEnd)
                         responseParser.free(error)
                       }
 
                       realSocket
                         .on('data', onResponseData)
-                        .once('close', onResponseClose)
+                        .once('end', onResponseEnd)
+                        .once('close', onResponseEnd)
                     }
                   },
                 },

--- a/src/interceptors/net/socket-controller.ts
+++ b/src/interceptors/net/socket-controller.ts
@@ -1314,6 +1314,11 @@ export class TcpSocketController extends SocketController {
       // but this skips the detection cost on its every "destroyed" read).
       realSocket[kPatched] = true
 
+      // The client owns half-close semantics. It may not have consumed
+      // the forwarded EOF yet, so keep the real connection writable until
+      // the client ends its writable side.
+      realSocket.allowHalfOpen = true
+
       if (this.socket.timeout != null) {
         realSocket.setTimeout(this.socket.timeout)
       }

--- a/test/modules/net/compliance/socket-half-open.test.ts
+++ b/test/modules/net/compliance/socket-half-open.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
+import { once } from 'node:events'
 import net from 'node:net'
+import tls from 'node:tls'
+import { setImmediate } from 'node:timers/promises'
 import { SocketInterceptor } from '#/src/interceptors/net'
 import { createRawTestServer, spyOnSocket } from '#/test/helpers'
+import { TLS_CERTIFICATE, TLS_PRIVATE_KEY } from './fixtures/tls'
 
 const interceptor = new SocketInterceptor()
 
@@ -106,4 +110,127 @@ it('ends the socket automatically without "allowHalfOpen"', async () => {
   // back once the server ends the connection.
   await expect.poll(() => serverEndListener).toHaveBeenCalledOnce()
   expect(listeners.close).toHaveBeenCalledWith(false)
+})
+
+/**
+ * @see https://github.com/mswjs/interceptors/issues/821
+ */
+it('delivers TCP writes while the server response remains unread', async () => {
+  const receivedData = Promise.withResolvers<string>()
+  await using server = await createRawTestServer(() => {
+    return new net.Server({ allowHalfOpen: true }, (socket) => {
+      socket.on('data', (chunk) => {
+        receivedData.resolve(chunk.toString())
+      })
+      socket.end('response')
+    })
+  })
+  const serverEnded = Promise.withResolvers<void>()
+
+  interceptor.on('connection', ({ controller }) => {
+    const realSocket = controller.passthrough()
+    realSocket.once('end', serverEnded.resolve)
+  })
+
+  const socket = net.connect({
+    host: server.hostname,
+    port: server.port,
+  })
+  onTestFinished(() => {
+    socket.destroy()
+  })
+  const errorListener = vi.fn()
+  socket.on('error', errorListener)
+
+  await serverEnded.promise
+
+  // Process the server ending while the client keeps its response buffered.
+  await setImmediate()
+  await setImmediate()
+
+  expect.soft(socket.readableEnded).toBe(false)
+  expect(socket.writable).toBe(true)
+
+  const writeCompleted = Promise.withResolvers<void>()
+
+  expect(() => {
+    socket.write(Buffer.from('remaining data'), (error) => {
+      if (error) {
+        writeCompleted.reject(error)
+      } else {
+        writeCompleted.resolve()
+      }
+    })
+  }).not.toThrow()
+
+  await expect(writeCompleted.promise).resolves.toBeUndefined()
+  await expect(receivedData.promise).resolves.toBe('remaining data')
+  expect(socket.read()).toEqual(Buffer.from('response'))
+
+  const closed = once(socket, 'close')
+  socket.resume()
+  await closed
+  expect(errorListener).not.toHaveBeenCalled()
+})
+
+it('delivers TLS writes while the server response remains unread', async () => {
+  const receivedData = Promise.withResolvers<string>()
+  await using server = await createRawTestServer(() => {
+    return new tls.Server(
+      { cert: TLS_CERTIFICATE, key: TLS_PRIVATE_KEY, allowHalfOpen: true },
+      (socket) => {
+        socket.on('data', (chunk) => {
+          receivedData.resolve(chunk.toString())
+        })
+        socket.end('response')
+      }
+    )
+  })
+  const serverEnded = Promise.withResolvers<void>()
+
+  interceptor.on('connection', ({ controller }) => {
+    const realSocket = controller.passthrough()
+    realSocket.once('end', serverEnded.resolve)
+  })
+
+  const socket = tls.connect({
+    host: server.hostname,
+    port: server.port,
+    ca: TLS_CERTIFICATE,
+  })
+  onTestFinished(() => {
+    socket.destroy()
+  })
+  const errorListener = vi.fn()
+  socket.on('error', errorListener)
+
+  await serverEnded.promise
+
+  // Process the server ending while the client keeps its response buffered.
+  await setImmediate()
+  await setImmediate()
+
+  expect.soft(socket.readableEnded).toBe(false)
+  expect(socket.writable).toBe(true)
+
+  const writeCompleted = Promise.withResolvers<void>()
+
+  expect(() => {
+    socket.write(Buffer.from('remaining data'), (error) => {
+      if (error) {
+        writeCompleted.reject(error)
+      } else {
+        writeCompleted.resolve()
+      }
+    })
+  }).not.toThrow()
+
+  await expect(writeCompleted.promise).resolves.toBeUndefined()
+  await expect(receivedData.promise).resolves.toBe('remaining data')
+  expect(socket.read()).toEqual(Buffer.from('response'))
+
+  const closed = once(socket, 'close')
+  socket.resume()
+  await closed
+  expect(errorListener).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Fixes #821 